### PR TITLE
Extend ETL dev tools to consult azure env config

### DIFF
--- a/etl/docs/etl.md
+++ b/etl/docs/etl.md
@@ -43,13 +43,15 @@ func azure functionapp publish <function-app-name> --dotnet
 ## Ad-hoc testing
 
 In a development environment, the `upload.bash` tool can be used to upload test CSV files to a storage account.
+
+For example, if you are targeting the `tts/dev` environment and the `eastate5or4l3nqzevf4` storage account:
 ```
-./etl/tools/upload.bash docs/csv/example.csv storage-account-name
+./tools/upload.bash tts/dev ./docs/csv/example.csv eastate5or4l3nqzevf4
 ```
 
-`upload.bash` uses the credentials of the signed in Azure administrator to access the storage accounts. Privileges to perform that operation have to be explicitly granted:
+`upload.bash` uses the credentials of the signed in Azure administrator to access the storage accounts. Privileges to perform that operation have to be explicitly granted on each storage account:
 ```
-./etl/tools/grant-blob.bash storage-account-name
+./tools/grant-blob.bash tts/dev eastate5or4l3nqzevf4
 ``` 
 
 While `grant-blob.bash` may return within a few seconds, it take can up to several minutes for Azure to replicate the privileges across its internal infrastructure; e.g., if `upload.bash` fails right after `grant-blob.bash` has been run, try it again in a couple of minutes.

--- a/etl/tools/grant-blob.bash
+++ b/etl/tools/grant-blob.bash
@@ -4,18 +4,21 @@
 # storage account. Used in conjunction with upload.bash for ad-hoc testing.
 # Only intended for development environments.
 #
-# usage: grant-blob.bash account-name
+# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# See iac/env for available environments.
+#
+# usage: grant-blob.bash <azure-env> <storage-account>
 
-set -e
-set -u
+source $(dirname "$0")/../../tools/common.bash || exit
+source $(dirname "$0")/../../iac/iac-common.bash || exit
 
 main () {
-  storage_account=$1
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source $(dirname "$0")/../../iac/env/${azure_env}.bash
+  verify_cloud
 
-  # XXX Constants duplicated from iac/create-resources.bash
-
-  # Default resource group for our system
-  RESOURCE_GROUP=piipan-resources
+  storage_account=$2
 
   # The default Azure subscription
   SUBSCRIPTION_ID=`az account show --query id -o tsv`

--- a/etl/tools/upload.bash
+++ b/etl/tools/upload.bash
@@ -5,14 +5,22 @@
 # database. Requires that the user has write privileges on the account; use
 # grant-blob.bash to establish those privs.
 #
-# usage: upload.bash path-to-file account-name
+# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# See iac/env for available environments.
+#
+# usage: upload.bash <azure-env> <path-to-file> <storage-account>
 
-set -e
-set -u
+source $(dirname "$0")/../../tools/common.bash || exit
+source $(dirname "$0")/../../iac/iac-common.bash || exit
 
 main () {
-  file_path=$1
-  storage_account=$2
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source $(dirname "$0")/../../iac/env/${azure_env}.bash
+  verify_cloud
+
+  file_path=$2
+  storage_account=$3
 
   az storage blob upload \
     --account-name $storage_account \


### PR DESCRIPTION
By requiring the target azure environment on the CLI, we defensively protect ourselves from running against the wrong account and avoid hard-coding the resource group in the case of grant-blob.