### PR TITLE
Don't let local silently absorb non-zero exit code

### DIFF
--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -66,13 +66,13 @@ pg_connection_string () {
 
 # Verify that the expected Azure environment is the active cloud
 verify_cloud () {
-  local cn=$(az cloud show --query name -o tsv)
+  local cn
+  cn=$(az cloud show --query name -o tsv)
 
   if [ "$CLOUD_NAME" != "$cn" ]; then
-    echo "error: '$cn' is the active cloud, expecting '$CLOUD_NAME'"
+    echo "error: '$cn' is the active cloud, expecting '$CLOUD_NAME'" 1>&2
     return 1
   fi
-  return 0
 }
 
 # hard-coded switches between commerical and government Azure environments


### PR DESCRIPTION
Per bash docs, `local myvar=$(subcommand)` will always return 0 so don't use it inline with subcommands. Also: explicitly send error messages to `stderr`.