### PR TITLE
Create APIM stub for public API

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -27,10 +27,14 @@ To (re)create the Azure resources that `piipan` uses:
     cd iac
     ./create-resources.bash tts/dev
 ```
+6. Run `create-apim`, which deploys ARM template and runs associated CLI commands to create an Azure API Management (APIM) instance, specifying the [name of the deployment environment](#deployment-environments) and an administrator email (a required property which can be subsequently changed). If the APIM instance does not already exist this script can take ~45 minutes to complete.
+```
+    ./create-apim.bash tts/dev your-email
+```
 
 ## Deployment environments
 
-Configuration for each enviroment is in `iac/env` in a corresponding, `source`-able bash script.
+Configuration for each environment is in `iac/env` in a corresponding, `source`-able bash script.
 
 | Name | Description |
 |---|---|
@@ -65,6 +69,7 @@ The following environment variables are pre-configured by the Infrastructure-as-
 | OrchestratorApi | the single Function App for the Orchestrator API |
 | DashboardApp | the single Dashboard App Service |
 | QueryApp | the single Query tool App Service |
+| NacApi | the single API Management instance for the external-facing NAC API |
 
 In the Azure Portal, tags can be added to resource lists using the "Manage view" and/or "Edit columns" menu item that appears at the top left of the view. Specific tag values can also be filtered via "Add filter".
 

--- a/docs/iac.md
+++ b/docs/iac.md
@@ -69,7 +69,7 @@ The following environment variables are pre-configured by the Infrastructure-as-
 | OrchestratorApi | the single Function App for the Orchestrator API |
 | DashboardApp | the single Dashboard App Service |
 | QueryApp | the single Query tool App Service |
-| NacApi | the single API Management instance for the external-facing NAC API |
+| PublicApi | the single API Management instance for the external-facing matching API |
 
 In the Azure Portal, tags can be added to resource lists using the "Manage view" and/or "Edit columns" menu item that appears at the top left of the view. Specific tag values can also be filtered via "Add filter".
 

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "apiName": {
+            "type": "String"
+        },
+        "resourceTags": {
+            "type": "object"
+        },
+        "location": {
+            "type": "String"
+        },
+        "publisherEmail": {
+            "type": "String"
+        },
+        "publisherName": {
+            "type": "String"
+        },
+        "functionAppName": {
+            "type": "String"
+        }
+    },
+    "variables": {
+        "uniqueApiName": "[concat(toLower(parameters('apiName')), '-', uniqueString(resourceGroup().id))]",
+        "systemTypeTag": {
+            "SysType": "NacApi"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.ApiManagement/service",
+            "apiVersion": "2020-06-01-preview",
+            "name": "[variables('uniqueApiName')]",
+            "location": "[parameters('location')]",
+            "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
+            "sku": {
+                "name": "Developer",
+                "capacity": 1
+            },
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "publisherEmail": "[parameters('publisherEmail')]",
+                "publisherName": "[parameters('publisherName')]",
+                "hostnameConfigurations": [
+                    {
+                        "type": "Proxy",
+                        "hostName": "[concat(variables('uniqueApiName'), '.azure-api.net')]",
+                        "defaultSslBinding": true
+                    }
+                ],
+                /* Explicity asserting security settings rather than relying on defaults. */
+                "customProperties": {
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168": "false",
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11": "false",
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "false",
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30": "false",
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11": "false",
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10": "false",
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30": "false",
+                    "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2": "false"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis",
+            "apiVersion": "2020-06-01-preview",
+            "name": "[concat(variables('uniqueApiName'), '/', parameters('functionAppName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service', variables('uniqueApiName'))]"
+            ],
+            "properties": {
+                "displayName": "Orchestrator API",
+                "subscriptionRequired": true,
+                "protocols": [
+                    "https"
+                ],
+                "path": "/api"
+            }
+        }
+    ],
+    "outputs": {
+        "apimName": {
+            "type": "string",
+            "value": "[variables('uniqueApiName')]"
+        }
+    }
+}

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -22,16 +22,16 @@
         }
     },
     "variables": {
-        "uniqueApiName": "[concat(toLower(parameters('apiName')), '-', uniqueString(resourceGroup().id))]",
         "systemTypeTag": {
-            "SysType": "NacApi"
-        }
+            "SysType": "PublicApi"
+        },
+        "displayName": "Public API"
     },
     "resources": [
         {
             "type": "Microsoft.ApiManagement/service",
             "apiVersion": "2020-06-01-preview",
-            "name": "[variables('uniqueApiName')]",
+            "name": "[parameters('apiName')]",
             "location": "[parameters('location')]",
             "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
             "sku": {
@@ -47,7 +47,7 @@
                 "hostnameConfigurations": [
                     {
                         "type": "Proxy",
-                        "hostName": "[concat(variables('uniqueApiName'), '.azure-api.net')]",
+                        "hostName": "[concat(parameters('apiName'), '.azure-api.net')]",
                         "defaultSslBinding": true
                     }
                 ],
@@ -67,12 +67,12 @@
         {
             "type": "Microsoft.ApiManagement/service/apis",
             "apiVersion": "2020-06-01-preview",
-            "name": "[concat(variables('uniqueApiName'), '/', parameters('functionAppName'))]",
+            "name": "[concat(parameters('apiName'), '/', parameters('functionAppName'))]",
             "dependsOn": [
-                "[resourceId('Microsoft.ApiManagement/service', variables('uniqueApiName'))]"
+                "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]"
             ],
             "properties": {
-                "displayName": "Orchestrator API",
+                "displayName": "[variables('displayName')]",
                 "subscriptionRequired": true,
                 "protocols": [
                     "https"
@@ -84,7 +84,7 @@
     "outputs": {
         "apimName": {
             "type": "string",
-            "value": "[variables('uniqueApiName')]"
+            "value": "[parameters('apiName')]"
         }
     }
 }

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
-# Creates the API Management instance for managing the NAC API. Assumes
-# an Azure user with the Global Administrator role has signed in with
-# the Azure CLI. See install-extensions.bash for prerequisite Azure CLI
-# extensions. Deployment can take ~45 minutes for new instances.
+# Creates the API Management instance for managing the public-facing
+# match API. Assumes an Azure user with the Global Administrator role
+# has signed in with the Azure CLI. See install-extensions.bash for
+# prerequisite Azure CLI extensions. Deployment can take ~45 minutes
+# for new instances.
 #
 # azure-env is the name of the deployment environment (e.g., "tts/dev").
 # See iac/env for available environments.
@@ -52,8 +53,8 @@ main () {
   source $(dirname "$0")/env/${azure_env}.bash
   verify_cloud
 
-  APIM_NAME='nac-api'
-  PUBLISHER_NAME='NAC Administrator'
+  APIM_NAME=apim-publicapi-${ENV}
+  PUBLISHER_NAME='API Administrator'
   publisher_email=$2
   orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
 

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Creates the API Management instance for managing the NAC API. Assumes
+# an Azure user with the Global Administrator role has signed in with
+# the Azure CLI. See install-extensions.bash for prerequisite Azure CLI
+# extensions. Deployment can take ~45 minutes for new instances.
+#
+# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# See iac/env for available environments.
+#
+# admin-email is the email address to use for the required "publisher
+# email" property. A notification will be sent to the email when the
+# instance has been created.
+#
+# usage: create-apim.bash <azure-env> <admin-email>
+
+source $(dirname "$0")/../tools/common.bash || exit
+source $(dirname "$0")/iac-common.bash || exit
+
+clean_defaults () {
+  group=$1
+  apim=$2
+  
+  # Delete "echo API" example API
+  az apim api delete \
+    --api-id echo-api \
+    -g ${group} \
+    -n ${apim_name} \
+    -y
+  
+  # Delete default "Starter" and "Unlimited" products and their associated
+  # product subscriptions
+  az apim product delete \
+    --product-id starter \
+    --delete-subscriptions true \
+    -g ${group} \
+    -n ${apim_name} \
+    -y
+  
+  az apim product delete \
+    --product-id unlimited \
+    --delete-subscriptions true \
+    -g ${group} \
+    -n ${apim_name} \
+    -y
+}
+
+main () {
+
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source $(dirname "$0")/env/${azure_env}.bash
+  verify_cloud
+
+  APIM_NAME='nac-api'
+  PUBLISHER_NAME='NAC Administrator'
+  publisher_email=$2
+  #orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
+  orch_name='ofunchaaz7alkqwuvo'
+
+  apim_name=$(\
+    az deployment group create \
+      --name apim-dev \
+      --resource-group $MATCH_RESOURCE_GROUP \
+      --template-file ./arm-templates/apim.json \
+      --query properties.outputs.apimName.value \
+      --output tsv \
+      --parameters \
+        apiName=$APIM_NAME \
+        publisherEmail=$publisher_email \
+        publisherName="$PUBLISHER_NAME" \
+        location=$LOCATION \
+        functionAppName=$orch_name \
+        resourceTags="$RESOURCE_TAGS")
+
+  # Clear out default example resources
+  # See: https://stackoverflow.com/a/64297708
+  clean_defaults $MATCH_RESOURCE_GROUP $apim_name
+}
+
+main "$@"

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -55,8 +55,7 @@ main () {
   APIM_NAME='nac-api'
   PUBLISHER_NAME='NAC Administrator'
   publisher_email=$2
-  #orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
-  orch_name='ofunchaaz7alkqwuvo'
+  orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
 
   apim_name=$(\
     az deployment group create \

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -8,6 +8,7 @@ PER_STATE_MATCH_API_TAG="SysType=PerStateMatchApi"
 ORCHESTRATOR_API_TAG="SysType=OrchestratorApi"
 DASHBOARD_APP_TAG="SysType=DashboardApp"
 QUERY_APP_TAG="SysType=QueryApp"
+NAC_API_TAG="SysType=NacApi"
 
 # Identity object ID for the Azure environment account
 CURRENT_USER_OBJID=`az ad signed-in-user show --query objectId --output tsv`

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -8,7 +8,7 @@ PER_STATE_MATCH_API_TAG="SysType=PerStateMatchApi"
 ORCHESTRATOR_API_TAG="SysType=OrchestratorApi"
 DASHBOARD_APP_TAG="SysType=DashboardApp"
 QUERY_APP_TAG="SysType=QueryApp"
-NAC_API_TAG="SysType=NacApi"
+PUBLIC_API_TAG="SysType=PublicApi"
 
 # Identity object ID for the Azure environment account
 CURRENT_USER_OBJID=`az ad signed-in-user show --query objectId --output tsv`


### PR DESCRIPTION
First step in creating the API Management (APIM) instance to sit in front of the orchestrator API. Specifically:
- Creates APIM instance from ARM template
- Cleans unused default resources created in the process

This does not create a function API or any publicly accessible resources (other than a "portal" error page at `https://<apim-name>.developer.azure-api.net/`) that seems to be unavoidable at this juncture). This a first step in a series of self-contained PRs for this issue.

I'd especially appreciate feedback on:
- Creating a new APIM instance can take upwards of ~45-50 minutes. Consequently, I've created a `create-apim` script that is intended to be run separately from `create-resources` so developers aren't subjected to that delay on every IaC build.
- APIM instances require a "published email" property. I've externalized this as an argument passed to `create-apim` so as not to include any email addresses in the repo. An alternative would be to use a junk email.
- The name of the APIM instance becomes part of the public-facing URL. Since APIM names are globally unique, I'm appending a standard unique string to the end of the name. The result is a URL like `https://<apim-name>-<unique-string>.azure-api.net/`. Calling this out since (1) the URL is now dependent on the resource group name and (2) we'll need this URL to be stable if/when first round states use the sandbox for testing.