### PR TITLE
show participant upload metrics in dashboard

### DIFF
--- a/dashboard/src/Piipan.Dashboard/Api/ParticipantUploadRequest.cs
+++ b/dashboard/src/Piipan.Dashboard/Api/ParticipantUploadRequest.cs
@@ -8,19 +8,23 @@ namespace Piipan.Dashboard
 {
     namespace Api
     {
-        public class ParticipantUploadRequest
+        public interface IParticipantUploadRequest
         {
-            private readonly HttpClient Client;
+            public Task<ParticipantUploadResponse> Get(string url);
+        }
+        public class ParticipantUploadRequest : IParticipantUploadRequest
+        {
+            private readonly HttpClient _httpClient;
 
-            public ParticipantUploadRequest(HttpClient _client)
+            public ParticipantUploadRequest(HttpClient client)
             {
-                Client = _client;
+                _httpClient = client;
             }
             public async Task<ParticipantUploadResponse> Get(string url)
             {
                 try
                 {
-                    var response = await Client.GetAsync(url);
+                    var response = await _httpClient.GetAsync(url);
                     var body = await response.Content.ReadAsStringAsync();
                     return JsonConvert.DeserializeObject<ParticipantUploadResponse>(body);
                 }

--- a/dashboard/src/Piipan.Dashboard/Api/ParticipantUploadRequest.cs
+++ b/dashboard/src/Piipan.Dashboard/Api/ParticipantUploadRequest.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Piipan.Dashboard
+{
+    namespace Api
+    {
+        public class ParticipantUploadRequest
+        {
+            private readonly HttpClient Client;
+
+            public ParticipantUploadRequest(HttpClient _client)
+            {
+                Client = _client;
+            }
+            public async Task<ParticipantUploadResponse> Get(string url)
+            {
+                try
+                {
+                    var response = await Client.GetAsync(url);
+                    var body = await response.Content.ReadAsStringAsync();
+                    return JsonConvert.DeserializeObject<ParticipantUploadResponse>(body);
+                }
+                catch (HttpRequestException e)
+                {
+                    Console.WriteLine("\nException Caught: {0}", e.Message);
+                    throw e;
+                }
+            }
+        }
+
+        public class ParticipantUploadResponse
+        {
+            public ParticipantUploadResponseMeta meta { get; set; }
+            public List<ParticipantUpload> data { get; set; }
+        }
+
+        public class ParticipantUploadResponseMeta
+        {
+            public int page { get; set; }
+            public int perPage { get; set; }
+            public Int64 total { get; set; }
+            public string nextPage { get; set; }
+            public string prevPage { get; set; }
+        }
+    }
+}

--- a/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml
+++ b/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml
@@ -2,3 +2,5 @@
 @model IndexModel
 
 <p>@Model.Message</p>
+
+<a class="" asp-page="/ParticipantUploads">Participant Uploads</a>

--- a/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml
+++ b/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml
@@ -3,4 +3,4 @@
 
 <p>@Model.Message</p>
 
-<a class="" asp-page="/ParticipantUploads">Participant Uploads</a>
+<a asp-page="/ParticipantUploads">Participant Uploads</a>

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml
@@ -1,0 +1,41 @@
+﻿@page
+@model Piipan.Dashboard.Pages.ParticipantUploadsModel
+
+<h1>@Model.Title</h1>
+
+<form method="post">
+     <input type="text" name="state">
+    <input type="submit" />
+</form>
+
+@if (!String.IsNullOrEmpty(Model.StateQuery))
+{
+    <span>@Model.StateQuery</span>
+    <a asp-page="/ParticipantUploads">Clear Search</a>
+}
+
+@if (Model.ParticipantUploadResults.Any())
+{
+    <table>
+        <thead>
+            <th>state</th>
+            <th>uploaded at</th>
+        </thead>
+        @foreach (var record in @Model.ParticipantUploadResults)
+        {
+            <tr>
+                <td>@record.State</td>
+                <td>@record.UploadedAt</td>
+            </tr>
+        }
+    </table>
+
+}
+@if (!String.IsNullOrEmpty(Model.PrevPageParams))
+{
+    <a href="@Model.PrevPageParams">Prev</a>
+}
+@if (!String.IsNullOrEmpty(Model.NextPageParams))
+{
+    <a href="@Model.NextPageParams">Next</a>
+}

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
 using Piipan.Dashboard.Api;
 
 #nullable enable
@@ -37,7 +37,8 @@ namespace Piipan.Dashboard.Pages
             if (BaseUrl == null)
                 throw new Exception("BaseUrl is null.");
             StateQuery = Request.Form["state"];
-            var url = $"{BaseUrl}?state={StateQuery}&perPage={PerPageDefault}";
+            var url = QueryHelpers.AddQueryString(BaseUrl, "state", StateQuery);
+            url = QueryHelpers.AddQueryString(url, "perPage", PerPageDefault.ToString());
             var api = new ParticipantUploadRequest(httpClient);
             var response = await api.Get(url);
             ParticipantUploadResults = response.data;
@@ -53,19 +54,7 @@ namespace Piipan.Dashboard.Pages
             var url = BaseUrl + Request.QueryString;
             StateQuery = Request.Query["state"];
             if (String.IsNullOrEmpty(Request.Query["perPage"]))
-            {
-                string perPageDefault = $"perPage={PerPageDefault}";
-                Regex regex = new Regex(@"\?");
-                Match match = regex.Match(url);
-                if (match.Success)
-                {
-                    url += String.Concat("&", perPageDefault);
-                }
-                else
-                {
-                    url += String.Concat("?", perPageDefault);
-                }
-            }
+                url = QueryHelpers.AddQueryString(url, "perPage", PerPageDefault.ToString());
             return url;
         }
 

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -13,6 +13,12 @@ namespace Piipan.Dashboard.Pages
 {
     public class ParticipantUploadsModel : PageModel
     {
+        private readonly IParticipantUploadRequest _participantUploadRequest;
+
+        public ParticipantUploadsModel(IParticipantUploadRequest participantUploadRequest)
+        {
+            _participantUploadRequest = participantUploadRequest;
+        }
         public string Title = "Participant Uploads";
         public List<ParticipantUpload> ParticipantUploadResults { get; private set; } = new List<ParticipantUpload>();
         public string? NextPageParams { get; private set; }
@@ -26,8 +32,7 @@ namespace Piipan.Dashboard.Pages
         public async Task OnGetAsync()
         {
             var url = FormatUrl();
-            var api = new ParticipantUploadRequest(httpClient);
-            var response = await api.Get(url);
+            var response = await _participantUploadRequest.Get(url);
             ParticipantUploadResults = response.data;
             SetPageLinks(response.meta);
         }
@@ -39,8 +44,7 @@ namespace Piipan.Dashboard.Pages
             StateQuery = Request.Form["state"];
             var url = QueryHelpers.AddQueryString(BaseUrl, "state", StateQuery);
             url = QueryHelpers.AddQueryString(url, "perPage", PerPageDefault.ToString());
-            var api = new ParticipantUploadRequest(httpClient);
-            var response = await api.Get(url);
+            var response = await _participantUploadRequest.Get(url);
             ParticipantUploadResults = response.data;
             SetPageLinks(response.meta);
             return Page();

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -19,7 +19,7 @@ namespace Piipan.Dashboard.Pages
         public string? PrevPageParams { get; private set; }
         public string? StateQuery { get; private set; }
         public static int PerPageDefault = 10;
-        public static string BaseUrl = "https://piipanmetricsapiztqzsbh432oyw.azurewebsites.net/api/GetParticipantUploads";
+        public static string? BaseUrl = Environment.GetEnvironmentVariable("MetricsApiUri");
 
         private HttpClient httpClient = new HttpClient();
 
@@ -34,6 +34,8 @@ namespace Piipan.Dashboard.Pages
 
         public async Task<IActionResult> OnPostAsync()
         {
+            if (BaseUrl == null)
+                throw new Exception("BaseUrl is null.");
             StateQuery = Request.Form["state"];
             var url = $"{BaseUrl}?state={StateQuery}&perPage={PerPageDefault}";
             var api = new ParticipantUploadRequest(httpClient);
@@ -43,8 +45,11 @@ namespace Piipan.Dashboard.Pages
             return Page();
         }
 
+        // adds default pagination to the api url if none is present from request params
         private string FormatUrl()
         {
+            if (BaseUrl == null)
+                throw new Exception("BaseUrl is null.");
             var url = BaseUrl + Request.QueryString;
             StateQuery = Request.Query["state"];
             if (String.IsNullOrEmpty(Request.Query["perPage"]))

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -19,7 +19,7 @@ namespace Piipan.Dashboard.Pages
         public string? PrevPageParams { get; private set; }
         public string? StateQuery { get; private set; }
         public static int PerPageDefault = 10;
-        public static string? BaseUrl = Environment.GetEnvironmentVariable("MetricsApiUri");
+        public string? BaseUrl = Environment.GetEnvironmentVariable("MetricsApiUri");
 
         private HttpClient httpClient = new HttpClient();
 

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Piipan.Dashboard.Api;
+
+#nullable enable
+
+namespace Piipan.Dashboard.Pages
+{
+    public class ParticipantUploadsModel : PageModel
+    {
+        public string Title = "Participant Uploads";
+        public List<ParticipantUpload> ParticipantUploadResults { get; private set; } = new List<ParticipantUpload>();
+        public string? NextPageParams { get; private set; }
+        public string? PrevPageParams { get; private set; }
+        public string? StateQuery { get; private set; }
+        public static int PerPageDefault = 10;
+        public static string BaseUrl = "https://piipanmetricsapiztqzsbh432oyw.azurewebsites.net/api/GetParticipantUploads";
+
+        private HttpClient httpClient = new HttpClient();
+
+        public async Task OnGetAsync()
+        {
+            var url = FormatUrl();
+            var api = new ParticipantUploadRequest(httpClient);
+            var response = await api.Get(url);
+            ParticipantUploadResults = response.data;
+            SetPageLinks(response.meta);
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            StateQuery = Request.Form["state"];
+            var url = $"{BaseUrl}?state={StateQuery}&perPage={PerPageDefault}";
+            var api = new ParticipantUploadRequest(httpClient);
+            var response = await api.Get(url);
+            ParticipantUploadResults = response.data;
+            SetPageLinks(response.meta);
+            return Page();
+        }
+
+        private string FormatUrl()
+        {
+            var url = BaseUrl + Request.QueryString;
+            StateQuery = Request.Query["state"];
+            if (String.IsNullOrEmpty(Request.Query["perPage"]))
+            {
+                string perPageDefault = $"perPage={PerPageDefault}";
+                Regex regex = new Regex(@"\?");
+                Match match = regex.Match(url);
+                if (match.Success)
+                {
+                    url += String.Concat("&", perPageDefault);
+                }
+                else
+                {
+                    url += String.Concat("?", perPageDefault);
+                }
+            }
+            return url;
+        }
+
+        private void SetPageLinks(ParticipantUploadResponseMeta meta)
+        {
+            NextPageParams = meta.nextPage;
+            PrevPageParams = meta.prevPage;
+        }
+    }
+}

--- a/dashboard/src/Piipan.Dashboard/ParticipantUpload.cs
+++ b/dashboard/src/Piipan.Dashboard/ParticipantUpload.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Piipan.Dashboard
+{
+    public class ParticipantUpload
+    {
+        public string State { get; set; }
+        public DateTime UploadedAt { get; set; }
+
+        public ParticipantUpload(string state, DateTime uploaded_at)
+        {
+            State = state;
+            UploadedAt = uploaded_at;
+        }
+    }
+}

--- a/dashboard/src/Piipan.Dashboard/Piipan.Dashboard.csproj
+++ b/dashboard/src/Piipan.Dashboard/Piipan.Dashboard.csproj
@@ -6,4 +6,8 @@
     <RestoreLockedMode Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreLockedMode>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
+using Piipan.Dashboard.Api;
 namespace Piipan.Dashboard
 {
     public class Startup
@@ -24,6 +24,7 @@ namespace Piipan.Dashboard
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
+            services.AddHttpClient<IParticipantUploadRequest, ParticipantUploadRequest>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/dashboard/src/Piipan.Dashboard/packages.lock.json
+++ b/dashboard/src/Piipan.Dashboard/packages.lock.json
@@ -1,6 +1,13 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.1": {}
+    ".NETCoreApp,Version=v3.1": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[12.0.3, )",
+        "resolved": "12.0.3",
+        "contentHash": "6mgjfnRB4jKMlzHSl+VD+oUc1IebOZabkbyWj2RiTgWwYPPuaK1H97G1sHqGwPlS5npiF5Q0OrxN1wni2n5QWg=="
+      }
+    }
   }
 }

--- a/dashboard/tests/Piipan.Dashboard.Tests/Api/ParticipantUploadRequestTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/Api/ParticipantUploadRequestTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Moq;
+using Moq.Protected;
+using Piipan.Dashboard.Api;
+
+
+namespace Piipan.Dashboard.Tests
+{
+    public class ParticipantUploadRequestTests
+    {
+        static Mock<HttpMessageHandler> MessageHandlerMock(string mockResponse)
+        {
+            var handlerMock = new Mock<HttpMessageHandler>();
+            var resp = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(mockResponse),
+            };
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(resp);
+
+            return handlerMock;
+        }
+
+        [Fact]
+        public async void GetSuccess()
+        {
+            var mockResponse = @"{
+                ""meta"": {
+                    ""page"": 1,
+                    ""perPage"": 5,
+                    ""total"": 5,
+                    ""nextPage"": null,
+                    ""prevPage"": null
+                },
+                ""data"": [
+                    {
+                        ""state"": ""eb"",
+                        ""uploaded_at"": ""1/1/0001 12:00:00 AM""
+                    }
+                ]
+            }";
+            var handlerMock = MessageHandlerMock(mockResponse);
+            var httpClient = new HttpClient(handlerMock.Object);
+            var api = new ParticipantUploadRequest(httpClient);
+            var resultResponse = await api.Get("http://example.com");
+
+            Assert.NotNull(resultResponse);
+            Assert.Equal(1, resultResponse.meta.page);
+            Assert.IsType<ParticipantUpload>(resultResponse.data[0]);
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Exactly(1),
+               ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+               ItExpr.IsAny<CancellationToken>());
+        }
+    }
+    public class ParticipantUploadResponseMetaTests
+    {
+        [Fact]
+        public void CreateSuccess()
+        {
+            var obj = new ParticipantUploadResponseMeta()
+            {
+                page = 1,
+                perPage = 5,
+                total = 10,
+                prevPage = null,
+                nextPage = "foobar"
+            };
+            Assert.Equal(1, obj.page);
+            Assert.Equal(5, obj.perPage);
+            Assert.Equal(10, obj.total);
+            Assert.Null(obj.prevPage);
+            Assert.Equal("foobar", obj.nextPage);
+        }
+    }
+
+    public class ParticipantUploadResponseTests
+    {
+        [Fact]
+        public void CreateSuccess()
+        {
+            var meta = new ParticipantUploadResponseMeta()
+            {
+                page = 1,
+                perPage = 5,
+                total = 10,
+                prevPage = null,
+                nextPage = "foobar"
+            };
+            var record = new ParticipantUpload("eb", new DateTime());
+            var list = new List<ParticipantUpload>() { record };
+            var response = new ParticipantUploadResponse()
+            {
+                meta = meta,
+                data = list
+            };
+            Assert.Equal(meta, response.meta);
+            Assert.Equal(list[0], response.data[0]);
+        }
+    }
+}

