### PR TITLE
include lookup api when generating api specs

### DIFF
--- a/match/docs/openapi/lookup/index.yaml
+++ b/match/docs/openapi/lookup/index.yaml
@@ -4,8 +4,6 @@ info:
   title: "Lookup ID Endpoint"
   version: 1.0.0
   description: "API for providing a Lookup ID and receiving the original match data"
-tags:
-  - name: "Match"
 servers:
   - url: "/v1"
 paths:

--- a/match/tools/generate-specs.bash
+++ b/match/tools/generate-specs.bash
@@ -11,7 +11,7 @@ set -e
 set -u
 
 main () {
-    specs=(orchestrator state)
+    specs=(orchestrator state lookup)
 
     for s in "${specs[@]}"
     do


### PR DESCRIPTION
Just noticed I didn't include the new lookup api here