### PR TITLE
Deny all IP addresses as lower-priority firewall rule

### DIFF
--- a/iac/arm-templates/front-door-app-service.json
+++ b/iac/arm-templates/front-door-app-service.json
@@ -89,7 +89,7 @@
                             ],
                             "action": "Allow"
                         },
-                        /* Deny any non-GSA IP's */
+                        /* Deny all IP's */
                         {
                             "name": "IPDenyListRule",
                             "enabledState": "Enabled",
@@ -100,11 +100,8 @@
                             "matchConditions": [
                                 {
                                     "matchVariable": "RemoteAddr",
-                                    "operator": "IPMatch",
-                                    "negateCondition": true, /* This is a double negative meaning "deny all IP's NOT within the matched range" */
-                                    "matchValue": [
-                                        "159.142.0.0/16" /* GSA IP range */
-                                    ],
+                                    "operator": "Any",
+                                    "matchValue": [], /* The matchValue key is required, but can be empty for the "Any" operator */
                                     "transforms": []
                                 }
                             ],


### PR DESCRIPTION
For simplicity purposes -- this effectively does the same thing as the previous rule to deny all non-GSA IP's