### PR TITLE
Configure CircleCI to require successful testing before deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,18 +92,21 @@ workflows:
       - build
       - deploy-dev:
           requires:
+            - test
             - build
           filters:
             branches:
               only: develop
       - deploy-staging:
           requires:
+            - test
             - build
           filters:
             branches:
               only: staging
       - deploy-prod:
           requires:
+            - test
             - build
           filters:
             branches:


### PR DESCRIPTION
Adjusts `.circleci/config.yml` to include the `test` job in the `requires` list for each deploy job. Fixes an issue with my original implementation that ran the test job but did not require it for before starting a deploy job.