--- a/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 using Piipan.Dashboard.Pages;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Piipan.Dashboard.Pages;
+
+namespace Piipan.Dashboard.Tests
+{
+    public class ParticipantUploadsModelTests
+    {
+        [Fact]
+        public void BeforeOnGetAsync_TitleIsCorrect()
+        {
+            var pageModel = new ParticipantUploadsModel();
+            Assert.Equal("Participant Uploads", pageModel.Title);
+        }
+
+        [Fact]
+        public void BeforeOnGetAsync_PerPageDefaultIsCorrect()
+        {
+            Assert.True(ParticipantUploadsModel.PerPageDefault > 0, "page default is greater than 0");
+        }
+
+        [Fact]
+        public void BeforeOnGetAsync_BaseUrlIsCorrect()
+        {
+            Assert.Matches("http", ParticipantUploadsModel.BaseUrl);
+        }
+    }
+}

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -23,7 +23,9 @@ namespace Piipan.Dashboard.Tests
         [Fact]
         public void BeforeOnGetAsync_BaseUrlIsCorrect()
         {
+            Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
             Assert.Matches("http", ParticipantUploadsModel.BaseUrl);
+            Environment.SetEnvironmentVariable("MetricsApiUri", null);
         }
     }
 }

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -24,7 +24,7 @@ namespace Piipan.Dashboard.Tests
         public void BeforeOnGetAsync_BaseUrlIsCorrect()
         {
             Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
-            Assert.Matches("http", ParticipantUploadsModel.BaseUrl);
+            Assert.Matches("http://example.com", new ParticipantUploadsModel().BaseUrl);
             Environment.SetEnvironmentVariable("MetricsApiUri", null);
         }
     }

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
-using Xunit;
 using Piipan.Dashboard.Pages;
