### PR TITLE
Add versioning to APIM instance

### DIFF
--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -16,16 +16,14 @@
         },
         "publisherName": {
             "type": "String"
-        },
-        "functionAppName": {
-            "type": "String"
         }
     },
     "variables": {
         "systemTypeTag": {
             "SysType": "PublicApi"
         },
-        "displayName": "Public API"
+        "displayName": "Public API",
+        "matchSetName": "match"
     },
     "resources": [
         {
@@ -65,11 +63,24 @@
             }
         },
         {
-            "type": "Microsoft.ApiManagement/service/apis",
+            "type": "Microsoft.ApiManagement/service/apiVersionSets",
             "apiVersion": "2020-06-01-preview",
-            "name": "[concat(parameters('apiName'), '/', parameters('functionAppName'))]",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]"
+            ],
+            "properties": {
+                "displayName": "[variables('displayName')]",
+                "versioningScheme": "Segment"
+            }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis",
+            "apiVersion": "2020-06-01-preview",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]",
+                "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('matchSetName'))]"
             ],
             "properties": {
                 "displayName": "[variables('displayName')]",
@@ -77,7 +88,9 @@
                 "protocols": [
                     "https"
                 ],
-                "path": "/api"
+                "path": "",
+                "apiVersion": "v1",
+                "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('matchSetName'))]"
             }
         }
     ],

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -19,14 +19,14 @@ source $(dirname "$0")/../tools/common.bash || exit
 source $(dirname "$0")/iac-common.bash || exit
 
 clean_defaults () {
-  group=$1
-  apim=$2
+  local group=$1
+  local apim=$2
   
   # Delete "echo API" example API
   az apim api delete \
     --api-id echo-api \
     -g ${group} \
-    -n ${apim_name} \
+    -n ${apim} \
     -y
   
   # Delete default "Starter" and "Unlimited" products and their associated
@@ -35,14 +35,14 @@ clean_defaults () {
     --product-id starter \
     --delete-subscriptions true \
     -g ${group} \
-    -n ${apim_name} \
+    -n ${apim} \
     -y
   
   az apim product delete \
     --product-id unlimited \
     --delete-subscriptions true \
     -g ${group} \
-    -n ${apim_name} \
+    -n ${apim} \
     -y
 }
 
@@ -56,26 +56,21 @@ main () {
   APIM_NAME=apim-publicapi-${ENV}
   PUBLISHER_NAME='API Administrator'
   publisher_email=$2
-  orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
 
-  apim_name=$(\
-    az deployment group create \
-      --name apim-dev \
-      --resource-group $MATCH_RESOURCE_GROUP \
-      --template-file ./arm-templates/apim.json \
-      --query properties.outputs.apimName.value \
-      --output tsv \
-      --parameters \
-        apiName=$APIM_NAME \
-        publisherEmail=$publisher_email \
-        publisherName="$PUBLISHER_NAME" \
-        location=$LOCATION \
-        functionAppName=$orch_name \
-        resourceTags="$RESOURCE_TAGS")
+  az deployment group create \
+    --name apim-dev \
+    --resource-group $MATCH_RESOURCE_GROUP \
+    --template-file ./arm-templates/apim.json \
+    --parameters \
+      apiName=$APIM_NAME \
+      publisherEmail=$publisher_email \
+      publisherName="$PUBLISHER_NAME" \
+      location=$LOCATION \
+      resourceTags="$RESOURCE_TAGS"
 
   # Clear out default example resources
   # See: https://stackoverflow.com/a/64297708
-  clean_defaults $MATCH_RESOURCE_GROUP $apim_name
+  clean_defaults $MATCH_RESOURCE_GROUP $APIM_NAME
 }
 
 main "$@"


### PR DESCRIPTION
- Create version set with v1 identifier
- Link API to version set
- Remove unused variables and parameters

Establishes a versioned API which uses a path segment (e.g., `/v1`) to differentiate between versions. Still fleshing out the scaffolding, no publicly-accessible components.

Partially addresses #28.