### PR TITLE
Reincorporate Easy Auth config into main IaC

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -18,7 +18,7 @@ To (re)create the Azure resources that `piipan` uses:
 ```
     az cloud set --name AzureCloud
 ```
-4. Sign in with the Azure CLI `login` command. Step 5 can be run with an account having the Contributor role on the subscription. Step 6 appears to require yet-to-be-understood privileges on Azure Active Directory; use a Global Administrator account.
+4. Sign in with the Azure CLI `login` command. An account with at least the Contributor role on the subscription is required.
 ```
     az login
 ```
@@ -26,10 +26,6 @@ To (re)create the Azure resources that `piipan` uses:
 ```
     cd iac
     ./create-resources.bash tts/dev
-```
-6. Run `configure-easy-auth`, which runs app registrations, creates local service principals, and enables [App Service Authentication for internal APIs](./securing-internal-apis.md).
-```
-    ./configure-easy-auth.bash tts/dev
 ```
 
 ## Deployment environments

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -448,6 +448,11 @@ main () {
   # Establish metrics sub-system
   ./create-metrics-resources.bash $azure_env
 
+  # Configures App Service Authentication between:
+  #   - PerStateMatchApi and OrchestratorApi
+  #   - OrchestratorApi and QueryApp
+  ./configure-easy-auth.bash $azure_env
+
   script_completed
 }
 


### PR DESCRIPTION
Contributor access is sufficient for setting up Easy Auth after all.