### PR TITLE
Require first name in API/Query tool; Don't require middle name

### DIFF
--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -11,6 +11,7 @@ MatchQueryRequest:
 MatchQuery:
   type: object
   required:
+    - first
     - last
     - dob
     - ssn

--- a/match/src/Piipan.Match.Orchestrator/MatchRequest.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchRequest.cs
@@ -20,7 +20,6 @@ namespace Piipan.Match.Orchestrator
         public string Last { get; set; }
 
         [JsonProperty("first", Required = Required.Always)]
-        [JsonConverter(typeof(NullConverter))]
         public string First { get; set; }
 
         [JsonProperty("middle", NullValueHandling = NullValueHandling.Ignore)]

--- a/match/src/Piipan.Match.Orchestrator/MatchRequest.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchRequest.cs
@@ -19,7 +19,7 @@ namespace Piipan.Match.Orchestrator
         [JsonProperty("last", Required = Required.Always)]
         public string Last { get; set; }
 
-        [JsonProperty("first", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("first", Required = Required.Always)]
         [JsonConverter(typeof(NullConverter))]
         public string First { get; set; }
 

--- a/match/src/Piipan.Match.Orchestrator/MatchRequestValidator.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchRequestValidator.cs
@@ -6,6 +6,7 @@ namespace Piipan.Match.Orchestrator
     {
         public MatchQueryRequestValidator()
         {
+            RuleFor(m => m.Query.First).NotEmpty();
             RuleFor(m => m.Query.Last).NotEmpty();
             RuleFor(m => m.Query.Ssn).Matches(@"^[0-9]{3}-[0-9]{2}-[0-9]{4}$");
         }

--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -99,8 +99,7 @@ namespace Piipan.Match.State
                 middle = request.Query.Middle
             };
             var sql = "SELECT upload_id, first, last, middle, dob, ssn, exception FROM participants " +
-                        "WHERE ssn=@ssn AND dob=@dob AND last=@last " +
-                        "AND " + (p.first == null ? "first IS NULL" : "first=@first") + " " +
+                        "WHERE ssn=@ssn AND dob=@dob AND last=@last AND first=@first" +
                         "AND " + (p.middle == null ? "middle IS NULL" : "middle=@middle") + " " +
                         "AND upload_id=(SELECT id FROM uploads WHERE created_at = (SELECT MAX(created_at) FROM uploads))";
 

--- a/match/src/Piipan.Match.State/MatchRequest.cs
+++ b/match/src/Piipan.Match.State/MatchRequest.cs
@@ -19,7 +19,7 @@ namespace Piipan.Match.State
         [JsonProperty("last", Required = Required.Always)]
         public string Last { get; set; }
 
-        [JsonProperty("first", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("first", Required = Required.Always)]
         [JsonConverter(typeof(NullConverter))]
         public string First { get; set; }
 

--- a/match/src/Piipan.Match.State/MatchRequest.cs
+++ b/match/src/Piipan.Match.State/MatchRequest.cs
@@ -20,7 +20,6 @@ namespace Piipan.Match.State
         public string Last { get; set; }
 
         [JsonProperty("first", Required = Required.Always)]
-        [JsonConverter(typeof(NullConverter))]
         public string First { get; set; }
 
         [JsonProperty("middle", NullValueHandling = NullValueHandling.Ignore)]

--- a/match/src/Piipan.Match.State/MatchRequestValidator.cs
+++ b/match/src/Piipan.Match.State/MatchRequestValidator.cs
@@ -6,6 +6,7 @@ namespace Piipan.Match.State
     {
         public MatchQueryRequestValidator()
         {
+            RuleFor(m => m.Query.First).NotEmpty();
             RuleFor(m => m.Query.Last).NotEmpty();
             RuleFor(m => m.Query.Ssn).Matches(@"^[0-9]{3}-[0-9]{2}-[0-9]{4}$");
         }

--- a/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
@@ -139,13 +139,13 @@ namespace Piipan.Match.Orchestrator.Tests
         [Fact]
         public void PiiRecordJson()
         {
-            var json = @"{last: 'Last', dob: '2020-01-01', ssn: '000000000'}";
+            var json = @"{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '000000000'}";
             var record = JsonConvert.DeserializeObject<PiiRecord>(json);
 
             Assert.Contains("\"last\": \"Last\"", record.ToJson());
             Assert.Contains("\"dob\": \"2020-01-01\"", record.ToJson());
             Assert.Contains("\"ssn\": \"000000000\"", record.ToJson());
-            Assert.Contains("\"first\": null", record.ToJson());
+            Assert.Contains("\"first\": \"First\"", record.ToJson());
             Assert.Contains("\"middle\": null", record.ToJson());
             Assert.Contains("\"exception\": null", record.ToJson());
             Assert.Contains("\"state_name\": null", record.ToJson());
@@ -178,6 +178,8 @@ namespace Piipan.Match.Orchestrator.Tests
         [InlineData(@"{last: 'Last', dob: '2020-01-01', ssn: '000-00-000'}")] // Invalid Ssn format
         [InlineData(@"{last: '', dob: '2020-01-01', ssn: '000-00-0000'}")] // Empty last
         [InlineData(@"{last: '        ', dob: '2020-01-01', ssn: '000-00-0000'}")] // Whitespace last
+        [InlineData(@"{last: 'Last', first: '', dob: '2020-01-01', ssn: '000-00-000'}")] // Empty first
+        [InlineData(@"{last: 'Last', first: '       ', dob: '2020-01-01', ssn: '000-00-000'}")] // Whitespace first
         [InlineData(@"{last: 'Last', dob: '2020-01-01', ssn: '000000000'}")] // Invalid Ssn format
         public async void ExpectBadResultFromInvalidData(string query)
         {
@@ -203,6 +205,7 @@ namespace Piipan.Match.Orchestrator.Tests
         [InlineData(@"{last: 'Last', dob: '2020-01-01'}")] // Missing Ssn
         [InlineData(@"{last: 'Last', dob: '2020-01-1', ssn: '000-00-000'}")] // Invalid Dob DateTime
         [InlineData(@"{last: 'Last', dob: '', ssn: '000-00-000'}")] // Empty Dob DateTime
+        [InlineData(@"{last: 'Last', dob: '2020-01-01', ssn: '000-00-000'}")] // Missing First
         public async void ExpectBadResultFromIncompleteData(string query)
         {
             // Arrange

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -61,9 +61,10 @@ namespace Piipan.Match.State.Tests
 
         // Non-required and empty/whitespace properties parse to null
         [Theory]
-        [InlineData(@"{last: 'Last', dob: '2020-01-01', ssn: '000-00-0000'}")] // Missing optionals
-        [InlineData(@"{last: 'Last', middle: '', first: '', dob: '2020-01-01', ssn: '000-00-0000'}")] // Empty optionals
-        [InlineData(@"{last: 'Last', middle: '     ', first: '\n', dob: '2020-01-01', ssn: '000-00-0000'}")] // Whitespace optionals
+        [InlineData(@"{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}")] // Missing optionals
+        [InlineData(@"{last: 'Last', middle: '', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}")] // Empty optionals
+        [InlineData(@"{last: 'Last', middle: '     ', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}")] // Whitespace optionals
+        [InlineData(@"{last: 'Last', middle: '\n', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}")] // Whitespace optionals
         public void ExpectEmptyOptionalPropertiesToBeNull(string query)
         {
             // Arrage
@@ -76,7 +77,6 @@ namespace Piipan.Match.State.Tests
 
             // Assert
             Assert.Null(request.Query.Middle);
-            Assert.Null(request.Query.First);
             Assert.True(valid);
         }
 
@@ -163,10 +163,12 @@ namespace Piipan.Match.State.Tests
         // Invalid data fails validation
         // Note: date validation happens in `Api.Parse` not `Api.Validate`
         [Theory]
-        [InlineData(@"{last: 'Last', dob: '2020-01-01', ssn: '000-00-000'}")] // Invalid Ssn format
-        [InlineData(@"{last: '', dob: '2020-01-01', ssn: '000-00-0000'}")] // Empty last
-        [InlineData(@"{last: '        ', dob: '2020-01-01', ssn: '000-00-0000'}")] // Whitespace last
-        [InlineData(@"{last: 'Last', dob: '2020-01-01', ssn: '000000000'}")] // Invalid Ssn format
+        [InlineData(@"{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '000-00-000'}")] // Invalid Ssn format
+        [InlineData(@"{last: '', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}")] // Empty last
+        [InlineData(@"{last: 'Last', first: '', dob: '2020-01-01', ssn: '000-00-0000'}")] // Empty first
+        [InlineData(@"{last: '        ', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}")] // Whitespace last
+        [InlineData(@"{last: 'Last', first: '       ', dob: '2020-01-01', ssn: '000-00-0000'}")] // Whitespace first
+        [InlineData(@"{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '000000000'}")] // Invalid Ssn format
         public void ExpectQueryToBeInvalid(string query)
         {
             // Arrange
@@ -228,7 +230,7 @@ namespace Piipan.Match.State.Tests
         public void SqlHasIsNullCondition()
         {
             // Arrange
-            var body = JsonBody(@"{last:'Last', dob: '1970-01-01', ssn: '000-00-0000'}");
+            var body = JsonBody(@"{last:'Last', first: 'First', dob: '1970-01-01', ssn: '000-00-0000'}");
             var logger = Mock.Of<ILogger>();
 
             // Act
@@ -237,7 +239,6 @@ namespace Piipan.Match.State.Tests
 
             // Assert
             Assert.Contains("middle IS NULL", sql);
-            Assert.Contains("first IS NULL", sql);
         }
 
         // SQL contains strings

--- a/query-tool/src/Piipan.QueryTool/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool/PiiRecord.cs
@@ -11,7 +11,6 @@ namespace Piipan.QueryTool
         [JsonPropertyName("first")]
         public string FirstName { get; set; }
 
-        [Required]
         [Display(Name = "Middle Name")]
         [JsonPropertyName("middle")]
         public string MiddleName { get; set; }


### PR DESCRIPTION
Addresses #528 

* Add validations for first name in Match & Orchestrator APIs
* Remove validation for middle name in Query Tool