### PR TITLE
Re-add dropped whitespace in concatenated SQL query

### DIFF
--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -99,7 +99,7 @@ namespace Piipan.Match.State
                 middle = request.Query.Middle
             };
             var sql = "SELECT upload_id, first, last, middle, dob, ssn, exception FROM participants " +
-                        "WHERE ssn=@ssn AND dob=@dob AND last=@last AND first=@first" +
+                        "WHERE ssn=@ssn AND dob=@dob AND last=@last AND first=@first " +
                         "AND " + (p.middle == null ? "middle IS NULL" : "middle=@middle") + " " +
                         "AND upload_id=(SELECT id FROM uploads WHERE created_at = (SELECT MAX(created_at) FROM uploads))";
 
@@ -123,7 +123,8 @@ namespace Piipan.Match.State
 
             var resourceId = CommercialId;
             var cn = Environment.GetEnvironmentVariable(CloudName);
-            if (cn == GovernmentCloud) {
+            if (cn == GovernmentCloud)
+            {
                 resourceId = GovermentId;
             }
 


### PR DESCRIPTION
A trailing space got dropped in a previous commit resulting in a broken SQL query (line 102). OmniSharp picked up an additional formatting tweak upon save.