### PR TITLE
Update dependencies

### DIFF
--- a/match/src/Piipan.Match.Orchestrator/Piipan.Match.Orchestrator.csproj
+++ b/match/src/Piipan.Match.Orchestrator/Piipan.Match.Orchestrator.csproj
@@ -6,8 +6,8 @@
     <RestoreLockedMode Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreLockedMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.5.0" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
+    <PackageReference Include="FluentValidation" Version="9.5.1" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
   </ItemGroup>

--- a/match/src/Piipan.Match.Orchestrator/packages.lock.json
+++ b/match/src/Piipan.Match.Orchestrator/packages.lock.json
@@ -4,15 +4,15 @@
     ".NETCoreApp,Version=v3.1": {
       "FluentValidation": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "gsu4SrlTgTCS57nynfUXmuEqOqQdsgZGd69dO4dJg/TRDvNTXKlw5TPKVoY/ieQLsmFBzd9ax/Y1Tx+8Ds3XKw=="
+        "requested": "[9.5.1, )",
+        "resolved": "9.5.1",
+        "contentHash": "By09e2m4N3giD7Giq8NCFgkgN5Hkm8Lv/bk8AadD9Xc6jjj2WDGrD6l9keZbWbkO9aygiHQREIt47iS2sVSU7w=="
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Direct",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "SYHgRdHvtbjSvs7BIBO7JLBm4Y8QXcHDV64AbideJDLoasQXKzqR71AsyyeWwGZTZ0DYSQoUYmCg9i494Ti++A==",
+        "requested": "[1.6.1, )",
+        "resolved": "1.6.1",
+        "contentHash": "78AcjpxnhJDov7HJa4kPpZxpI0coZhS0tdA9ZLUSPExKz5KTgfozayBTLAXDuTuq0gLRzFyf85SvIkrtbB8KpA==",
         "dependencies": {
           "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.0",
           "System.Diagnostics.Process": "4.3.0"

--- a/match/src/Piipan.Match.State/Piipan.Match.State.csproj
+++ b/match/src/Piipan.Match.State/Piipan.Match.State.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.78" />
-    <PackageReference Include="FluentValidation" Version="9.5.0" />
+    <PackageReference Include="FluentValidation" Version="9.5.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />

--- a/match/src/Piipan.Match.State/packages.lock.json
+++ b/match/src/Piipan.Match.State/packages.lock.json
@@ -13,9 +13,9 @@
       },
       "FluentValidation": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "gsu4SrlTgTCS57nynfUXmuEqOqQdsgZGd69dO4dJg/TRDvNTXKlw5TPKVoY/ieQLsmFBzd9ax/Y1Tx+8Ds3XKw=="
+        "requested": "[9.5.1, )",
+        "resolved": "9.5.1",
+        "contentHash": "By09e2m4N3giD7Giq8NCFgkgN5Hkm8Lv/bk8AadD9Xc6jjj2WDGrD6l9keZbWbkO9aygiHQREIt47iS2sVSU7w=="
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Direct",

--- a/match/tests/Piipan.Match.Orchestrator.Tests/Piipan.Match.Orchestrator.Tests.csproj
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/Piipan.Match.Orchestrator.Tests.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="Moq.Dapper" Version="1.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
@@ -28,12 +28,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Moq.Dapper": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "7h8XLeZi2bk+X6cPZqtXbVlxPBmMcwdX7OTqDyE6eDAMhI6b9O35gMJ0ELIC2+mpT+0Z7YPukeCA+soLV2N/zg=="
-      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.3, )",

--- a/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
@@ -76,8 +76,8 @@
       },
       "FluentValidation": {
         "type": "Transitive",
-        "resolved": "9.5.0",
-        "contentHash": "gsu4SrlTgTCS57nynfUXmuEqOqQdsgZGd69dO4dJg/TRDvNTXKlw5TPKVoY/ieQLsmFBzd9ax/Y1Tx+8Ds3XKw=="
+        "resolved": "9.5.1",
+        "contentHash": "By09e2m4N3giD7Giq8NCFgkgN5Hkm8Lv/bk8AadD9Xc6jjj2WDGrD6l9keZbWbkO9aygiHQREIt47iS2sVSU7w=="
       },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
@@ -283,8 +283,8 @@
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Transitive",
-        "resolved": "1.6.0",
-        "contentHash": "SYHgRdHvtbjSvs7BIBO7JLBm4Y8QXcHDV64AbideJDLoasQXKzqR71AsyyeWwGZTZ0DYSQoUYmCg9i494Ti++A==",
+        "resolved": "1.6.1",
+        "contentHash": "78AcjpxnhJDov7HJa4kPpZxpI0coZhS0tdA9ZLUSPExKz5KTgfozayBTLAXDuTuq0gLRzFyf85SvIkrtbB8KpA==",
         "dependencies": {
           "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.0",
           "System.Diagnostics.Process": "4.3.0"
@@ -1915,8 +1915,8 @@
       "piipan.match.orchestrator": {
         "type": "Project",
         "dependencies": {
-          "FluentValidation": "9.5.0",
-          "Microsoft.Azure.Services.AppAuthentication": "1.6.0",
+          "FluentValidation": "9.5.1",
+          "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
           "Microsoft.NET.Sdk.Functions": "3.0.11",
           "Newtonsoft.Json.Schema": "3.0.13"
         }

--- a/match/tests/Piipan.Match.State.Tests/Piipan.Match.State.Tests.csproj
+++ b/match/tests/Piipan.Match.State.Tests/Piipan.Match.State.Tests.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="Moq.Dapper" Version="1.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Npgsql" Version="5.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/match/tests/Piipan.Match.State.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.State.Tests/packages.lock.json
@@ -28,12 +28,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Moq.Dapper": {
-        "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "7h8XLeZi2bk+X6cPZqtXbVlxPBmMcwdX7OTqDyE6eDAMhI6b9O35gMJ0ELIC2+mpT+0Z7YPukeCA+soLV2N/zg=="
-      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.3, )",
@@ -93,8 +87,8 @@
       },
       "FluentValidation": {
         "type": "Transitive",
-        "resolved": "9.5.0",
-        "contentHash": "gsu4SrlTgTCS57nynfUXmuEqOqQdsgZGd69dO4dJg/TRDvNTXKlw5TPKVoY/ieQLsmFBzd9ax/Y1Tx+8Ds3XKw=="
+        "resolved": "9.5.1",
+        "contentHash": "By09e2m4N3giD7Giq8NCFgkgN5Hkm8Lv/bk8AadD9Xc6jjj2WDGrD6l9keZbWbkO9aygiHQREIt47iS2sVSU7w=="
       },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
@@ -1927,7 +1921,7 @@
         "type": "Project",
         "dependencies": {
           "Dapper": "2.0.78",
-          "FluentValidation": "9.5.0",
+          "FluentValidation": "9.5.1",
           "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
           "Microsoft.NET.Sdk.Functions": "3.0.11",
           "Newtonsoft.Json.Schema": "3.0.13",


### PR DESCRIPTION
Updates `Microsoft.Azure.Services.AppAuthentication` and `FluentValidation` dependencies, removes residual `Moq.Dapper` dependency.

Reference: [Updating .NET dependencies](https://github.com/18F/piipan/blob/main/docs/update-deps.md)