+using Piipan.Dashboard.Api;
+using Moq;
+using Xunit;
 
 namespace Piipan.Dashboard.Tests
 {
@@ -10,7 +12,8 @@ namespace Piipan.Dashboard.Tests
         [Fact]
         public void BeforeOnGetAsync_TitleIsCorrect()
         {
-            var pageModel = new ParticipantUploadsModel();
+            var mockApi = new Mock<IParticipantUploadRequest>();
+            var pageModel = new ParticipantUploadsModel(mockApi.Object);
             Assert.Equal("Participant Uploads", pageModel.Title);
         }
 
@@ -24,8 +27,20 @@ namespace Piipan.Dashboard.Tests
         public void BeforeOnGetAsync_BaseUrlIsCorrect()
         {
             Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
-            Assert.Matches("http://example.com", new ParticipantUploadsModel().BaseUrl);
+            var mockApi = new Mock<IParticipantUploadRequest>();
+            var pageModel = new ParticipantUploadsModel(mockApi.Object);
+            Assert.Matches("http://example.com", pageModel.BaseUrl);
             Environment.SetEnvironmentVariable("MetricsApiUri", null);
         }
+
+        [Fact]
+        public void BeforeOnGetAsync_initializesParticipantUploadResults()
+        {
+            var mockApi = new Mock<IParticipantUploadRequest>();
+            var pageModel = new ParticipantUploadsModel(mockApi.Object);
+            Assert.IsType<List<ParticipantUpload>>(pageModel.ParticipantUploadResults);
+        }
+
+        // Add more here
     }
 }

