### PR TITLE
Fix for creating Azure Front Door instances

### DIFF
--- a/iac/add-front-door-to-app.bash
+++ b/iac/add-front-door-to-app.bash
@@ -28,13 +28,14 @@ main () {
 
   echo "WAF name: ${waf_full_name}"
 
+  suffix=$(front_door_host_suffix)
   az deployment group create \
     --name $front_door_full_name \
     --resource-group $resource_group \
     --template-file ./arm-templates/front-door-app-service.json \
     --parameters \
       appAddress=$app_address \
-      frontDoorHostName="${front_door_full_name}${front_door_host_suffix}" \
+      frontDoorHostName=${front_door_full_name}${suffix} \
       frontDoorName=$front_door_full_name \
       resourceGroupName=$resource_group \
       resourceTags="$RESOURCE_TAGS" \

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -258,7 +258,8 @@ EOF
         metricsApiUri=$metrics_api_uri)
 
   echo "Create Front Door and WAF policy for dashboard app"
-  dashboard_host="${dashboard_host_prefix}${web_app_host_suffix}"
+  suffix=$(web_app_host_suffix)
+  dashboard_host=${dashboard_host_prefix}${suffix}
   ./add-front-door-to-app.bash \
     $azure_env \
     $RESOURCE_GROUP \

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -634,7 +634,8 @@ main () {
         OrchApiUri=$orch_api_uri)
 
   echo "Create Front Door and WAF policy for query tool app"
-  query_tool_host="${query_tool_name}${web_app_host_suffix}"
+  suffix=$(web_app_host_suffix)
+  query_tool_host=${query_tool_name}${suffix}
   ./add-front-door-to-app.bash \
     $azure_env \
     $RESOURCE_GROUP \

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -78,19 +78,17 @@ verify_cloud () {
 # hard-coded switches between commerical and government Azure environments
 web_app_host_suffix () {
   if [ "$CLOUD_NAME" = "AzureUSGovernment" ]; then
-    return ".azurewebsites.us"
+    echo ".azurewebsites.us"
   else
-    return ".azurewebsites.net"
+    echo ".azurewebsites.net"
   fi
 }
 
 front_door_host_suffix () {
   if [ "$CLOUD_NAME" = "AzureUSGovernment" ]; then
-    # can't find this in the list of azure gov domains so I'm guessing here
-    # https://docs.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure
-    return ".azurefd.us"
+    echo ".azurefd.us"
   else
-    return ".azurefd.net"
+    echo ".azurefd.net"
   fi
 }
 ### END Functions


### PR DESCRIPTION
A few minor tweaks needed to create Front Door instances:
- resolves "web_app_host_suffix: unbound variable" error
- confirms azurefd.us is Azure Government Front Door domain
- echos the return suffix instead of returning; bash functions can only return integers in [0-255] range