### PR TITLE
Bind database connection string at provision time

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -19,8 +19,17 @@ To (re)create the Azure resources that `piipan` uses:
     cd iac
     ./create-resources.bash
 ```
+
+### Environment variables
+
+The following variables are pre-configured by the Infrastructure-as-Code. Most often they are used to [bind backing services to application code](https://12factor.net/backing-services) via connection strings.
+
+| Environment variable | Value |
+|---|---|
+| `DatabaseConnectionString` | ADO.NET-formatted database connection string. If `Password` has the value `{password}`; i.e., `password` in curly quotes, then it is a partial connection string indicating the use of managed identities. An access token must be retrieved at run-time (e.g., via [AzureServiceTokenProvider](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/service-to-service-authentication)) to build the full connection string.  |
+
 ## Notes
-- `iac/states.csv` contains the comma-delimited records of participating states/territories. The first field is the [two-leter postal abbreviation](https://pe.usps.com/text/pub28/28apb.htm); the second field is the name of the state/territory.
+- `iac/states.csv` contains the comma-delimited records of participating states/territories. The first field is the [two-letter postal abbreviation](https://pe.usps.com/text/pub28/28apb.htm); the second field is the name of the state/territory.
 - For development, dummy state/territories are used (e.g., the state of `Echo Alpha`, with an abbreviation of `EA`).
 - If you forget to connect to a trusted network and `create-resources` fails, connect to the network, then re-run the script.
 - Some Azure CLI provisioning commands will return before all of their behind-the-scenes operations complete in the Azure environment. Very occasionally, subsequent provisioning commands in `create-resources` will fail as it won't be able to locate services it expects to be present; e.g., `Can't find app with name` when publishing a Function to a Function App. As a workaround, re-run the script.


### PR DESCRIPTION
Partially addresses #150.

For the ETL functions, bind the corresponding database connection string to the function via the DatabaseConnectionString environment variable. The Password placeholder will be replaced at runtime by the ETL function code with the a service token in a follow-on PR.