### PR TITLE
Better script error handling and ADR for scripts

### DIFF
--- a/docs/adr/0010-use-bash-for-scripting.md
+++ b/docs/adr/0010-use-bash-for-scripting.md
@@ -1,0 +1,26 @@
+# 10. Use bash for scripting
+
+Date: 2021-01-22
+
+## Status
+
+Accepted
+
+## Context
+
+We need a basic scripting tool to assist with deployment of code, automate tasks in CI/CD, and perform manual integration tests against our deployment environments.
+
+PowerShell and sh/bash are our primary options. bash is installed by default on macOS and in Linux distributions. sh/bash is available on Windows via the Windows Subsystem for Linux (WSL) and Cygwin. PowerShell ships with Windows 10 and is available for macOS and Linux.
+
+In general, our implementation team does not have much experience with PowerShell, while sh/bash scripts are pervasive across 18F projects and our CI/CD tools (e.g., CircleCI, GitHub Actions).
+
+In some environments, `/bin/sh` will be a soft-link to `/bin/bash`. Other times it will be linked to other implementations (e.g., dash or zsh). It is often the case that non-trivial shell scripts that describe themselves as POSIX sh scripts will incorporate useful "bash-isms" which can fail when `/bin/sh` is not actually bash.
+
+## Decision
+
+For now, use bash (explicitly as `/bin/bash`, not `/bin/sh`), as our primary scripting language. Bash scripts should be written to support bash 3.2, which is the latest version of bash on macOS and 
+
+## Consequences
+
+* The macOS-equipped 18F team is more productive in the near term, deferring the ramp up on PowerShell.
+* A future Windows-equipped team may have to install bash and gain familiarity with it. Or they may strongly prefer PowerShell and the team will need to rewrite any existing bash scripts.

--- a/docs/adr/0010-use-bash-for-scripting.md
+++ b/docs/adr/0010-use-bash-for-scripting.md
@@ -18,7 +18,7 @@ In some environments, `/bin/sh` will be a soft-link to `/bin/bash`. Other times 
 
 ## Decision
 
-For now, use bash (explicitly as `/bin/bash`, not `/bin/sh`), as our primary scripting language. Bash scripts should be written to support bash 3.2, which is the latest version of bash on macOS and 
+For now, use bash (explicitly as `/bin/bash`, not `/bin/sh`), as our primary scripting language. Bash scripts should be written to support bash 3.2, which is the latest version of bash on macOS.
 
 ## Consequences
 

--- a/iac/create-databases.bash
+++ b/iac/create-databases.bash
@@ -1,10 +1,10 @@
 #!/bin/bash
-set -e
+
+source $(dirname "$0")/../tools/common.bash || exit
 
 # Require PGHOST, PGUSER, PGPASSWORD be set by the caller;
 # PGUSER and PGPASSWORD should correspond to the out-of-the-box,
 # non-AD "superuser" administrtor login
-set -u
 : "$PGHOST"
 : "$PGUSER"
 : "$PGPASSWORD"
@@ -196,6 +196,8 @@ main () {
     create_managed_role $db $role $client_id
     config_managed_role $db $role
   done < states.csv
+
+  script_completed
 }
 
 main "$@"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -6,8 +6,7 @@
 #
 # usage: create-resources.bash
 
-set -e
-set -u
+source $(dirname "$0")/../tools/common.bash || exit
 
 # Default resource group for our system
 RESOURCE_GROUP=piipan-resources
@@ -414,3 +413,5 @@ done < states.csv
 
 # Create a service principal for use by CI/CD pipeline.
 ./create-service-principal.bash $SP_NAME_CICD none
+
+script_completed

--- a/iac/create-service-principal.bash
+++ b/iac/create-service-principal.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
-set -u
+
+source $(dirname "$0")/../tools/common.bash || exit
 
 main () {
     # Required name parameter
@@ -33,6 +33,8 @@ main () {
         --scopes $SCOPES \
         --only-show-errors \
         --output $OUTPUT
+
+    script_completed
 }
 
 main "$@"

--- a/tools/common.bash
+++ b/tools/common.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Common preamble for bash scripts.
+
+# Exit immediately if a command fails
+set -e
+
+# Unset variables are an error
+set -u
+
+# Conform more closely to POSIX standard, specifically so command substitutions
+# inherit the value of the -e option. The more targeted inherit_errexit option 
+# would be preferred, but it is not available in bash 3.2, which ships with macOS.
+set -o posix
+
+# Exit immediately if any command in a pipeline errors
+set -o pipefail
+
+# Inherit trap on ERR in shell functions, command substitutions, etc.
+set -o errtrace
+
+_script=$(basename $0)
+
+_err_report () {
+  # If the error occurred in a while/done loop or in a function, the trap can
+  # only report the line number of the loop or the function, not the offending
+  # command itself.
+  echo "$_script: error on (or around) line $1"
+}
+
+trap '_err_report $LINENO' ERR
+
+script_completed () {
+  echo "$_script: completed successfully"
+}


### PR DESCRIPTION
- -e flag doesn't on its own work with command substitutions, so several
  options were added to allow scripts to always immediately exit on error
- add explicit success message to end of IaC scripts

Foundational work for #243 