### PR TITLE
Remove unused environment variables from match APIs and tests

### DIFF
--- a/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
@@ -18,12 +18,6 @@ namespace Piipan.Match.Orchestrator
 
     public class PiiRecord
     {
-        public PiiRecord()
-        {
-            StateName = Environment.GetEnvironmentVariable("StateName");
-            StateAbbr = Environment.GetEnvironmentVariable("StateAbbr");
-        }
-
         [JsonProperty("last")]
         public string Last { get; set; }
 

--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -21,9 +21,6 @@ namespace Piipan.Match.State
     /// </summary>
     public static class Api
     {
-        internal static string stateAbbr = Environment.GetEnvironmentVariable("StateAbbr");
-        internal static string serverName = Environment.GetEnvironmentVariable("ServerName");
-
         /// <summary>
         /// API endpoint for conducting a state-level match
         /// </summary>

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -17,7 +17,6 @@ namespace Piipan.Match.State.Tests
         {
             Environment.SetEnvironmentVariable("StateName", "Echo Alpha");
             Environment.SetEnvironmentVariable("StateAbbr", "ea");
-            Environment.SetEnvironmentVariable("ServerName", "server-name");
         }
 
         static PiiRecord FullRecord()
@@ -267,17 +266,6 @@ namespace Piipan.Match.State.Tests
             // Assert
             Assert.Equal("ea", record.StateAbbr);
             Assert.Equal("Echo Alpha", record.StateName);
-        }
-
-        [Fact]
-        public void ApiStaticMembers()
-        {
-            // Arrange
-            SetEnvironment();
-
-            // Assert
-            Assert.Equal("ea", Api.stateAbbr);
-            Assert.Equal("server-name", Api.serverName);
         }
 
         [Fact]


### PR DESCRIPTION
`StateName` and `StateAbbr` in `Piipan.Match.Orchestrator.PiiRecord` were vestiges from previous work on the per-state APIs.

`Piipan.Match.State.Api` no longer used `StateAbbr` or `ServerName` after the database connection mechanism was updated in #210.