### PR TITLE
Temporarily add AllowAllWindowsAzureIps to db

### DIFF
--- a/iac/arm-templates/participant-records.json
+++ b/iac/arm-templates/participant-records.json
@@ -70,6 +70,12 @@
                         "firewallrules": {
                             "batch": {
                                 "rules": [
+                                    // TODO: Remove AllowAllWindowsAzureIps when we define all of our private subnets/network security groups
+                                    {
+                                        "name": "AllowAllWindowsAzureIps",
+                                        "StartIpAddress": "0.0.0.0",
+                                        "EndIpAddress": "0.0.0.0"
+                                    },
                                     {
                                         "Name": "GSA-network",
                                         "StartIpAddress": "159.142.0.0",


### PR DESCRIPTION
Closes #299. Allows ETL and state match API to communicate to participatns-db ahead of fully fleshed out VNets, network security groups in our sandbox. Will be reversed in https://github.com/18F/piipan/issues/331