### PR TITLE
Update dependabot to reflect `metrics` directory structure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,12 +44,17 @@ updates:
     interval: daily
     time: "09:00"
 - package-ecosystem: nuget
-  directory: "/metrics/src/Piipan.Metrics/PiipanMetricsApi"
+  directory: "/metrics/src/Piipan.Metrics/Piipan.Metrics.Api"
   schedule:
     interval: daily
     time: "09:00"
 - package-ecosystem: nuget
-  directory: "/metrics/src/Piipan.Metrics/PiipanMetricsFunctions"
+  directory: "/metrics/src/Piipan.Metrics/Piipan.Metrics.Collect"
+  schedule:
+    interval: daily
+    time: "09:00"
+- package-ecosystem: nuget
+  directory: "/metrics/src/Piipan.Metrics/Piipan.Metrics.Models"
   schedule:
     interval: daily
     time: "09:00"


### PR DESCRIPTION
`dependabot.yml` has references to `metrics` subsystem paths as they were before #442. Updated paths to reflect current directory structure.