### PR TITLE
Follow up to initial state match API work

### DIFF
--- a/iac/arm-templates/function-state-match.json
+++ b/iac/arm-templates/function-state-match.json
@@ -93,10 +93,33 @@
                     ],
                     "ftpsState": "Disabled",
                     "appSettings": [
+                        /*
+                            The following settings are required for Function apps per the MS documentation:
+                            - AzureWebJobsStorage
+                            - FUNCTIONS_WORKER_RUNTIME
+                            - FUNCTIONS_EXTENSION_VERSION
+
+                            See: https://docs.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code#function-app)
+                        */
                         {
                             "name": "AzureWebJobsStorage",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
                         },
+                        {
+                            "name": "FUNCTIONS_WORKER_RUNTIME",
+                            "value": "[variables('functionWorkerRuntime')]"
+                        },
+                        {
+                            "name": "FUNCTIONS_EXTENSION_VERSION",
+                            "value": "~3"
+                        },
+                        /*
+                            The `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` and `WEBSITE_CONTENTSHARE`
+                            settings are required for Windows function apps using a consumption plan,
+                            per the MS documentation.
+
+                            See: https://docs.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code#windows)
+                        */
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
@@ -105,14 +128,18 @@
                             "name": "WEBSITE_CONTENTSHARE",
                             "value": "[toLower(variables('functionAppName'))]"
                         },
-                        {
-                            "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
-                        },
+                        // Required when using the zip deployment method (i.e., the method
+                        // used by `func azure functionapp publish`)
                         {
                             "name": "WEBSITE_RUN_FROM_PACKAGE",
                             "value": "1"
                         },
+                        // Connect app to Application Insights instance
+                        {
+                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                            "value": "[reference(resourceId('microsoft.insights/components', variables('functionAppName')), '2020-02-02-preview').InstrumentationKey]"
+                        },
+                        // Custom environment variables:
                         {
                             "name": "StateName",
                             "value": "[parameters('stateName')]"
@@ -128,14 +155,6 @@
                         {
                             "name": "AzureServicesAuthConnectionString",
                             "value": "[concat('RunAs=App;AppId=',parameters('identityClientId'))]"
-                        },
-                        {
-                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                            "value": "[reference(resourceId('microsoft.insights/components', variables('functionAppName')), '2020-02-02-preview').InstrumentationKey]"
-                        },
-                        {
-                            "name": "FUNCTIONS_WORKER_RUNTIME",
-                            "value": "[variables('functionWorkerRuntime')]"
                         }
                     ]
                 }

--- a/iac/arm-templates/function-state-match.json
+++ b/iac/arm-templates/function-state-match.json
@@ -17,11 +17,13 @@
         "identityGroup": {
             "type": "string"
         },
-        "identityClientId": {
-            "type": "string",
-            "defaultValue": ""
+        "azAuthConnectionString": {
+            "type": "string"
         },
-        "serverName": {
+        "dbConnectionString": {
+            "type": "string"
+        },
+        "dbConnectionStringKey": {
             "type": "string"
         }
     },
@@ -149,12 +151,12 @@
                             "value": "[parameters('stateAbbr')]"
                         },
                         {
-                            "name": "ServerName",
-                            "value": "[parameters('serverName')]"
+                            "name": "AzureServicesAuthConnectionString",
+                            "value": "[parameters('azAuthConnectionString')]"
                         },
                         {
-                            "name": "AzureServicesAuthConnectionString",
-                            "value": "[concat('RunAs=App;AppId=',parameters('identityClientId'))]"
+                            "name": "[parameters('dbConnectionStringKey')]",
+                            "value": "[parameters('dbConnectionString')]"
                         }
                     ]
                 }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -378,12 +378,15 @@ while IFS=, read -r abbr name ; do
   abbr=`echo "$abbr" | tr '[:upper:]' '[:lower:]'`
 
   identity=${abbr}admin
+  db_name=${abbr}
   client_id=$(\
     az identity show \
       --resource-group $RESOURCE_GROUP \
       --name $identity \
       --query clientId \
       --output tsv)
