### PR TITLE
Downgrading metrics db to Basic tier with other iac improvements

### DIFF
--- a/iac/arm-templates/metrics.json
+++ b/iac/arm-templates/metrics.json
@@ -89,41 +89,6 @@
                             "metadata": {
                                 "description": "Server Name for Azure database for PostgreSQL"
                             }
-                        },
-                        "subnetName": {
-                            "type": "string",
-                            "defaultValue": "azure_postgresql_subnet",
-                            "metadata": {
-                                "description": "Subnet Name"
-                            }
-                        },
-                        "subnetPrefix": {
-                            "type": "string",
-                            "defaultValue": "10.0.0.0/16",
-                            "metadata": {
-                                "description": "Subnet Address Prefix"
-                            }
-                        },
-                        "virtualNetworkName": {
-                            "type": "string",
-                            "defaultValue": "azure_postgresql_vnet",
-                            "metadata": {
-                                "description": "Virtual Network Name"
-                            }
-                        },
-                        "virtualNetworkRuleName": {
-                            "type": "string",
-                            "defaultValue": "AllowSubnet",
-                            "metadata": {
-                                "description": "Virtual Network RuleName"
-                            }
-                        },
-                        "vnetAddressPrefix": {
-                            "type": "string",
-                            "defaultValue": "10.0.0.0/16",
-                            "metadata": {
-                                "description": "Virtual Network Address Prefix"
-                            }
                         }
                     },
                     "variables": {
@@ -148,42 +113,15 @@
                     },
                     "resources": [
                         {
-                            "type": "Microsoft.Network/virtualNetworks",
-                            "apiVersion": "2020-06-01",
-                            "name": "[parameters('virtualNetworkName')]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "addressSpace": {
-                                    "addressPrefixes": [
-                                        "[parameters('vnetAddressPrefix')]"
-                                    ]
-                                }
-                            },
-                            "resources": [
-                                {
-                                    "type": "subnets",
-                                    "apiVersion": "2020-06-01",
-                                    "name": "[parameters('subnetName')]",
-                                    "location": "[parameters('location')]",
-                                    "dependsOn": [
-                                        "[parameters('virtualNetworkName')]"
-                                    ],
-                                    "properties": {
-                                        "addressPrefix": "[parameters('subnetPrefix')]"
-                                    }
-                                }
-                            ]
-                        },
-                        {
                             "type": "Microsoft.DBforPostgreSQL/servers",
-                            "apiVersion": "2017-12-01",
+                            "apiVersion": "2017-12-01-preview",
                             "name": "[parameters('serverName')]",
                             "location": "[parameters('location')]",
                             "tags": "[parameters('resourceTags')]",
                             "sku": {
-                                "name": "GP_Gen5_2",
-                                "tier": "GeneralPurpose",
-                                "capacity": 2,
+                                "name": "B_Gen5_1",
+                                "tier": "Basic",
+                                "capacity": 1,
                                 "size": "5120",
                                 "family": "Gen5"
                             },
@@ -197,22 +135,10 @@
                                     "backupRetentionDays": 7,
                                     "geoRedundantBackup": "Disabled",
                                     "storageAutoGrow": "Enabled"
-                                }
-                            },
-                            "resources": [
-                                {
-                                    "type": "virtualNetworkRules",
-                                    "apiVersion": "2017-12-01",
-                                    "name": "[parameters('virtualNetworkRuleName')]",
-                                    "dependsOn": [
-                                        "[resourceId('Microsoft.DBforPostgreSQL/servers/', parameters('serverName'))]"
-                                    ],
-                                    "properties": {
-                                        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]",
-                                        "ignoreMissingVnetServiceEndpoint": true
-                                    }
-                                }
-                            ]
+                                },
+                                "previewFeature": "",
+                                "infrastructureEncryption": "Disabled"
+                            }
                         },
                         {
                             "type": "Microsoft.DBforPostgreSQL/servers/firewallRules",

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -94,8 +94,9 @@ FUNCTIONS_UNIQ_STR=`az deployment group create \
   --template-file ./arm-templates/unique-string.json \
   --query properties.outputs.uniqueString.value \
   -o tsv`
-FUNC_APP_NAME=PiipanMetricsFunctions${FUNCTIONS_UNIQ_STR}
-FUNC_STORAGE_NAME=piipanmetricsstorage${FUNCTIONS_UNIQ_STR}
+FUNC_APP_PREFIX=PiipanMetricsFunctions
+FUNC_APP_NAME=${FUNC_APP_PREFIX}${FUNCTIONS_UNIQ_STR}
+FUNC_STORAGE_NAME=piipanmet${FUNCTIONS_UNIQ_STR}
 FUNC_NAME=BulkUploadMetrics
 
 # Need a storage account to publish function app to:
@@ -156,12 +157,12 @@ fi
 
 # publish the function app
 echo "Publishing function app $FUNC_APP_NAME"
-pushd ../metrics/src/Piipan.Metrics/$FUNC_APP_NAME
+pushd ../metrics/src/Piipan.Metrics/$FUNC_APP_PREFIX
   func azure functionapp publish $FUNC_APP_NAME --dotnet
 popd
 
 # Subscribe each dynamically created event blob topic to this function
-FUNCTIONS_PROVIDERS=/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers
+FUNCTIONS_PROVIDERS=/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${METRICS_RESOURCE_GROUP}/providers
 SUBS_RESOURCE_GROUP=piipan-resources
 
 while IFS=, read -r abbr name ; do
@@ -217,7 +218,7 @@ fi
 
 # publish metrics function app
 echo "Publishing function app $METRICS_FUNC_APP_NAME"
-pushd ../metrics/src/Piipan.Metrics/PiipanMetricsApi
+pushd ../metrics/src/Piipan.Metrics/$METRICS_FUNC_APP_PREFIX
   func azure functionapp publish $METRICS_FUNC_APP_NAME --dotnet
 popd
 


### PR DESCRIPTION
Resolves [#338](https://github.com/18F/piipan/issues/388)

Doing this made me realize the virtual network in my metrics.json template was unnecessary. I think this was residual from pulling this example ARM template from Azure docs.