--- a/dashboard/tests/Piipan.Dashboard.Tests/Piipan.Dashboard.Tests.csproj
+++ b/dashboard/tests/Piipan.Dashboard.Tests/Piipan.Dashboard.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">

--- a/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
+++ b/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
@@ -18,6 +18,16 @@
           "Microsoft.TestPlatform.TestHost": "16.8.3"
         }
       },
+      "Moq": {
+        "type": "Direct",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "YomI39ySpUBi0wX05+orpdO3pyj+2NykmUJdY1vglhm58I+acV4QaGf9FG2JnZ6DTs1tbnv7vsfeAAkYwiSvYQ==",
+        "dependencies": {
+          "Castle.Core": "4.4.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.4.1, )",
@@ -35,33 +45,27 @@
         "resolved": "2.4.3",
         "contentHash": "kZZSmOmKA8OBlAJaquPXnJJLM9RwQ27H7BMVqfMLUcTi9xHinWGJiWksa3D4NEtz0wZ/nxd2mogObvBgJKCRhQ=="
       },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "b5rRL5zeaau1y/5hIbI+6mGw3cwun16YjkHZnV9RRT5UyUIFsgLmNXJ0YnIN9p8Hw7K7AbG1q1UclQVU3DinAQ==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "System.Collections.Specialized": "4.3.0",
+          "System.ComponentModel": "4.3.0",
+          "System.ComponentModel.TypeConverter": "4.3.0",
+          "System.Diagnostics.TraceSource": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
+        }
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "16.8.3",
         "contentHash": "pFZAEvmIEkEIKl6WD1wCZ2qkc3f6PLdc2kAjCsUJfaMxVtgq3qxcQd4eZq+ZMt9eSX12VfxtFav2vPy1yiu8bw=="
