### PR TITLE
Add POST operation for matching API query

### DIFF
--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -92,6 +92,32 @@
                 "apiVersion": "v1",
                 "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('matchSetName'))]"
             }
+        },
+        /* XXX generate via OpenAPI spec rather than hardcode */
+        {
+            "type": "Microsoft.ApiManagement/service/apis/operations",
+            "apiVersion": "2020-06-01-preview",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/post-query')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]",
+                "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('matchSetName'))]"
+            ],
+            "properties": {
+                "displayName": "Search for all matching PII records",
+                "method": "POST",
+                "urlTemplate": "/query",
+                "description": "Queries all state databases for any PII records that are an exact match to the full name, date of birth, and social security number in the request body's `query` property.",
+                "responses": [
+                    {
+                        "statusCode": 200,
+                        "description": "Matching PII records, if any exist"
+                    },
+                    {
+                        "statusCode": 400,
+                        "description": "Bad request. Missing one of the required properties in the request body."
+                    }
+                ]
+            }
         }
     ],
     "outputs": {


### PR DESCRIPTION
Adds initial operation to APIM instance and creates a `/query` endpoint.

Follow up PR will connect this operation to the backend server (orchestrator Function App). Until then, the endpoint is effectively a stub.

The operation is hard-coded in `apim.json` for now, but could be scraped in favor of dynamic creation by importing the OpenAPI spec via the [`value` property on the API resource](https://docs.microsoft.com/en-us/azure/templates/microsoft.apimanagement/2019-01-01/service/apis?tabs=json#apicreateorupdateproperties-object). This work is described in #548.