### PR TITLE
Add APIM policy for Public API

### DIFF
--- a/iac/apim-policy.xml
+++ b/iac/apim-policy.xml
@@ -1,0 +1,18 @@
+<!-- Generated via IaC -->
+
+<policies>
+    <inbound>
+        <base />
+        <authentication-managed-identity resource="{applicationUri}" />
+        <set-header name="Ocp-Apim-Subscription-Key" exists-action="delete" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/iac/apim-policy.xml
+++ b/iac/apim-policy.xml
@@ -4,6 +4,7 @@
     <inbound>
         <base />
         <authentication-managed-identity resource="{applicationUri}" />
+        <!-- APIM has used this header to authenticate the request, drop it as we forward the request to our internal endpoint, as it has no use for the client's private API key -->
         <set-header name="Ocp-Apim-Subscription-Key" exists-action="delete" />
     </inbound>
     <backend>

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -19,6 +19,9 @@
         },
         "orchestratorUrl": {
             "type": "String"
+        },
+        "policyXml": {
+            "type": "String"
         }
     },
     "variables": {
@@ -121,6 +124,20 @@
                         "description": "Bad request. Missing one of the required properties in the request body."
                     }
                 ]
+            }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis/operations/policies",
+            "apiVersion": "2020-06-01-preview",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/post-query/policy')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('apiName'), variables('matchSetName'), 'post-query')]",
+                "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('matchSetName'))]",
+                "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]"
+            ],
+            "properties": {
+                "value": "[parameters('policyXml')]",
+                "format": "xml"
             }
         }
     ],

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -67,6 +67,11 @@ main () {
   orch_base_url="https://${orch_base_url}"
   orch_api_url="${orch_base_url}/api/v1"
 
+  # Edit policy template with proper application ID URI
+  APP_URI_PLACEHOLDER="{applicationUri}"
+  policy_path=$(dirname "$0")/apim-policy.xml
+  policy_xml=$(sed "s,$APP_URI_PLACEHOLDER,${orch_base_url}," $policy_path)
+
   az deployment group create \
     --name apim-dev \
     --resource-group $MATCH_RESOURCE_GROUP \
@@ -76,6 +81,7 @@ main () {
       publisherEmail=$publisher_email \
       publisherName="$PUBLISHER_NAME" \
       orchestratorUrl=$orch_api_url \
+      policyXml="$policy_xml" \
       location=$LOCATION \
       resourceTags="$RESOURCE_TAGS"
 


### PR DESCRIPTION
- Add base XML policy, extended to include managed identity auth
- Update policy with application ID URI when running IaC
- Drop unnecessary subscription key header when forwarding request to
  orchestrator API

This is the final piece in creating a working APIM instance for the public API. After the IaC is run, any request with a valid [subscription key](https://docs.microsoft.com/en-us/azure/api-management/api-management-subscriptions) will initiate an API call to the orchestrator API. Specifically:
1. A user/system submits a valid request to the APIM endpoint
2. APIM authenticates with orchestrator API using its system-assigned identity
3. APIM forwards the request to the orchestrator API
4. APIM forwards response from orchestrator API back to user/system

The XML policy is barebones, and the current ["templating" solution using `sed`](https://github.com/18F/piipan/blob/a021622f1bee701a40e3d47bb2ef7ff7e385f838/iac/create-apim.bash#L70-L73) may not scale if it becomes more complex.

Addresses #28 