-      },
-      "Microsoft.CSharp": {
-        "type": "Transitive",
-        "resolved": "4.0.1",
-        "contentHash": "17h8b5mXa87XYKrrVqdgZ38JefSUqLChUQpXgSnpzsM0nDOhE40FTeNWOJ/YmySGV6tG6T8+hjz6vxbknHJr6A==",
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Dynamic.Runtime": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Threading": "4.0.11"
-        }
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
@@ -155,32 +159,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "9.0.1",
-        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.0.1",
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Dynamic.Runtime": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Extensions": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Text.Encoding": "4.0.11",
-          "System.Text.Encoding.Extensions": "4.0.11",
-          "System.Text.RegularExpressions": "4.1.0",
-          "System.Threading": "4.0.11",
-          "System.Threading.Tasks": "4.0.11",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XDocument": "4.0.11"
-        }
+        "resolved": "12.0.3",
+        "contentHash": "6mgjfnRB4jKMlzHSl+VD+oUc1IebOZabkbyWj2RiTgWwYPPuaK1H97G1sHqGwPlS5npiF5Q0OrxN1wni2n5QWg=="
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
@@ -341,6 +321,73 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Collections.NonGeneric": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections.Specialized": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Epx8PoVZR0iuOnJJDzp7pWvdfMMOAvpUo95pC4ScH2mJuXkKA2Y4aR3cG9qt2klHgSons1WFh4kcGW7cSXvrxg==",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ComponentModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VyGn1jGRZVfxnh8EdvDCi71v3bMXrsu8aYJOwoV7SNDLVhiEqwP86pPMyRGsDsxhXAm2b3o9OIqeETfN5qfezw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "j8GUkCpM8V4d4vhLIIoBLGey2Z5bCkMVNjEZseyAlm4n5arcsJOeI3zkUP+zvZgzsbLTYh4lYeP/ZD/gdIAPrw==",
+        "dependencies": {
+          "System.ComponentModel": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.TypeConverter": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "16pQ6P+EdhcXzPiEK4kbA953Fu0MNG2ovxTZU81/qsCd1zPRsKc3uif5NgvllCY598k6bI0KUyKW8fanlfaDQg==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Collections.Specialized": "4.3.0",
+          "System.ComponentModel": "4.3.0",
+          "System.ComponentModel.Primitives": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
       "System.Console": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -385,6 +432,22 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VnYp1NxGx8Ww731y2LJ1vpfb/DKVNKEZ8Jsh5SgQTZREL/YpWRArgh9pI8CDLmgHspZmLL697CaLvH85qQpRiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
       "System.Diagnostics.Tracing": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -397,24 +460,23 @@
       },
       "System.Dynamic.Runtime": {
         "type": "Transitive",
-        "resolved": "4.0.11",
-        "contentHash": "db34f6LHYM0U0JpE+sOmjar27BnqTVkbLJhgfwMpTdgTigG/Hna3m2MYVwnFzGGKnEJk2UXFuoVTr8WUbU91/A==",
+        "resolved": "4.3.0",
+        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
         "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Diagnostics.Debug": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.Linq": "4.1.0",
-          "System.Linq.Expressions": "4.1.0",
-          "System.ObjectModel": "4.0.12",
-          "System.Reflection": "4.1.0",
-          "System.Reflection.Emit": "4.0.1",
-          "System.Reflection.Emit.ILGeneration": "4.0.1",
-          "System.Reflection.Primitives": "4.0.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Threading": "4.0.11"
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -788,15 +850,6 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.1.1",
-        "contentHash": "HZ6Du5QrTG8MNJbf4e4qMO3JRAkIboGT5Fk804uZtg3Gq516S7hAqTm2UZKUHa7/6HUGdVy3AqMQKbns06G/cg==",
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0"
-        }
-      },
       "System.Security.Cryptography.Algorithms": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -991,13 +1044,8 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "npvJkVKl5rKXrtl1Kkm6OhOUaYGEiF9wFbppFRWSMoApKzt2PiPHT2Bb8a5sAWxprvdOAtvaARS9QYMznEUtug==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
