### PR TITLE
Fixes UnrecognizedArgumentError error in metrics IaC

### DIFF
--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -248,7 +248,7 @@ EOF
       --name $DASHBOARD_APP_NAME \
       --resource-group $RESOURCE_GROUP \
       --template-file ./arm-templates/dashboard-app.json \
-      --query properties.outputs.appName.value \ # LEFT OFF HERE
+      --query properties.outputs.appName.value \
       --output tsv \
       --parameters \
         location=$LOCATION \


### PR DESCRIPTION
Fixes error where the comment inadvertently became part of the command since the command was split across multiple lines via the backslash:
```
UnrecognizedArgumentError: unrecognized arguments:  # LEFT OFF HERE
```