### PR TITLE
Remove redundant CSVHelper package

### DIFF
--- a/etl/tests/Piipan.Etl.Tests/Piipan.Etl.Tests.csproj
+++ b/etl/tests/Piipan.Etl.Tests/Piipan.Etl.Tests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="17.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
Since we include Piipan.Etl, don't need to re-specify CSVHelper as a dependency here. Doing so can cause mismatches, Dependabot failures.