+  db_conn_str=`pg_connection_string $PG_SERVER_NAME $db_name $identity`
+  az_serv_str=`az_connection_string $identity`
 
   echo "Deploying ${name} function resources"
   func_name=$(\
@@ -397,10 +400,11 @@ while IFS=, read -r abbr name ; do
         resourceTags="$RESOURCE_TAGS" \
         identityGroup=$RESOURCE_GROUP \
         location=$LOCATION \
-        identityClientId=$client_id \
-        serverName=$PG_SERVER_NAME \
+        azAuthConnectionString=$az_serv_str \
         stateName="$name" \
-        stateAbbr="$abbr")
+        stateAbbr="$abbr" \
+        dbConnectionString="$db_conn_str" \
+        dbConnectionStringKey="$DB_CONN_STR_KEY")
   
   echo "Publishing ${name} function app"
   pushd ../match/src/Piipan.Match.State

--- a/match/docs/state-match.md
+++ b/match/docs/state-match.md
@@ -36,20 +36,13 @@ See the [ETL database setup instructions](../../etl/docs/etl.md#database-setup).
 
 ### App deployment
 
-Before deploying the app for the first time, switch to the project directory and fetch settings from Azure:
+Deploy the app using the Functions Core Tools, making sure to pass the `--dotnet` flag:
 
 ```
-cd match/src/Piipan.Match.State
-func azure functionapp fetch-app-settings {app-name}
+func azure functionapp publish <app_name> --dotnet
 ```
 
-This will create a file named `local.settings.json` containing app settings. Some settings are required by the deployment process (e.g., `FUNCTIONS_WORKER_RUNTIME`).
-
-With settings stored, the app can be manually deployed:
-
-```
-func azure functionapp publish {app-name}
-```
+`<app_name>` is the name of the Azure Function App resource created by the IaC process.
 
 ## Remote testing
 

--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -134,9 +134,6 @@ namespace Piipan.Match.State
                 conn.ConnectionString = await ConnectionString(log);
                 conn.Open();
 
-                // Set role to owner before executing query
-                conn.Execute($"SET ROLE to {stateAbbr}");
-
                 (var sql, var parameters) = Prepare(request, log);
                 records = conn.Query<PiiRecord>(sql, (object)parameters).AsList();
 

--- a/match/src/Piipan.Match.State/Converters.cs
+++ b/match/src/Piipan.Match.State/Converters.cs
@@ -2,7 +2,16 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace Piipan.Match.State {
+namespace Piipan.Match.State
+{
+
+    /// <summary>
+    /// JSON.NET converter for serializing/deserializing a DateTime
+    /// object using our desired YYYY-MM-DD format.
+    /// </summary>
+    /// <remarks>
+    /// Applied to model properties as `[JsonConverter(typeof(DateTimeConverter))]`
+    /// </remarks>
     public class DateTimeConverter : IsoDateTimeConverter
     {
         public DateTimeConverter()
@@ -10,7 +19,21 @@ namespace Piipan.Match.State {
             base.DateTimeFormat = "yyyy-MM-dd";
         }
     }
-    
+
+    /// <summary>
+    /// JSON.NET converter used for converting null, missing, or empty
+    /// properties to a `null` value when deserializing JSON.
+    /// </summary>
+    /// <remarks>
+    /// Applied to model properties as `[JsonConverter(typeof(NullConverter))]`.
+    ///
+    /// Intended for use when deserializing JSON in incoming request bodies.
+    /// Null values are needed for optional fields to properly perform exact
+    /// matches when querying the state-level database.
+    ///
+    /// Matches the behavoir of `Piipan.Etl.BulkUpload` which writes missing
+    /// or empty optional fields to the databse as `DbNull.Value`.
+    /// </remarks>
     public class NullConverter : JsonConverter
     {
         public override bool CanRead => true;


### PR DESCRIPTION
Adds some follow up work from #168:
- Cleans up documentation
- Removes unneeded `SET ROLE` directive (#198)
- Brings DB connection approach into sync with #199