### PR TITLE
Add local development approach to orchestrator API

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -449,9 +449,10 @@ app_role_manifest () {
   json="\
   [{
     \"allowedMemberTypes\": [
+      \"User\",
       \"Application\"
     ],
-    \"description\": \"Grants application-to-application access\",
+    \"description\": \"Grants application access\",
     \"displayName\": \"Authorized client\",
     \"isEnabled\": true,
     \"origin\": \"Application\",

--- a/match/docs/orchestrator-match.md
+++ b/match/docs/orchestrator-match.md
@@ -35,8 +35,9 @@ At runtime, the app requests an authentication token from the state app's Active
 
 Local development is achieved by connecting a locally running instance of the orchestrator API to remote instances of the state APIs. When running locally, `Startup.cs` conditionally configures the `Piipan.Shared.Autentication.AuthorizedJsonApiClient` dependency to use Azure CLI credentials when obtaining access tokens. To make use of this functionality:
 
-1. Adjust the orchestrator's local configuration by adding `"DEVELOPMENT": "true"` to the `Values` object in `local.settings.json`.
-1. Assign your user account the `StateApi.Query` role for each state the orchestrator queries. Assignment can be done using the [`tools/assign-app-role.bash`](../../tools/assign-app-role.bash) script.
+1. Run `func azure functionapp fetch-app-settings <remote orchestrator name>` to ensure you have up-to-date local settings configured in `local.settings.json`.
+1. Run `func settings add DEVELOPMENT true` to add a `"DEVELOPMENT"` setting with a value of `"true"` to `local.settings.json`. This triggers the orchestrator to use your Azure CLI credentials when authenticating with the state APIs.
+1. Assign your user account the `StateApi.Query` role for each state the orchestrator queries. Assignment can be done using the [`tools/assign-app-role.bash`](../../tools/assign-app-role.bash) script. E.g., `./assign-app-role.bash <remote state function name> StateApi.Query`.
 1. Ensure the Azure CLI has been added as an authorized client application to each state API's application object. This can be done via the Azure Portal at Azure Active Directory > Application registrations > {State API's application object} > Expose an API > Add a client application and adding the client ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46` (the global identifier for the Azure CLI) with the `user_impersonation` scope. A helper script for this action does not yet exist.
 
 With the orchestrator running locally (`func start` or `dotnet watch msbuild /t:RunFunctions`), any requests to the local endpoint will now use the user account authorized with Azure CLI to obtain access tokens from the state APIs.
@@ -56,7 +57,7 @@ func azure functionapp publish <app_name> --dotnet
 ## Remote testing
 
 To test the orchestrator remotely:
-1. Assign your user account the `OrchestratorApi.Query` role for each state the orchestrator queries. Assignment can be done using the [`tools/assign-app-role.bash`](../../tools/assign-app-role.bash) script.
+1. Assign your user account the `OrchestratorApi.Query` role for the remote orchestrator application. Assignment can be done using the [`tools/assign-app-role.bash`](../../tools/assign-app-role.bash) script. E.g., `./assign-app-role.bash <remote orchestrator name> OrchestratorApi.Query`.
 1. Ensure the Azure CLI has been added as an authorized client application to the orchestrator's application object (see [local development](#local-development)).
 1. Retrieve a token for your user using the Azure CLI: `az account get-access-token --resource <orchestrator application ID URI>`.
 1. Send a request to the remote endpoint—perhaps using a tool like Postman or `curl`—and include the access token in the Authorization header: `Authorization: Bearer {token}`.

--- a/match/src/Piipan.Match.Orchestrator/Startup.cs
+++ b/match/src/Piipan.Match.Orchestrator/Startup.cs
@@ -13,7 +13,7 @@ namespace Piipan.Match.Orchestrator
             ITokenProvider tokenProvider;
             var configuration = builder.GetContext().Configuration;
 
-            if (configuration["DEVELOPMENT"] == "true")
+            if (configuration?["DEVELOPMENT"] == "true")
             {
                 tokenProvider = new CliTokenProvider();
             }

--- a/match/src/Piipan.Match.Orchestrator/Startup.cs
+++ b/match/src/Piipan.Match.Orchestrator/Startup.cs
@@ -10,12 +10,21 @@ namespace Piipan.Match.Orchestrator
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
+            ITokenProvider tokenProvider;
+            var configuration = builder.GetContext().Configuration;
+
+            if (configuration["DEVELOPMENT"] == "true")
+            {
+                tokenProvider = new CliTokenProvider();
+            }
+            else
+            {
+                tokenProvider = new EasyAuthTokenProvider();
+            }
+
             builder.Services.AddSingleton<IAuthorizedApiClient>((s) =>
             {
-                var client = new HttpClient();
-                var tokenProvider = new EasyAuthTokenProvider();
-
-                return new AuthorizedJsonApiClient(client, tokenProvider);
+                return new AuthorizedJsonApiClient(new HttpClient(), tokenProvider);
             });
         }
     }

--- a/shared/src/Piipan.Shared/Authentication.cs
+++ b/shared/src/Piipan.Shared/Authentication.cs
@@ -12,6 +12,18 @@ namespace Piipan.Shared.Authentication
         Task<AccessToken> RetrieveAsync(string resourceUri);
     }
 
+    public class CliTokenProvider : ITokenProvider
+    {
+        public async Task<AccessToken> RetrieveAsync(string resourceUri)
+        {
+            var tokenCredential = new AzureCliCredential();
+            var context = new TokenRequestContext(new[] { resourceUri });
+            var tokenTask = await tokenCredential.GetTokenAsync(context);
+
+            return tokenTask;
+        }
+    }
+
     public class EasyAuthTokenProvider : ITokenProvider
     {
         public async Task<AccessToken> RetrieveAsync(string appUri)

--- a/tools/assign-app-role.bash
+++ b/tools/assign-app-role.bash
@@ -8,7 +8,7 @@
 #
 # usage: assign-app-role.bash function-name role-name
 
-source common.bash || exit
+source $(dirname "$0")/common.bash || exit
 
 main () {
   function=$1

--- a/tools/assign-app-role.sh
+++ b/tools/assign-app-role.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Assigns the current CLI user to the specified application role of the
+# specified Azure Function. Used to enable the use of Azure CLI credentials
+# (i.e., `Azure.Identity.AzureCliCredential`) when connecting to remote APIs
+# which have been secured using App Service Authentication. Only intended
+# for development environments.
+#
+# usage: assign-app-role.bash function-name role-name
+
+source common.bash || exit
+
+main () {
+  function=$1
+  role=$2
+
+  # Get function's application object
+  application=$(\
+    az ad app list \
+      --display-name ${function} \
+      --query "[0].appId" \
+      --output tsv)
+
+  # Get application role ID from application object
+  role_id=$(\
+    az ad app show \
+      --id ${application} \
+      --query "appRoles[?value == '${role}'].id" \
+      --output tsv)
+
+  # Get application object's service principal
+  service_principal=$(\
+    az ad sp list \
+      --display-name ${function} \
+      --filter "appId eq '${application}'" \
+      --query [0].objectId \
+      --output tsv)
+
+  # Get user's Azure AD object ID
+  user=$(\
+    az ad signed-in-user show \
+      --query objectId \
+      --output tsv)
+
+  json="\
+  {
+    \"principalId\": \"${user}\",
+    \"resourceId\": \"${service_principal}\",
+    \"appRoleId\": \"${role_id}\"
+  }"
+
+  # Assign application role
+  az rest \
+    --method POST \
+    --uri "https://graph.microsoft.com/v1.0/users/${user}/appRoleAssignments" \
+    --headers 'Content-Type=application/json' \
+    --body "$json"
+}
+
+main "$@"


### PR DESCRIPTION
Establishes the approach for #425. Specifically:
- Adds CLI-based token provider
- Adds helper script for assigning app roles
- Updates orchestrator to use appropriate token provider for the current configuration
- Documents local development for orchestrator
- Updates IaC to allow app role assignment to users

All of the above has been done in the context of `Piipan.Match.Orchestrator`, but I'm thinking this same approach applies to any Azure resource acting as a client of one of our internal APIs.

Follow-up work:
- Add a helper script for adding the Azure CLI as an authorized client application to an existing application object (requires more research)