### PR TITLE
feat: Display alert when search returns no results

### DIFF
--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
@@ -8,6 +8,14 @@
     <h2>@Model.Title</h2>
     <form asp-page="Index" class="usa-form">
         <fieldset class="usa-fieldset">
+            @if (Model.NoResults)
+            {
+                    <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--validation">
+                        <div class="usa-alert__body">
+                            <p class="usa-alert__text">Your search did not return any results.</p>
+                        </div>
+                    </div>
+            }
             <legend class="usa-legend">Search for dual enrollments</legend>
             <label class="usa-label" asp-for="Query.LastName"></label>
             <input class="usa-input" type="text" asp-for="Query.LastName" />

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -21,6 +21,7 @@ namespace Piipan.QueryTool.Pages
 
         private readonly OrchestratorApiRequest _apiRequest = new OrchestratorApiRequest();
         public List<PiiRecord> QueryResult { get; private set; } = new List<PiiRecord>();
+        public bool NoResults = false;
 
         public async Task<IActionResult> OnPostAsync(PiiRecord query)
         {
@@ -29,6 +30,7 @@ namespace Piipan.QueryTool.Pages
                 query
             );
 
+            NoResults = QueryResult.Count == 0;
             Title = "NAC Query Results";
             return Page();
         }


### PR DESCRIPTION
Provide visual feedback to the user that the query completed successfully, but that there were no matches:

![image](https://user-images.githubusercontent.com/6290/108722480-36302f80-74f1-11eb-9d54-f945a5f3c3e1.png)

