### PR TITLE
Fix: move GSA IP restrictions from web app level to Front Door/WAF policy level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,10 +143,10 @@ jobs:
       - azure-cli/login-with-service-principal
       - run:
           name: Upload Dashboard
-          command: az webapp deployment source config-zip -g rg-core-dev -n piipan-dashboard-5or4l3nqzevf4 --src /build/workspace/dashboard.zip
+          command: az webapp deployment source config-zip -g rg-core-dev -n fns-fd-dashboard-dev --src /build/workspace/dashboard.zip
       - run:
           name: Upload Query Tool
-          command: az webapp deployment source config-zip -g rg-core-dev -n piipan-query-tool-5or4l3nqzevf4 --src /build/workspace/query-tool.zip
+          command: az webapp deployment source config-zip -g rg-core-dev -n fns-app-query-tool-dev --src /build/workspace/query-tool.zip
 
   accessibility_dashboard:
     docker:

--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -5,6 +5,9 @@
         "appName": {
             "type": "string"
         },
+        "frontDoorId": {
+            "type": "string"
+        },
         "location": {
             "type": "string"
         },
@@ -19,16 +22,24 @@
         }
     },
     "variables": {
-        "appName": "[concat(parameters('appName'), '-', uniqueString(resourceGroup().id))]",
+        "appName": "[concat(parameters('appName'))]",
         "sku": "S1",
         "baseSiteConfig": {
             "linuxFxVersion": "DOTNETCORE|3.1",
             "ipSecurityRestrictions": [
+                /* Restricts access to Front Door resource only */
+                /* https://docs.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions#manage-access-restriction-rules-programmatically */
                 {
-                    "ipAddress": "159.142.0.0/16",
+                    "ipAddress": "AzureFrontDoor.Backend",
+                    "tag": "ServiceTag",
                     "action": "Allow",
-                    "name": "GSA IP range",
-                    "priority": 100
+                    "priority": 100,
+                    "name": "Allow Azure Front Door access",
+                    "headers": {
+                        "x-azure-fdid": [
+                            "[concat(parameters('frontDoorId'))]"
+                        ]
+                    }
                 }
             ],
             "ftpsState": "Disabled",

--- a/iac/arm-templates/front-door-app-service.json
+++ b/iac/arm-templates/front-door-app-service.json
@@ -66,6 +66,52 @@
                     "mode": "[parameters('wafMode')]",
                     "enabledState": "Enabled"
                 },
+                "customRules": {
+                    "rules": [
+                        /* Allow GSA IP's */
+                        {
+                            "name": "IPAllowListRule",
+                            "enabledState": "Enabled",
+                            "priority": 300, /* Lower number denotes higher priority. This Allow Rule must be a highger priority than the Deny rule below. */
+                            "ruleType": "MatchRule",
+                            "rateLimitDurationInMinutes": 1,
+                            "rateLimitThreshold": 100,
+                            "matchConditions": [
+                                {
+                                    "matchVariable": "RemoteAddr",
+                                    "operator": "IPMatch",
+                                    "negateCondition": false,
+                                    "matchValue": [
+                                        "159.142.0.0/16" /* GSA IP range */
+                                    ],
+                                    "transforms": []
+                                }
+                            ],
+                            "action": "Allow"
+                        },
+                        /* Deny any non-GSA IP's */
+                        {
+                            "name": "IPDenyListRule",
+                            "enabledState": "Enabled",
+                            "priority": 301,
+                            "ruleType": "MatchRule",
+                            "rateLimitDurationInMinutes": 1,
+                            "rateLimitThreshold": 100,
+                            "matchConditions": [
+                                {
+                                    "matchVariable": "RemoteAddr",
+                                    "operator": "IPMatch",
+                                    "negateCondition": true, /* This is a double negative meaning "deny all IP's NOT within the matched range" */
+                                    "matchValue": [
+                                        "159.142.0.0/16" /* GSA IP range */
+                                    ],
+                                    "transforms": []
+                                }
+                            ],
+                            "action": "Block"
+                        }
+                    ]
+                },
                 "managedRules": {
                     "managedRuleSets": [
                         {

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -5,6 +5,9 @@
         "appName": {
             "type": "string"
         },
+        "frontDoorId": {
+            "type": "string"
+        },
         "location": {
             "type": "string"
         },
@@ -19,16 +22,24 @@
         }
     },
     "variables": {
-        "appName": "[concat(parameters('appName'), '-', uniqueString(resourceGroup().id))]",
+        "appName": "[concat(parameters('appName'))]",
         "sku": "S1",
         "baseSiteConfig": {
             "linuxFxVersion": "DOTNETCORE|3.1",
             "ipSecurityRestrictions": [
+                /* Restricts access to Front Door resource only */
+                /* https://docs.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions#manage-access-restriction-rules-programmatically */
                 {
-                    "ipAddress": "159.142.0.0/16",
+                    "ipAddress": "AzureFrontDoor.Backend",
+                    "tag": "ServiceTag",
                     "action": "Allow",
-                    "name": "GSA IP range",
-                    "priority": 100
+                    "priority": 100,
+                    "name": "Allow Azure Front Door access",
+                    "headers": {
+                        "x-azure-fdid": [
+                            "[concat(parameters('frontDoorId'))]"
+                        ]
+                    }
                 }
             ],
             "ftpsState": "Disabled",

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -27,7 +27,7 @@ set_constants () {
   # Name of secret used to store the PostgreSQL metrics server admin password
   PG_SECRET_NAME=metrics-pg-admin
   # Base name of dashboard app
-  DASHBOARD_APP_NAME=piipan-dashboard
+  DASHBOARD_APP_NAME=${PREFIX}-app-dashboard-${ENV}
   DASHBOARD_FRONTDOOR_NAME=dashboard
 }
 
@@ -232,9 +232,25 @@ EOF
     func azure functionapp publish $API_APP_NAME --dotnet
   popd
 
-  # Deploying Dashboard App here because it now relies on info from metrics api.
-  # If we can get the metrics api function app name dynamically without deploying,
-  # then this can be moved to its own file.
+  ## Dashboard stuff
+
+  echo "Create Front Door and WAF policy for dashboard app"
+  suffix=$(web_app_host_suffix)
+  dashboard_host=${DASHBOARD_APP_NAME}${suffix}
+  ./add-front-door-to-app.bash \
+    $azure_env \
+    $RESOURCE_GROUP \
+    $DASHBOARD_FRONTDOOR_NAME \
+    $dashboard_host
+
+  front_door_id=$(\
+  az network front-door show \
+    --name $DASHBOARD_FRONTDOOR_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --query frontdoorId \
+    --output tsv)
+  echo "Front Door iD: ${front_door_id}"
+
   metrics_api_uri=$(\
     az functionapp function show \
       -g $METRICS_RESOURCE_GROUP \
@@ -245,28 +261,17 @@ EOF
 
   # Create App Service resources for dashboard app
   echo "Creating App Service resources for dashboard app"
-  dashboard_host_prefix=$(\
-    az deployment group create \
-      --name $DASHBOARD_APP_NAME \
-      --resource-group $RESOURCE_GROUP \
-      --template-file ./arm-templates/dashboard-app.json \
-      --query properties.outputs.appName.value \
-      --output tsv \
-      --parameters \
-        location=$LOCATION \
-        resourceTags="$RESOURCE_TAGS" \
-        appName=$DASHBOARD_APP_NAME \
-        servicePlan=$APP_SERVICE_PLAN \
-        metricsApiUri=$metrics_api_uri)
-
-  echo "Create Front Door and WAF policy for dashboard app"
-  suffix=$(web_app_host_suffix)
-  dashboard_host=${dashboard_host_prefix}${suffix}
-  ./add-front-door-to-app.bash \
-    $azure_env \
-    $RESOURCE_GROUP \
-    $DASHBOARD_FRONTDOOR_NAME \
-    $dashboard_host
+  az deployment group create \
+    --name $DASHBOARD_APP_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --template-file ./arm-templates/dashboard-app.json \
+    --parameters \
+      location=$LOCATION \
+      resourceTags="$RESOURCE_TAGS" \
+      appName=$DASHBOARD_APP_NAME \
+      servicePlan=$APP_SERVICE_PLAN \
+      frontDoorId=$front_door_id \
+      metricsApiUri=$metrics_api_uri
 
   script_completed
 }

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -245,7 +245,7 @@ EOF
 
   front_door_id=$(\
   az network front-door show \
-    --name $DASHBOARD_FRONTDOOR_NAME \
+    --name ${PREFIX}-fd-${DASHBOARD_FRONTDOOR_NAME}-${ENV} \
     --resource-group $RESOURCE_GROUP \
     --query frontdoorId \
     --output tsv)

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -29,7 +29,7 @@ PG_AAD_ADMIN=piipan-admins
 PG_SERVER_NAME=participant-records
 
 # Base name of query tool app
-QUERY_TOOL_APP_NAME=piipan-query-tool
+QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
 QUERY_TOOL_FRONTDOOR_NAME=querytool
 
 # Display name of service principal account responsible for CI/CD tasks
@@ -414,6 +414,23 @@ main () {
   # $orch_api to be set.
   echo "Creating App Service resources for query tool app"
 
+  echo "Create Front Door and WAF policy for query tool app"
+  suffix=$(web_app_host_suffix)
+  query_tool_host=${QUERY_TOOL_APP_NAME}${suffix}
+  ./add-front-door-to-app.bash \
+    $azure_env \
+    $RESOURCE_GROUP \
+    $QUERY_TOOL_FRONTDOOR_NAME \
+    $query_tool_host
+
+  front_door_id=$(\
+  az network front-door show \
+    --name $QUERY_TOOL_FRONTDOOR_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --query frontdoorId \
+    --output tsv)
+  echo "Front Door iD: ${front_door_id}"
+
   orch_api_uri=$(\
     az functionapp function show \
       -g $MATCH_RESOURCE_GROUP \
@@ -422,28 +439,17 @@ main () {
       --query invokeUrlTemplate \
       -o tsv)
 
-  query_tool_name=$(\
-    az deployment group create \
-      --name $QUERY_TOOL_APP_NAME \
-      --resource-group $RESOURCE_GROUP \
-      --template-file ./arm-templates/query-tool-app.json \
-      --query properties.outputs.appName.value \
-      --output tsv \
-      --parameters \
-        location=$LOCATION \
-        resourceTags="$RESOURCE_TAGS" \
-        appName=$QUERY_TOOL_APP_NAME \
-        servicePlan=$APP_SERVICE_PLAN \
-        OrchApiUri=$orch_api_uri)
-
-  echo "Create Front Door and WAF policy for query tool app"
-  suffix=$(web_app_host_suffix)
-  query_tool_host=${query_tool_name}${suffix}
-  ./add-front-door-to-app.bash \
-    $azure_env \
-    $RESOURCE_GROUP \
-    $QUERY_TOOL_FRONTDOOR_NAME \
-    $query_tool_host
+  az deployment group create \
+    --name $QUERY_TOOL_APP_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --template-file ./arm-templates/query-tool-app.json \
+    --parameters \
+      location=$LOCATION \
+      resourceTags="$RESOURCE_TAGS" \
+      appName=$QUERY_TOOL_APP_NAME \
+      servicePlan=$APP_SERVICE_PLAN \
+      frontDoorId=$front_door_id \
+      OrchApiUri=$orch_api_uri
 
   # Establish metrics sub-system
   ./create-metrics-resources.bash $azure_env

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -13,30 +13,32 @@
 source $(dirname "$0")/../tools/common.bash || exit
 source $(dirname "$0")/iac-common.bash || exit
 
-# Name of Key Vault
-VAULT_NAME=secret-keeper
+set_constants () {
+  # Name of Key Vault
+  VAULT_NAME=secret-keeper
 
-# Name of secret used to store the PostgreSQL server admin password
-PG_SECRET_NAME=particpants-records-admin
+  # Name of secret used to store the PostgreSQL server admin password
+  PG_SECRET_NAME=particpants-records-admin
 
-# Name of administrator login for PostgreSQL server
-PG_SUPERUSER=postgres
+  # Name of administrator login for PostgreSQL server
+  PG_SUPERUSER=postgres
 
-# Name of Azure Active Directory admin for PostgreSQL server
-PG_AAD_ADMIN=piipan-admins
+  # Name of Azure Active Directory admin for PostgreSQL server
+  PG_AAD_ADMIN=piipan-admins
 
-# Name of PostgreSQL server
-PG_SERVER_NAME=participant-records
+  # Name of PostgreSQL server
+  PG_SERVER_NAME=participant-records
 
-# Base name of query tool app
-QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
-QUERY_TOOL_FRONTDOOR_NAME=querytool
+  # Base name of query tool app
+  QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
+  QUERY_TOOL_FRONTDOOR_NAME=querytool
 
-# Display name of service principal account responsible for CI/CD tasks
-SP_NAME_CICD=piipan-cicd
+  # Display name of service principal account responsible for CI/CD tasks
+  SP_NAME_CICD=piipan-cicd
 
-# App Service Authentication is done at the Azure tenant level
-TENANT_ID=$(az account show --query homeTenantId -o tsv)
+  # App Service Authentication is done at the Azure tenant level
+  TENANT_ID=$(az account show --query homeTenantId -o tsv)
+}
 
 # Generate the storage account connection string for the corresponding
 # blob storage account.
@@ -76,6 +78,8 @@ main () {
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
   verify_cloud
+
+  set_constants
 
   ./create-resource-groups.bash $azure_env
 
@@ -425,7 +429,7 @@ main () {
 
   front_door_id=$(\
   az network front-door show \
-    --name $QUERY_TOOL_FRONTDOOR_NAME \
+    --name ${PREFIX}-fd-${QUERY_TOOL_FRONTDOOR_NAME}-${ENV} \
     --resource-group $RESOURCE_GROUP \
     --query frontdoorId \
     --output tsv)


### PR DESCRIPTION
Initially, restricting access to only GSA IP's was set on the web apps themselves.

When Azure Front Doors were applied to the apps, this blocked traffic from the Front Door Backends.

Instead, the web apps are now restricted to `AzureFrontDoor.Backend` traffic, and GSA IP restrictions are now set as rules on the related Front Door WAF policies. 

This restricts traffic to the app from everywhere except through the front-door URL when on the GSA network.

## Considerations
This creates a co-dependency when creating web app and front door resources: web apps need the front door ID in order to set the backend restrictions, and front doors need the app host name in order to connect the app to the front door resource.

Consequently, the ARM templates become more reliant on naming conventions. It also becomes more difficult to name resources dynamically through the templates, as names are often needed for other resources before the main resource is deployed.