### PR TITLE
Adapt metrics subsystem for AzureUSGovernment

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -56,7 +56,7 @@ The following environment variables are pre-configured by the Infrastructure-as-
 | `StateAbbr` | Abbreviation of the state associated with the Function App instance. | Piipan.Match.State |
 | `MetricsApiUri` | URI for the Metrics API endpoint. | Piipan.Dashboard |
 | `KeyVaultName` | Name of key vault resource needed to acquire a secret | Piipan.Metrics.Api, Piipan.Metrics.Collect |
-| `CloudName` | Name of the active Azure cloud environment, either `AzureCloud` or `AzureUSGovernment` | Piipan.Etl, Piipan.Match.State |
+| `CloudName` | Name of the active Azure cloud environment, either `AzureCloud` or `AzureUSGovernment` | Piipan.Etl, Piipan.Match.State, Piipan.Metrics.Api, Piipan.Metrics.Collect |
 
 
 ## `SysType` resource tag

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -137,6 +137,7 @@ EOF
     --settings \
       $DB_CONN_STR_KEY="$DB_CONN_STR" \
       $VAULT_NAME_KEY="$VAULT_NAME" \
+      $CLOUD_NAME_STR_KEY="$CLOUD_NAME" \
     --output none
 
   # Connect creds from function app to key vault so app can connect to db
@@ -207,6 +208,7 @@ EOF
       --settings \
         $DB_CONN_STR_KEY="$DB_CONN_STR" \
         $VAULT_NAME_KEY="$VAULT_NAME" \
+        $CLOUD_NAME_STR_KEY="$CLOUD_NAME" \
       --output none
 
   # Connect creds from function app to key vault so app can connect to db

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/GetParticipantUploads.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/GetParticipantUploads.cs
@@ -195,12 +195,20 @@ namespace Piipan.Metrics.Api
         {
             // Environment variable (and placeholder) established
             // during initial function app provisioning in IaC
+            const string CloudName = "CloudName";
             const string DatabaseConnectionString = "DatabaseConnectionString";
             const string PasswordPlaceholder = "{password}";
+            const string GovernmentCloud = "AzureUSGovernment";
             const string secretName = "metrics-pg-admin";
             const string vaultNameKey = "KeyVaultName";
-            string? vaultName = Environment.GetEnvironmentVariable(vaultNameKey);
+
+            string? vaultName = Environment.GetEnvironmentVariable(vaultNameKey); 
             var kvUri = $"https://{vaultName}.vault.azure.net";
+
+            var cn = Environment.GetEnvironmentVariable(CloudName);
+            if (cn == GovernmentCloud) {
+                kvUri = $"https://{vaultName}.vault.usgovcloudapi.net";
+            }
 
             var builder = new NpgsqlConnectionStringBuilder(
                 Environment.GetEnvironmentVariable(DatabaseConnectionString));

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Collect/BulkUploadMetrics.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Collect/BulkUploadMetrics.cs
@@ -73,12 +73,20 @@ namespace Piipan.Metrics.Collect
         {
             // Environment variable (and placeholder) established
             // during initial function app provisioning in IaC
+            const string CloudName = "CloudName";
             const string DatabaseConnectionString = "DatabaseConnectionString";
             const string PasswordPlaceholder = "{password}";
+            const string GovernmentCloud = "AzureUSGovernment";
             const string secretName = "metrics-pg-admin";
             const string vaultNameKey = "KeyVaultName";
+
             string vaultName = Environment.GetEnvironmentVariable(vaultNameKey);
             var kvUri = $"https://{vaultName}.vault.azure.net";
+
+            var cn = Environment.GetEnvironmentVariable(CloudName);
+            if (cn == GovernmentCloud) {
+                kvUri = $"https://{vaultName}.vault.usgovcloudapi.net";
+            }
 
             var builder = new NpgsqlConnectionStringBuilder(
                 Environment.GetEnvironmentVariable(DatabaseConnectionString));


### PR DESCRIPTION
Adopt pattern implemented in ETL, per-state match API for Key Vault. Key Vault usage will be eliminated in #409, so not concerned about the duplicated code across `Api` and `Collect`.