### PR TITLE
Stub lookup ID into orchestrator response

### DIFF
--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -40,6 +40,7 @@ MatchQueryResponse:
   properties:
     lookup_id:
       type: string
+      nullable: true
       description: "the identifier of the match request"
     matches:
       type: array

--- a/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
@@ -7,6 +7,9 @@ namespace Piipan.Match.Orchestrator
 
     public class MatchQueryResponse
     {
+        [JsonProperty("lookup_id")]
+        public string LookupId { get; set; }
+
         [JsonProperty("matches")]
         public List<PiiRecord> Matches { get; set; }
 


### PR DESCRIPTION
- Update model
- Reflect null potential in spec

Small first step towards #452. Lookup ID generation has not been implemented. All responses will contain a `lookup_id` property with a `null` value. E.g.,
```
{
    "lookup_id": null,
    "matches": [
        {
            "last": "Lynn",
            "first": "Wesley",
            "middle": "Eura",
            "ssn": "000-12-3457",
            "dob": "1940-08-01",
            "exception": null,
            "state_name": "Echo Alpha",
            "state_abbr": "ea"
        }
    ]
}
```