### PR TITLE
Specify .NET Core version as 3.1 in Dashboard App Docs

### DIFF
--- a/dashboard/docs/dashboard.md
+++ b/dashboard/docs/dashboard.md
@@ -1,7 +1,7 @@
 # Dashboard application
 
 ## Prerequisites
-- [.NET Core SDK](https://dotnet.microsoft.com/download)
+- [.NET Core SDK 3.1](https://dotnet.microsoft.com/download)
 
 ## Local development
 To run the app locally:


### PR DESCRIPTION
Since .NET Core 5 was released a couple weeks into this project (after the hello world dashboard was created) and Azure Functions currently only support a max of 3.1.