### PR TITLE
Add page model tests to dashboard

### DIFF
--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -25,7 +25,8 @@ namespace Piipan.Dashboard.Pages
         public string? PrevPageParams { get; private set; }
         public string? StateQuery { get; private set; }
         public static int PerPageDefault = 10;
-        public string? BaseUrl = Environment.GetEnvironmentVariable("MetricsApiUri");
+        public static string ApiUrlKey = "MetricsApiUri";
+        public string? BaseUrl = Environment.GetEnvironmentVariable(ApiUrlKey);
 
         private HttpClient httpClient = new HttpClient();
 

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -32,13 +32,19 @@ namespace Piipan.Dashboard.Tests
         }
 
         [Fact]
+        public void BeforeOnGetAsync_ApiUrlKeyIsCorrect()
+        {
+            Assert.IsType<String>(ParticipantUploadsModel.ApiUrlKey);
+        }
+
+        [Fact]
         public void BeforeOnGetAsync_BaseUrlIsCorrect()
         {
-            Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
+            Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, "http://example.com");
             var mockApi = new Mock<IParticipantUploadRequest>();
             var pageModel = new ParticipantUploadsModel(mockApi.Object);
             Assert.Matches("http://example.com", pageModel.BaseUrl);
-            Environment.SetEnvironmentVariable("MetricsApiUri", null);
+            Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
 
         [Fact]
@@ -54,7 +60,7 @@ namespace Piipan.Dashboard.Tests
         public async void AfterOnGetAsync_setsParticipantUploadResults()
         {
             // setup env
-            Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
+            Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, "http://example.com");
             // setup mocks
             var participantUpload = new ParticipantUpload("eb", new DateTime());
             var data = new List<ParticipantUpload>();
@@ -72,14 +78,14 @@ namespace Piipan.Dashboard.Tests
             // assert
             Assert.Equal(participantUpload, pageModel.ParticipantUploadResults[0]);
             // teardown
-            Environment.SetEnvironmentVariable("MetricsApiUri", null);
+            Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
         // sets participant uploads after Post request
         [Fact]
         public async void AfterOnPostAsync_setsParticipantUploadResults()
         {
             // setup env
-            Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
+            Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, "http://example.com");
             // setup mock api response
             var participantUpload = new ParticipantUpload("eb", new DateTime());
             var data = new List<ParticipantUpload>();
@@ -105,7 +111,7 @@ namespace Piipan.Dashboard.Tests
             // assert
             Assert.Equal(participantUpload, pageModel.ParticipantUploadResults[0]);
             // teardown
-            Environment.SetEnvironmentVariable("MetricsApiUri", null);
+            Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
 
         private Mock<IParticipantUploadRequest> mockApiWithResponse(

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -1,5 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
 using Piipan.Dashboard.Pages;
 using Piipan.Dashboard.Api;
 using Moq;
@@ -41,6 +49,90 @@ namespace Piipan.Dashboard.Tests
             Assert.IsType<List<ParticipantUpload>>(pageModel.ParticipantUploadResults);
         }
 
-        // Add more here
+        // sets participant uploads after Get request
+        [Fact]
+        public async void AfterOnGetAsync_setsParticipantUploadResults()
+        {
+            // setup env
+            Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
+            // setup mocks
+            var participantUpload = new ParticipantUpload("eb", new DateTime());
+            var data = new List<ParticipantUpload>();
+            data.Add(participantUpload);
+            var meta = new ParticipantUploadResponseMeta();
+            var mockApi = mockApiWithResponse(data, meta);
+            var pageContext = MockPageContext(new DefaultHttpContext());
+            // setup page model with mocks
+            var pageModel = new ParticipantUploadsModel(mockApi.Object)
+            {
+                PageContext = pageContext
+            };
+            // run
+            await pageModel.OnGetAsync();
+            // assert
+            Assert.Equal(participantUpload, pageModel.ParticipantUploadResults[0]);
+            // teardown
+            Environment.SetEnvironmentVariable("MetricsApiUri", null);
+        }
+        // sets participant uploads after Post request
+        [Fact]
+        public async void AfterOnPostAsync_setsParticipantUploadResults()
+        {
+            // setup env
+            Environment.SetEnvironmentVariable("MetricsApiUri", "http://example.com");
+            // setup mock api response
+            var participantUpload = new ParticipantUpload("eb", new DateTime());
+            var data = new List<ParticipantUpload>();
+            data.Add(participantUpload);
+            var meta = new ParticipantUploadResponseMeta();
+            var mockApi = mockApiWithResponse(data, meta);
+            // setup mock page context with form data
+            var httpContext = new DefaultHttpContext();
+            var form = new FormCollection(new Dictionary<string,
+            Microsoft.Extensions.Primitives.StringValues>
+            {
+                { "state", "foo" }
+            });
+            httpContext.Request.Form = form;
+            var pageContext = MockPageContext(httpContext);
+            // setup page model with mocks
+            var pageModel = new ParticipantUploadsModel(mockApi.Object)
+            {
+                PageContext = pageContext
+            };
+            // run
+            await pageModel.OnPostAsync();
+            // assert
+            Assert.Equal(participantUpload, pageModel.ParticipantUploadResults[0]);
+            // teardown
+            Environment.SetEnvironmentVariable("MetricsApiUri", null);
+        }
+
+        private Mock<IParticipantUploadRequest> mockApiWithResponse(
+            List<ParticipantUpload> data,
+            ParticipantUploadResponseMeta meta
+        )
+        {
+            var mockResponse = new ParticipantUploadResponse();
+            mockResponse.meta = new ParticipantUploadResponseMeta();
+            mockResponse.data = data;
+            var mockApi = new Mock<IParticipantUploadRequest>();
+            mockApi.Setup(x => x.Get(It.IsAny<string>())).Returns(Task.FromResult(mockResponse));
+            return mockApi;
+        }
+        // setup mock httpcontext for page model,
+        // which provides the Route object to the model
+        private PageContext MockPageContext(DefaultHttpContext httpContext)
+        {
+            var modelState = new ModelStateDictionary();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor(), modelState);
+            var modelMetadataProvider = new EmptyModelMetadataProvider();
+            var viewData = new ViewDataDictionary(modelMetadataProvider, modelState);
+            var pageContext = new PageContext(actionContext)
+            {
+                ViewData = viewData
+            };
+            return pageContext;
+        }
     }
 }


### PR DESCRIPTION
Proof of concept of some basic tests for the Get and Request methods on a page model. Shows how to mock HttpContext so objects like `Request.Query` and `Request.Form` can be manipulated in the tests.

Nothing super specific I'm looking for feedback on here, just interested to hear anyone's general thoughts. 