### PR TITLE
Wait a bit before publishing func to new func app

### DIFF
--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -129,7 +129,7 @@ EOF
   # https://github.com/Azure/azure-functions-core-tools/issues/1616
   # https://github.com/Azure/azure-functions-core-tools/issues/1766
   echo "Waiting to publish function app"
-  sleep 60s
+  sleep 60
 
   echo "configure settings"
   az functionapp config appsettings set \
@@ -225,8 +225,8 @@ EOF
       --secret-permissions get list
   fi
 
-  echo "waiting to publish function app"
-  sleep 60s
+  echo "Waiting to publish function app"
+  sleep 60
 
   # publish metrics function app
   echo "Publishing function app $API_APP_NAME"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -559,6 +559,9 @@ main () {
     # Store function names for future auth configuration
     match_func_names+=("$func_name")
 
+    echo "Waiting to publish function app"
+    sleep 60
+
     echo "Publishing ${name} function app"
     pushd ../match/src/Piipan.Match.State
     func azure functionapp publish $func_name --dotnet
@@ -595,6 +598,10 @@ main () {
       --resource-group $MATCH_RESOURCE_GROUP \
       --query principalId \
       --output tsv)
+
+
+  echo "Waiting to publish function app"
+  sleep 60
 
   echo "Publishing ${orch_name} function app"
   pushd ../match/src/Piipan.Match.Orchestrator


### PR DESCRIPTION
Waiting 60 seconds before publishing a Function to a new Function App has worked well so far, as Azure will report a Function App has been deployed when it actually hasn't fully deployed.

macOS sleep does not support units, so drop the "s" in "60s" on existing sleep uses.