-        }
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "System.Threading.Timer": {
         "type": "Transitive",
@@ -1042,6 +1090,23 @@
           "System.Globalization": "4.3.0",
           "System.IO": "4.3.0",
           "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lJ8AxvkX7GQxpC6GFCeBj8ThYVyQczx2+f/cWHJU8tjS7YfI6Cv6bon70jVEgs2CiFbmmM8b9j1oZVx0dSI2Ww==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Runtime.Extensions": "4.3.0",
@@ -1096,7 +1161,10 @@
         }
       },
       "piipan.dashboard": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "12.0.3"
+        }
       }
     }
   }

--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -13,6 +13,9 @@
         },
         "servicePlan": {
             "type": "string"
+        },
+        "metricsApiUri": {
+            "type": "string"
         }
     },
     "variables": {
@@ -28,7 +31,14 @@
                     "priority": 100
                 }
             ],
-            "ftpsState": "Disabled"
+            "ftpsState": "Disabled",
+            "appSettings": [
+                // Environment Variables
+                {
+                    "name": "MetricsApiUri",
+                    "value": "[parameters('metricsApiUri')]"
+                }
+            ]
         }
     },
     "resources": [

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -10,9 +10,6 @@
 source $(dirname "$0")/../tools/common.bash || exit
 source $(dirname "$0")/iac-common.bash || exit
 
-# Default resource group for our system
-RESOURCE_GROUP=piipan-resources
-
 # In some cases, when trying to create a Function App, you may receive an
 # error, as Azure has various rules/limitations on how different App Service
 # plans are permitted to co-exist in a single resource group. Details at:
@@ -23,8 +20,6 @@ FUNCTIONS_RESOURCE_GROUP=piipan-functions
 # Use seperate resource group for matching API resources to allow use of
 # incremental deployments
 MATCH_RESOURCE_GROUP=piipan-match
-
-LOCATION=westus
 
 # Name of Key Vault
 VAULT_NAME=secret-keeper
@@ -40,12 +35,6 @@ PG_AAD_ADMIN=piipan-admins
 
 # Name of PostgreSQL server
 PG_SERVER_NAME=participant-records
-
-# Name of App Service Plan
-APP_SERVICE_PLAN=piipan-app-plan
-
-# Base name of dashboard app
-DASHBOARD_APP_NAME=piipan-dashboard
 
 # Base name of query tool app
 QUERY_TOOL_APP_NAME=piipan-query-tool
@@ -233,18 +222,6 @@ else
     --member-id $CURRENT_USER_OBJID
 fi
 
-# Create App Service resources for dashboard app
-echo "Creating App Service resources for dashboard app"
-az deployment group create \
-  --name $DASHBOARD_APP_NAME \
-  --resource-group $RESOURCE_GROUP \
-  --template-file ./arm-templates/dashboard-app.json \
-  --parameters \
-    location=$LOCATION \
-    resourceTags="$RESOURCE_TAGS" \
-    appName=$DASHBOARD_APP_NAME \
-    servicePlan=$APP_SERVICE_PLAN
-
 # This is a subscription-level resource provider
 az provider register --wait --namespace Microsoft.EventGrid
 
@@ -402,7 +379,7 @@ while IFS=, read -r abbr name ; do
         stateAbbr="$abbr" \
         dbConnectionString="$db_conn_str" \
         dbConnectionStringKey="$DB_CONN_STR_KEY")
