### PR TITLE
Adapt Easy Auth IaC for Azure Government

### DIFF
--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -120,4 +120,12 @@ front_door_host_suffix () {
     echo ".azurefd.net"
   fi
 }
+
+graph_host_suffix () {
+  if [ "$CLOUD_NAME" = "AzureUSGovernment" ]; then
+    echo ".microsoft.us"
+  else
+    echo ".microsoft.com"
+  fi
+}
 ### END Functions


### PR DESCRIPTION
- Use AzureUSGovernment-specific graph API URL
- Add pauses between resource creation and use in a few more places
- Generalize to reduce code duplication

Partially addresses #101 