### PR TITLE
Explicitly install required CLI extensions

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -9,12 +9,16 @@
 
 ## Steps
 To (re)create the Azure resources that `piipan` uses:
-1. Connect to a trusted network. Currently, only the GSA network block is trusted.
-2. Sign in with the Azure CLI `login` command :
+1. Run `install-extensions` to install Azure CLI extensions required by the `az` commands used by our IaC:
+```
+    ./iac/install-extensions.bash
+```
+2. Connect to a trusted network. Currently, only the GSA network block is trusted.
+3. Sign in with the Azure CLI `login` command:
 ```
     az login
 ```
-3. Run `create-resources`, which deploys Azure Resource Manager (ARM) templates and runs associated scripts:
+4. Run `create-resources`, which deploys Azure Resource Manager (ARM) templates and runs associated scripts:
 ```
     cd iac
     ./create-resources.bash
@@ -35,3 +39,4 @@ The following variables are pre-configured by the Infrastructure-as-Code. Most o
 - If you have recently deleted all the Piipan resource groups and are re-creating the infrastructure from scratch and get an `Exist soft deleted vault with the same name` error, try `az keyvault purge --name <vault-name>`. See output of `az keyvault list-deleted` for the name of the vault, which should correspond to `VAULT_NAME` in `create-resources.bash`.
 - Some Azure CLI provisioning commands will return before all of their behind-the-scenes operations complete in the Azure environment. Very occasionally, subsequent provisioning commands in `create-resources` will fail as it won't be able to locate services it expects to be present; e.g., `Can't find app with name` when publishing a Function to a Function App. As a workaround, re-run the script.
 - .NET 5 with Azure Functions v3 is [not (yet) supported by Microsoft](https://github.com/Azure/azure-functions-host/issues/6674).
+- `iac/.azure` contains local Azure CLI configuration that is used by `create-resources`

--- a/iac/.azure/config
+++ b/iac/.azure/config
@@ -1,0 +1,3 @@
+[extension]
+use_dynamic_install = no
+

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -3,6 +3,7 @@
 # Provisions and configures the infrastructure components for all Piipan
 # subsystems. Assumes an Azure user with the Global Administrator role
 # has signed in with the Azure CLI. Must be run from a trusted network.
+# See install-extensions.bash for prerequisite Azure CLI extensions.
 #
 # usage: create-resources.bash
 

--- a/iac/install-extensions.bash
+++ b/iac/install-extensions.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Installs Azure CLI extensions required for create-resources.bash.
+# 
+# usage: install-extensions.bash
+
+source $(dirname "$0")/../tools/common.bash || exit
+
+# Array of extension names
+declare -a extensions=("db-up")
+
+for name in ${extensions[@]}; do
+  echo "Installing '$name'..."
+  az extension add --name "$name"
+done


### PR DESCRIPTION
Closes #243

By default, Azure CLI commands will prompt to install extension libraries as it needs them. This can obscure the dependencies required for our IaC scripts and cause unexpected failures. To resolve this, we:
- add a local Azure CLI configuration to the working directory of the IaC scripts to turn off autodownload of extensions
- provide a script to install prerequisite extensions
- amend documentation to reference additional step