-  
+
   # Store function names for future auth configuration
   match_func_names+=("$func_name")
 

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -9,6 +9,18 @@ CURRENT_USER_OBJID=`az ad signed-in-user show --query objectId --output tsv`
 # The default Azure subscription
 SUBSCRIPTION_ID=`az account show --query id -o tsv`
 
+# Default resource group for our system
+RESOURCE_GROUP=piipan-resources
+
+# resource group for metrics
+METRICS_RESOURCE_GROUP=piipan-metrics
+
+# Name of App Service Plan
+APP_SERVICE_PLAN=piipan-app-plan
+
+# Default location
+LOCATION=westus
+
 # Name of environment variable used to pass database connection strings
 # to app or function code
 DB_CONN_STR_KEY=DatabaseConnectionString
@@ -23,8 +35,10 @@ AZ_SERV_STR_KEY=AzureServicesAuthConnectionString
 
 # For connection strings, our established placeholder value
 PASSWORD_PLACEHOLDER='{password}'
-### END Constants
 
+# Base name of dashboard app
+DASHBOARD_APP_NAME=piipan-dashboard
+### END Constants
 
 ### Functions
 # Create a very long, (mostly) random password. Ensures all Azure character

--- a/metrics/src/Piipan.Metrics/PiipanMetricsApi/GetParticipantUploads.cs
+++ b/metrics/src/Piipan.Metrics/PiipanMetricsApi/GetParticipantUploads.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Npgsql;
@@ -80,17 +80,13 @@ namespace Piipan.Metrics.Api
             if (total >= (page * perPage))
             {
                 if (!String.IsNullOrEmpty(state))
-                    result += $"&state={state}";
-                result += $"&page={nextPage}&perPage={perPage}";
+                    result = QueryHelpers.AddQueryString(result, "state", state);
+                result = QueryHelpers.AddQueryString(result, "page", nextPage.ToString());
+                result = QueryHelpers.AddQueryString(result, "perPage", perPage.ToString());
             }
             if (String.IsNullOrEmpty(result))
-            {
                 return null;
-            }
-            else
-            {
-                return "?" + result.TrimStart('&');
-            }
+            return result;
         }
 
         public static String? PrevPageParams(
@@ -104,9 +100,10 @@ namespace Piipan.Metrics.Api
 
             var result = "";
             if (!String.IsNullOrEmpty(state))
-                result += $"&state={state}";
-            result += $"&page={newPage}&perPage={perPage}";
-            return "?" + result.TrimStart('&');
+                result = QueryHelpers.AddQueryString(result, "state", state);
+            result = QueryHelpers.AddQueryString(result, "page", newPage.ToString());
+            result = QueryHelpers.AddQueryString(result, "perPage", perPage.ToString());
+            return result;
         }
 
         public async static Task<Int64> TotalQuery(

--- a/metrics/src/Piipan.Metrics/PiipanMetricsApi/GetParticipantUploads.cs
+++ b/metrics/src/Piipan.Metrics/PiipanMetricsApi/GetParticipantUploads.cs
@@ -48,6 +48,11 @@ namespace Piipan.Metrics.Api
                     meta.page,
                     meta.perPage,
                     meta.total);
