### PR TITLE
Point APIM to backend service

### DIFF
--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -16,6 +16,9 @@
         },
         "publisherName": {
             "type": "String"
+        },
+        "orchestratorUrl": {
+            "type": "String"
         }
     },
     "variables": {
@@ -90,7 +93,8 @@
                 ],
                 "path": "",
                 "apiVersion": "v1",
-                "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('matchSetName'))]"
+                "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('matchSetName'))]",
+                "serviceUrl": "[parameters('orchestratorUrl')]"
             }
         },
         /* XXX generate via OpenAPI spec rather than hardcode */

--- a/iac/configure-easy-auth.bash
+++ b/iac/configure-easy-auth.bash
@@ -259,6 +259,8 @@ main () {
 
   query_tool_name=$(get_resources $QUERY_APP_TAG $RESOURCE_GROUP)
 
+  public_api_name=$(get_resources $PUBLIC_API_TAG $MATCH_RESOURCE_GROUP)
+
   orch_identity=$(\
     az webapp identity show \
       --name $orch_name \
@@ -271,6 +273,13 @@ main () {
       --name $query_tool_name \
       --resource-group $RESOURCE_GROUP \
       --query principalId \
+      --output tsv)
+
+  public_api_identity=$(\
+    az apim show \
+      --name $public_api_name \
+      --resource-group $MATCH_RESOURCE_GROUP \
+      --query identity.principalId \
       --output tsv)
 
   for func in "${match_func_names[@]}"
@@ -287,6 +296,12 @@ main () {
     $orch_name $MATCH_RESOURCE_GROUP \
     $ORCH_API_APP_ROLE \
     $query_tool_identity
+
+  echo "Configure Easy Auth for OrchestratorApi and PublicApi"
+  configure_easy_auth_pair \
+    $orch_name $MATCH_RESOURCE_GROUP \
+    $ORCH_API_APP_ROLE \
+    $public_api_identity
 
   script_completed
 }

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -57,6 +57,16 @@ main () {
   PUBLISHER_NAME='API Administrator'
   publisher_email=$2
 
+  orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
+  orch_base_url=$(\
+    az functionapp show \
+      -g $MATCH_RESOURCE_GROUP \
+      -n $orch_name \
+      --query defaultHostName \
+      --output tsv)
+  orch_base_url="https://${orch_base_url}"
+  orch_api_url="${orch_base_url}/api/v1"
+
   az deployment group create \
     --name apim-dev \
     --resource-group $MATCH_RESOURCE_GROUP \
@@ -65,6 +75,7 @@ main () {
       apiName=$APIM_NAME \
       publisherEmail=$publisher_email \
       publisherName="$PUBLISHER_NAME" \
+      orchestratorUrl=$orch_api_url \
       location=$LOCATION \
       resourceTags="$RESOURCE_TAGS"
 


### PR DESCRIPTION
- Reference orchestrator URL from APIM API resource
- Configure Easy Auth between APIM and orchestrator

Follow on work to #549. Puts the pieces in place to connect the APIM instance to the orchestrator API. Will be followed by a PR that connects the APIM frontend to the orchestrator backend using a managed identity authentication policy.