### PR TITLE
Update to most recent CsvHelper version

### DIFF
--- a/etl/src/Piipan.Etl/BulkUpload.cs
+++ b/etl/src/Piipan.Etl/BulkUpload.cs
@@ -67,11 +67,13 @@ namespace Piipan.Etl
         internal static IEnumerable<PiiRecord> Read(Stream input, ILogger log)
         {
             var reader = new StreamReader(input);
-            var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
-
-            csv.Configuration.HasHeaderRecord = true;
-            csv.Configuration.TrimOptions = TrimOptions.Trim;
-            csv.Configuration.RegisterClassMap<PiiRecordMap>();
+            var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+            {
+                HasHeaderRecord = true,
+                TrimOptions = TrimOptions.Trim,
+            };
+            var csv = new CsvReader(reader, config);
+            csv.Context.RegisterClassMap<PiiRecordMap>();
 
             // Yields records as it is iterated over
             return csv.GetRecords<PiiRecord>();

--- a/etl/src/Piipan.Etl/PiiRecordMap.cs
+++ b/etl/src/Piipan.Etl/PiiRecordMap.cs
@@ -13,7 +13,7 @@ namespace Piipan.Etl
         {
             Map(m => m.Last).Name("last").Validate(field =>
             {
-                return !string.IsNullOrEmpty(field);
+                return !string.IsNullOrEmpty(field.Field);
             });
 
             Map(m => m.First).Name("first")
@@ -26,7 +26,7 @@ namespace Piipan.Etl
 
             Map(m => m.Ssn).Name("ssn").Validate(field =>
             {
-                Match match = Regex.Match(field, "^[0-9]{3}-[0-9]{2}-[0-9]{4}$");
+                Match match = Regex.Match(field.Field, "^[0-9]{3}-[0-9]{2}-[0-9]{4}$");
                 return match.Success;
             });
 

--- a/etl/src/Piipan.Etl/Piipan.Etl.csproj
+++ b/etl/src/Piipan.Etl/Piipan.Etl.csproj
@@ -6,7 +6,7 @@
     <RestoreLockedMode Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreLockedMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="19.0.0" />
+    <PackageReference Include="CsvHelper" Version="26.0.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />

--- a/etl/src/Piipan.Etl/packages.lock.json
+++ b/etl/src/Piipan.Etl/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "CsvHelper": {
         "type": "Direct",
-        "requested": "[19.0.0, )",
-        "resolved": "19.0.0",
-        "contentHash": "vUHF8wPOVvdtUQ4sXQI62jEIGcz5p7MG3Qf4Hazg+3EZQFh+UoTASEG0a1tsGmhNsHZ/Y+qRO+SgLMZO8jNcSg==",
+        "requested": "[26.0.1, )",
+        "resolved": "26.0.1",
+        "contentHash": "8osOmXbxzY8S1w21t5ilmWPIlo0DrfYNUklJvLiBWcb33Sm6v5jATN0DmCsBS5KVLYdwX+vnx+FIGoGF+rJwkw==",
         "dependencies": {
           "Microsoft.CSharp": "4.5.0"
         }

--- a/etl/tests/Piipan.Etl.Tests/Piipan.Etl.Tests.csproj
+++ b/etl/tests/Piipan.Etl.Tests/Piipan.Etl.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="csvhelper" Version="26.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Npgsql" Version="5.0.3" />

--- a/etl/tests/Piipan.Etl.Tests/packages.lock.json
+++ b/etl/tests/Piipan.Etl.Tests/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "3.0.3",
         "contentHash": "PdyhdzG2LK7YUEtccObPql+3OuFODaFNeYayxdPoK1eHb2StZoeQf1WMb16QrKiIdi4fs5Kog8jxXtlZOgAEuA=="
       },
+      "CsvHelper": {
+        "type": "Direct",
+        "requested": "[26.0.1, )",
+        "resolved": "26.0.1",
+        "contentHash": "8osOmXbxzY8S1w21t5ilmWPIlo0DrfYNUklJvLiBWcb33Sm6v5jATN0DmCsBS5KVLYdwX+vnx+FIGoGF+rJwkw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.5.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[16.9.1, )",
@@ -69,14 +78,6 @@
           "System.Reflection.Emit": "4.3.0",
           "System.Reflection.TypeExtensions": "4.3.0",
           "System.Xml.XmlDocument": "4.3.0"
-        }
-      },
-      "CsvHelper": {
-        "type": "Transitive",
-        "resolved": "19.0.0",
-        "contentHash": "vUHF8wPOVvdtUQ4sXQI62jEIGcz5p7MG3Qf4Hazg+3EZQFh+UoTASEG0a1tsGmhNsHZ/Y+qRO+SgLMZO8jNcSg==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.5.0"
         }
       },
       "Microsoft.AspNet.WebApi.Client": {
@@ -2149,7 +2150,7 @@
       "piipan.etl": {
         "type": "Project",
         "dependencies": {
-          "CsvHelper": "19.0.0",
+          "CsvHelper": "26.0.1",
           "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "2.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "4.0.4",


### PR DESCRIPTION
As noted in #230, `CsvHelper` has undergone quite a bit of churn recently. This PR just updates the library to the most recent version and fixes a handful of issues created by the many breaking changes.