### PR TITLE
Rename 'public API' to 'dual participation API'

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -72,7 +72,7 @@ The following environment variables are pre-configured by the Infrastructure-as-
 | OrchestratorApi | the single Function App for the Orchestrator API |
 | DashboardApp | the single Dashboard App Service |
 | QueryApp | the single Query tool App Service |
-| PublicApi | the single API Management instance for the external-facing matching API |
+| DualPartApi | the single API Management instance for the external-facing matching API |
 
 In the Azure Portal, tags can be added to resource lists using the "Manage view" and/or "Edit columns" menu item that appears at the top left of the view. Specific tag values can also be filtered via "Add filter".
 

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -26,9 +26,9 @@
     },
     "variables": {
         "systemTypeTag": {
-            "SysType": "PublicApi"
+            "SysType": "DualPartApi"
         },
-        "displayName": "Public API",
+        "displayName": "Dual participation API",
         "matchSetName": "match"
     },
     "resources": [

--- a/iac/configure-easy-auth.bash
+++ b/iac/configure-easy-auth.bash
@@ -259,7 +259,7 @@ main () {
 
   query_tool_name=$(get_resources $QUERY_APP_TAG $RESOURCE_GROUP)
 
-  public_api_name=$(get_resources $PUBLIC_API_TAG $MATCH_RESOURCE_GROUP)
+  dp_api_name=$(get_resources $DUAL_PART_API_TAG $MATCH_RESOURCE_GROUP)
 
   orch_identity=$(\
     az webapp identity show \
@@ -275,9 +275,9 @@ main () {
       --query principalId \
       --output tsv)
 
-  public_api_identity=$(\
+  dp_api_identity=$(\
     az apim show \
-      --name $public_api_name \
+      --name $dp_api_name \
       --resource-group $MATCH_RESOURCE_GROUP \
       --query identity.principalId \
       --output tsv)
@@ -297,11 +297,11 @@ main () {
     $ORCH_API_APP_ROLE \
     $query_tool_identity
 
-  echo "Configure Easy Auth for OrchestratorApi and PublicApi"
+  echo "Configure Easy Auth for OrchestratorApi and DualParticipationApi"
   configure_easy_auth_pair \
     $orch_name $MATCH_RESOURCE_GROUP \
     $ORCH_API_APP_ROLE \
-    $public_api_identity
+    $dp_api_identity
 
   script_completed
 }

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# Creates the API Management instance for managing the public-facing
-# match API. Assumes an Azure user with the Global Administrator role
-# has signed in with the Azure CLI. See install-extensions.bash for
+# Creates the API Management instance for managing the public-facing dual
+# participation API. Assumes an Azure user with the Global Administrator
+# role has signed in with the Azure CLI. See install-extensions.bash for
 # prerequisite Azure CLI extensions. Deployment can take ~45 minutes
 # for new instances.
 #
@@ -53,7 +53,7 @@ main () {
   source $(dirname "$0")/env/${azure_env}.bash
   verify_cloud
 
-  APIM_NAME=apim-publicapi-${ENV}
+  APIM_NAME=apim-dualpartapi-${ENV}
   PUBLISHER_NAME='API Administrator'
   publisher_email=$2
 

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -8,7 +8,7 @@ PER_STATE_MATCH_API_TAG="SysType=PerStateMatchApi"
 ORCHESTRATOR_API_TAG="SysType=OrchestratorApi"
 DASHBOARD_APP_TAG="SysType=DashboardApp"
 QUERY_APP_TAG="SysType=QueryApp"
-PUBLIC_API_TAG="SysType=PublicApi"
+DUAL_PART_API_TAG="SysType=DualPartApi"
 
 # Identity object ID for the Azure environment account
 CURRENT_USER_OBJID=`az ad signed-in-user show --query objectId --output tsv`

--- a/match/README.md
+++ b/match/README.md
@@ -8,4 +8,4 @@
 * [Orchestrator PII matching API](./docs/orchestrator-match.md)
 * [Match ID Lookup](./docs/lookup.md)
 * [OpenAPI specifications](./docs/openapi.md)
-* [Public API](./docs/public-api.md)
+* [Dual participation API](./docs/dual-participation-api.md)

--- a/match/docs/dual-participation-api.md
+++ b/match/docs/dual-participation-api.md
@@ -1,8 +1,8 @@
-# Public API
+# Dual participation API
 
 ## Summary
 
-The public API is intended as a collection of external-facing endpoints for consumption by state systems. It is managed as an Azure API Management (APIM) instance and deployed by the [IaC](../../docs/iac.md).
+The dual participation API is intended as a collection of external-facing endpoints for consumption by state systems. It is managed as an Azure API Management (APIM) instance and deployed by the [IaC](../../docs/iac.md).
 
 Currently the API includes a single endpoint which maps to the [orchestrator](orchestrator-match.md) API's query endpoint.
 
@@ -23,7 +23,7 @@ To call an endpoint:
 
 ## Managing endpoints
 
-In APIM, endpoints take the form of operations. Operations are collected together within a parent resource called an API ([details](https://docs.microsoft.com/en-us/azure/api-management/api-management-key-concepts#-apis-and-operations)). Operations and their associated resources are managed in the [apim.json ARM template](../../iac/arm-templates/apim.json). New operations can be added to the Public API by including additional `Microsoft.ApiManagement/service/apis/operations` resources in the template.
+In APIM, endpoints take the form of operations. Operations are collected together within a parent resource called an API ([details](https://docs.microsoft.com/en-us/azure/api-management/api-management-key-concepts#-apis-and-operations)). Operations and their associated resources are managed in the [apim.json ARM template](../../iac/arm-templates/apim.json). New operations can be added to the dual participation API by including additional `Microsoft.ApiManagement/service/apis/operations` resources in the template.
 
 An operation's endpoint is constructed using the following components, all provided via the ARM template:
 


### PR DESCRIPTION
Updated to reflect our decision around naming. This change creates a new APIM instance with the new name. Any subscription keys will need to be re-issued in the new instance.

Closes #592.