### PR TITLE
IaC for authentication between query tool and orchestrator API

### DIFF
--- a/iac/arm-templates/function-orch-match.json
+++ b/iac/arm-templates/function-orch-match.json
@@ -67,14 +67,6 @@
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
                 "httpsOnly": true,
                 "siteConfig": {
-                    "ipSecurityRestrictions": [
-                        {
-                            "ipAddress": "159.142.0.0/16",
-                            "action": "Allow",
-                            "name": "GSA IP range",
-                            "priority": 100
-                        }
-                    ],
                     "ftpsState": "Disabled",
                     "appSettings": [
                         /*

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -62,6 +62,9 @@
             "name": "[variables('appName')]",
             "location": "[parameters('location')]",
             "tags": "[parameters('resourceTags')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', parameters('servicePlan'))]"
             ],
@@ -80,5 +83,11 @@
                 ]
             }
         }
-    ]
+    ],
+    "outputs": {
+        "appName": {
+            "type": "string",
+            "value": "[variables('appName')]"
+        }
+    }
 }


### PR DESCRIPTION
This PR partially addresses #281 by declaring the necessary infrastructure for enabling authentication on the orchestrator API and granting permissions to the query tool. Specifically:

- Enables authentication on orchestrator
- Removes IP restriction from orchestrator
- Activates system identity for query tool
- Grants app role to query tool identity
- Moves easy auth activation to reusable `enable_easy_auth` function

Follow on work:

- Implement new authentication flow for the query tool using `Piipan.Shared.Authentication`
- Afterwards, disable the GSA network block that has been temporarily left in place (#331)