### PR TITLE
Unconditionally assign identity, set kv policy in metrics IaC

### DIFF
--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -138,24 +138,17 @@ EOF
       $VAULT_NAME_KEY="$VAULT_NAME" \
     --output none
 
-  # Assumes if any identity is set, it is the one we are specifying below
-  exists=`az functionapp identity show \
+  # Connect creds from function app to key vault so app can connect to db
+  principalId=`az functionapp identity assign \
     --resource-group $METRICS_RESOURCE_GROUP \
-    --name $COLLECT_APP_NAME`
+    --name $COLLECT_APP_NAME \
+    --query principalId \
+    --output tsv`
 
-  if [ -z "$exists" ]; then
-    # Connect creds from function app to key vault so app can connect to db
-    principalId=`az functionapp identity assign \
-      --resource-group $METRICS_RESOURCE_GROUP \
-      --name $COLLECT_APP_NAME \
-      --query principalId \
-      --output tsv`
-
-    az keyvault set-policy \
-      --name $VAULT_NAME \
-      --object-id $principalId \
-      --secret-permissions get list
-  fi
+  az keyvault set-policy \
+    --name $VAULT_NAME \
+    --object-id $principalId \
+    --secret-permissions get list
 
   # publish the function app
   echo "Publishing function app $COLLECT_APP_NAME"
@@ -215,24 +208,17 @@ EOF
         $VAULT_NAME_KEY="$VAULT_NAME" \
       --output none
 
-  # Assumes if any identity is set, it is the one we are specifying below
-  exists=`az functionapp identity show \
+  # Connect creds from function app to key vault so app can connect to db
+  principalId=`az functionapp identity assign \
     --resource-group $METRICS_RESOURCE_GROUP \
-    --name $API_APP_NAME`
+    --name $API_APP_NAME \
+    --query principalId \
+    --output tsv`
 
-  if [ -z "$exists" ]; then
-    # Connect creds from function app to key vault so app can connect to db
-    principalId=`az functionapp identity assign \
-      --resource-group $METRICS_RESOURCE_GROUP \
-      --name $API_APP_NAME \
-      --query principalId \
-      --output tsv`
-
-    az keyvault set-policy \
-      --name $VAULT_NAME \
-      --object-id $principalId \
-      --secret-permissions get list
-  fi
+  az keyvault set-policy \
+    --name $VAULT_NAME \
+    --object-id $principalId \
+    --secret-permissions get list
 
   echo "Waiting to publish function app"
   sleep 60


### PR DESCRIPTION
Remove the conditional block around assigning identity and Key Vault policy for both Function Apps. The conditional block is only required to workaround an Azure issue setting managed identity multiple times (see create-resources.bash).

This fixes an access control issue where a metrics Function App would be deployed but could not access its database secret; i.e., when there was a partial IaC run with an error, followed by a 2nd complete run.