+                meta.prevPage = PrevPageParams(
+                    req.Query["state"],
+                    meta.page,
+                    meta.perPage,
+                    meta.total);
                 var response = new ParticipantUploadsResponse(
                     data,
                     meta
@@ -86,6 +91,22 @@ namespace Piipan.Metrics.Api
             {
                 return "?" + result.TrimStart('&');
             }
+        }
+
+        public static String? PrevPageParams(
+            string? state,
+            int page,
+            int perPage,
+            Int64 total)
+        {
+            var newPage = page - 1;
+            if (newPage <= 0) return null;
+
+            var result = "";
+            if (!String.IsNullOrEmpty(state))
+                result += $"&state={state}";
+            result += $"&page={newPage}&perPage={perPage}";
+            return "?" + result.TrimStart('&');
         }
 
         public async static Task<Int64> TotalQuery(

--- a/metrics/src/Piipan.Metrics/PiipanMetricsApi/Serializers/Meta.cs
+++ b/metrics/src/Piipan.Metrics/PiipanMetricsApi/Serializers/Meta.cs
@@ -11,6 +11,7 @@ namespace Piipan.Metrics.Api
             public int perPage { get; set; }
             public Int64 total { get; set; }
             public string? nextPage { get; set; }
+            public string? prevPage { get; set; }
         }
     }
 }

--- a/metrics/tests/Piipan.Metrics.Tests/PiipanMetricsApiTests/GetParticipantUploads.Tests.cs
+++ b/metrics/tests/Piipan.Metrics.Tests/PiipanMetricsApiTests/GetParticipantUploads.Tests.cs
@@ -166,7 +166,7 @@ namespace Piipan.Metrics.Tests
                         page,
                         perPage,
                         total);
-                    Assert.Matches("state=ea", result);
+                    Assert.Matches(@"\?state=ea", result);
                 }
 
             }
@@ -215,7 +215,7 @@ namespace Piipan.Metrics.Tests
                         page,
                         perPage,
                         total);
-                    Assert.Matches("state=ea", result);
+                    Assert.Matches(@"\?state=ea", result);
                 }
 
             }

--- a/metrics/tests/Piipan.Metrics.Tests/PiipanMetricsApiTests/GetParticipantUploads.Tests.cs
+++ b/metrics/tests/Piipan.Metrics.Tests/PiipanMetricsApiTests/GetParticipantUploads.Tests.cs
@@ -171,6 +171,54 @@ namespace Piipan.Metrics.Tests
 
             }
 
+
+            public class PrevPageParamsTests
+            {
+                // when there's a previous page to be had
+                [Fact]
+                public void WhenPrevPage()
+                {
+                    var page = 2;
+                    var perPage = 5;
+                    var total = 6;
+                    var result = GetParticipantUploads.PrevPageParams(
+                        null,
+                        page,
+                        perPage,
+                        total);
+                    Assert.Matches(@"\?page=1\&perPage=5", result);
+                }
+                // when there's not a previous page to be had
+                [Fact]
+                public void WhenNotPrevPage()
+                {
+                    var page = 1;
+                    var perPage = 5;
+                    var total = 6;
+                    var result = GetParticipantUploads.PrevPageParams(
+                        null,
+                        page,
+                        perPage,
+                        total);
+                    Assert.Equal(null, result);
+                }
+                // when state is passed, result includes state param
+                [Fact]
+                public void WhenQueryPresent()
+                {
+                    var state = "ea";
+                    var page = 2;
+                    var perPage = 5;
+                    var total = 6;
+                    var result = GetParticipantUploads.PrevPageParams(
+                        state,
+                        page,
+                        perPage,
+                        total);
+                    Assert.Matches("state=ea", result);
+                }
+
+            }
             public class TotalQueryTests
             {
                 [Fact]

--- a/metrics/tests/Piipan.Metrics.Tests/PiipanMetricsApiTests/Serializers.Tests/MetaTests.cs
+++ b/metrics/tests/Piipan.Metrics.Tests/PiipanMetricsApiTests/Serializers.Tests/MetaTests.cs
@@ -37,6 +37,13 @@ namespace Piipan.Metrics.Tests
                 meta.nextPage = "foobar";
                 Assert.Equal("foobar", meta.nextPage);
             }
+
+            public static void HasAPrevPage()
+            {
+                var meta = new Meta();
+                meta.prevPage = "foobar";
+                Assert.Equal("foobar", meta.prevPage);
+            }
         }
     }
 }


### PR DESCRIPTION
Wanted to try getting this in before our demo tomorrow. This is a completely un-styled version of showing participant upload metrics in the Dashboard app through server-side API requests.

Creates a new Dashboard page and model `ParticipantUploads` which shows:
   - list of most recent participant uploads from the etl `BulkUpload` actions
    - a search input with a "clear search" button to query by state name
    - prev/next page links

Does not have:
    - frontend validation for search input
    - USWDS styling

I referred a lot to @heymatthenry's work in how to make server-side api requests and how to mock api requests in tests (thanks, Matt).

If you test locally, you need to be on the GSA network in order to make the API request.  

Specifically looking for better ways to test the page models, and to possibly use dependency injection for the Api service used there. I'm also wondering if my naming and breakdown of the Api classes makes sense.  