### PR TITLE
Automate blob binding, update docs

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -26,11 +26,12 @@ To (re)create the Azure resources that `piipan` uses:
 
 ### Environment variables
 
-The following variables are pre-configured by the Infrastructure-as-Code. Most often they are used to [bind backing services to application code](https://12factor.net/backing-services) via connection strings.
+The following variables are pre-configured by the Infrastructure-as-Code for Functions or Apps that require them. Most often they are used to [bind backing services to application code](https://12factor.net/backing-services) via connection strings.
 
 | Environment variable | Value |
 |---|---|
 | `DatabaseConnectionString` | ADO.NET-formatted database connection string. If `Password` has the value `{password}`; i.e., `password` in curly quotes, then it is a partial connection string indicating the use of managed identities. An access token must be retrieved at run-time (e.g., via [AzureServiceTokenProvider](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/service-to-service-authentication)) to build the full connection string.  |
+| `BlobStorageConnectionString` | Azure Storage Account connection string for accessing blobs. |
 
 ## Notes
 - `iac/states.csv` contains the comma-delimited records of participating states/territories. The first field is the [two-letter postal abbreviation](https://pe.usps.com/text/pub28/28apb.htm); the second field is the name of the state/territory.


### PR DESCRIPTION
Closes #242

- Move blob connection string binding to Function app from manual process to IaC
- Remove manual documentation for setting service bindings
- Update IaC docs to reflect standard environment variable name for blob
  connection strings
- Add note about grant-blob taking several minutes to replicate out