### PR TITLE
Fix local.settings.json error, use --dotnet

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -334,7 +334,7 @@ while IFS=, read -r abbr name ; do
 
   # Create Function endpoint before setting up event subscription
   pushd ../etl/src/Piipan.Etl
-  func azure functionapp publish $func_app
+  func azure functionapp publish $func_app --dotnet
   popd
 
   az eventgrid system-topic event-subscription create \
@@ -384,7 +384,7 @@ while IFS=, read -r abbr name ; do
   
   echo "Publishing ${name} function app"
   pushd ../match/src/Piipan.Match.State
-  func azure functionapp publish $func_name
+  func azure functionapp publish $func_name --dotnet
   popd
 done < states.csv
 


### PR DESCRIPTION
Should resolve need to have a local.settings.json file in the working directory when publishing initial Azure function in IaC.

Still need to make similar changes to CI/CD script, etc.