### PR TITLE
Don't use double quotes around orch api URI

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -619,7 +619,8 @@ main () {
       -g $MATCH_RESOURCE_GROUP \
       -n $orch_name \
       --function-name Query \
-      --query invokeUrlTemplate)
+      --query invokeUrlTemplate \
+      -o tsv)
 
   query_tool_name=$(\
     az deployment group create \


### PR DESCRIPTION
Resolves "Invalid URI: The URI scheme is not valid." error in query tool when it attempts to call out to the orchestrator API endpoint.