### PR TITLE
Use cloud-specific resource id w/managed identity

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -52,6 +52,7 @@ The following environment variables are pre-configured by the Infrastructure-as-
 | `StateAbbr` | Abbreviation of the state associated with the Function App instance. | Piipan.Match.State |
 | `MetricsApiUri` | URI for the Metrics API endpoint. | Piipan.Dashboard |
 | `KeyVaultName` | Name of key vault resource needed to acquire a secret | Piipan.Metrics.Api, Piipan.Metrics.Collect |
+| `CloudName` | Name of the active Azure cloud environment, either `AzureCloud` or `AzureUSGovernment` | Piipan.Etl |
 ## Notes
 - `iac/states.csv` contains the comma-delimited records of participating states/territories. The first field is the [two-letter postal abbreviation](https://pe.usps.com/text/pub28/28apb.htm); the second field is the name of the state/territory.
 - For development, dummy state/territories are used (e.g., the state of `Echo Alpha`, with an abbreviation of `EA`).

--- a/etl/docs/etl.md
+++ b/etl/docs/etl.md
@@ -23,6 +23,7 @@ The following environment variables are required by `BulkUpload` and are set by 
 |---|---|
 | `DatabaseConnectionString` | [details](../../docs/iac.md#\:\~\:text=DatabaseConnectionString) |
 | `BlobStorageConnectionString` | [details](../../docs/iac.md#\:\~\:text=BlobStorageConnectionString) |
+| `CloudName` | [details](../../docs/iac.md#\:\~\:text=CloudName) |
 
 ## Local development
 

--- a/etl/src/Piipan.Etl/BulkUpload.cs
+++ b/etl/src/Piipan.Etl/BulkUpload.cs
@@ -81,15 +81,24 @@ namespace Piipan.Etl
 
         internal async static Task<string> ConnectionString()
         {
-            // Environment variable (and placeholder) established
+            // Environment variables (and placeholder) established
             // during initial function app provisioning in IaC
+            const string CloudName = "CloudName";
             const string DatabaseConnectionString = "DatabaseConnectionString";
             const string PasswordPlaceholder = "{password}";
+            const string GovernmentCloud = "AzureUSGovernment";
 
-            // Resource Id for open source software databases in the public Azure cloud;
-            // in other clouds, see result of:
+            // Resource ids for open source software databases in the public and
+            // US government clouds. Set the desired active cloud, then see:
             // `az cloud show --query endpoints.ossrdbmsResourceId`
-            const string ResourceId = "https://ossrdbms-aad.database.windows.net";
+            const string CommercialId = "https://ossrdbms-aad.database.windows.net";
+            const string GovermentId = "https://ossrdbms-aad.database.usgovcloudapi.net";
+
+            var resourceId = CommercialId;
+            var cn = Environment.GetEnvironmentVariable(CloudName);
+            if (cn == GovernmentCloud) {
+                resourceId = GovermentId;
+            }
 
             var builder = new NpgsqlConnectionStringBuilder(
                 Environment.GetEnvironmentVariable(DatabaseConnectionString));
@@ -97,7 +106,7 @@ namespace Piipan.Etl
             if (builder.Password == PasswordPlaceholder)
             {
                 var provider = new AzureServiceTokenProvider();
-                var token = await provider.GetAccessTokenAsync(ResourceId);
+                var token = await provider.GetAccessTokenAsync(resourceId);
                 builder.Password = token;
             }
 

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -483,6 +483,7 @@ main () {
         $DB_CONN_STR_KEY="$db_conn_str" \
         $AZ_SERV_STR_KEY="$az_serv_str" \
         $BLOB_CONN_STR_KEY="$blob_conn_str" \
+        $CLOUD_NAME_STR_KEY="$CLOUD_NAME" \
       --output none
 
     az eventgrid system-topic create \

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -24,6 +24,10 @@ BLOB_CONN_STR_KEY=BlobStorageConnectionString
 # to app or function code (required to fetch managed identity tokens)
 AZ_SERV_STR_KEY=AzureServicesAuthConnectionString
 
+# Name of the environment variable used to indicate the active Azure cloud
+# so that application code can use the appropriate, cloud-specific domain
+CLOUD_NAME_STR_KEY=CloudName
+
 # For connection strings, our established placeholder value
 PASSWORD_PLACEHOLDER='{password}'
 ### END Constants


### PR DESCRIPTION
Commercial and Government Azure use different ossrdbms-aad resource ids; this id needs to be specified when accessing PostgreSQL via a managed identity. Bind the cloud name during infrastructure setup as an environment variable, then use that to choose the right id for the active cloud in the ETL function.