### PR TITLE
Align resource groups with new naming standard

### DIFF
--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -2,13 +2,13 @@
 LOCATION=westus
 
 # Default resource group
-RESOURCE_GROUP=piipan-resources
+RESOURCE_GROUP=rg-core-dev
 
 # Resource group for matching API
-MATCH_RESOURCE_GROUP=piipan-match
+MATCH_RESOURCE_GROUP=rg-match-dev
 
 # Resource group for metrics
-METRICS_RESOURCE_GROUP=piipan-metrics
+METRICS_RESOURCE_GROUP=rg-metrics-dev
 
 # Prefix for resource identifiers
 PREFIX=fns


### PR DESCRIPTION
Add `rg-` prefix, drop `piipan` since everything is Piipan, add `-dev` to reflect development deployment. See not-quite-finalized naming standard in PR #451.

Renaming this now since I'm rebuilding everything this evening due to a problem related to [changes in Azure](https://docs.microsoft.com/en-us/azure/app-service/overview#limitations) and making our Azure Government and Azure Commercial spaces consistent:
"However, all resource groups created on or after January 21, 2021 do support [mixing Windows and Linux apps in the same resource group]"
