### PR TITLE
Move resource group creation to separate script

### DIFF
--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -2,7 +2,7 @@
 #
 # Provisions and configures the infrastructure components for all Piipan Metrics subsystems.
 # Assumes an Azure user with the Global Administrator role has signed in with the Azure CLI.
-# Assumes Piipan base resources have been created in the same environment
+# Assumes Piipan base resource groups, resources have been created in the same environment
 # (for example, state-specific blob topics).
 # Must be run from a trusted network.
 #
@@ -36,11 +36,6 @@ main () {
   source $(dirname "$0")/env/${azure_env}.bash
 
   set_constants
-
-  # Create Metrics resource group
-  # Eventually resource group will already be created for us by partner
-  echo "Creating $METRICS_RESOURCE_GROUP group"
-  az group create --name $METRICS_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
 
   # Create new Key Vault for this resource group
   echo "Creating Key Vault"

--- a/iac/create-resource-groups.bash
+++ b/iac/create-resource-groups.bash
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Creates Piipan resource groups. Assumes an Azure user with at least
+# the Contributor role has signed in with the Azure CLI.
+#
+# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# See iac/env for available environments.
+#
+# usage: create-resource-groups.bash <azure-env>
+
+source $(dirname "$0")/../tools/common.bash || exit
+source $(dirname "$0")/iac-common.bash || exit
+
+main () {
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source $(dirname "$0")/env/${azure_env}.bash
+
+  # Any changes to the set of resource groups below should also
+  # be made to create-service-principal.bash
+  echo "Creating $RESOURCE_GROUP group"
+  az group create --name $RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+  echo "Creating match APIs resource group"
+  az group create --name $MATCH_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+  # Create Metrics resource group
+  echo "Creating $METRICS_RESOURCE_GROUP group"
+  az group create --name $METRICS_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+
+  script_completed
+}
+
+main "$@"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -263,10 +263,7 @@ main () {
 
   # Any changes to the set of resource groups below should also
   # be made to create-service-principal.bash
-  echo "Creating $RESOURCE_GROUP group"
-  az group create --name $RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
-  echo "Creating match APIs resource group"
-  az group create --name $MATCH_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+  ./create-resource-groups.bash $azure_env
 
   # Create a service principal for use by CI/CD pipeline.
   ./create-service-principal.bash $azure_env $SP_NAME_CICD none


### PR DESCRIPTION
This will be more important in environments where we do not have permission to create the resource groups ourselves.