### PR TITLE
Update resource group list that CI/CD can update

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -108,12 +108,17 @@ az_connection_string () {
     echo "RunAs=App;AppId=${client_id}"
 }
 
+# Any changes to the set of resource groups below should also
+# be made to create-service-principal.bash
 echo "Creating $RESOURCE_GROUP group"
 az group create --name $RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
 echo "Creating $FUNCTIONS_RESOURCE_GROUP group"
 az group create --name $FUNCTIONS_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
 echo "Creating match APIs resource group"
 az group create --name $MATCH_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+
+# Create a service principal for use by CI/CD pipeline.
+./create-service-principal.bash $SP_NAME_CICD none
 
 # uniqueString is used pervasively in our ARM templates to create globally
 # identifiers from the resource group id, but it is not available in the CLI.
@@ -411,8 +416,5 @@ while IFS=, read -r abbr name ; do
   func azure functionapp publish $func_name --dotnet
   popd
 done < states.csv
-
-# Create a service principal for use by CI/CD pipeline.
-./create-service-principal.bash $SP_NAME_CICD none
 
 script_completed

--- a/iac/create-service-principal.bash
+++ b/iac/create-service-principal.bash
@@ -14,7 +14,7 @@ main () {
     OUTPUT=${2:-json}
 
     # Array of groups to which the service principal will be scoped
-    RESOURCE_GROUPS=(piipan-functions piipan-resources)
+    RESOURCE_GROUPS=(piipan-functions piipan-resources piipan-match)
 
     # Create space-separated list of resource group IDs
     for g in "${RESOURCE_GROUPS[@]}"


### PR DESCRIPTION
- Add match API resouce group to CI/CD service principal
- Move invocation of create-service-principal to be closer
  to creation of resource groups