### PR TITLE
Add Table Storage resource for lookup API

### DIFF
--- a/iac/arm-templates/function-orch-match.json
+++ b/iac/arm-templates/function-orch-match.json
@@ -8,6 +8,9 @@
         "location": {
             "type": "string"
         },
+        "LookupStorageName": {
+            "type": "string"
+        },
         "StateApiUriStrings": {
             "type": "string"
         }
@@ -16,6 +19,7 @@
         "functionAppName": "[concat('ofunc', uniqueString(resourceGroup().id))]",
         "hostingPlanName": "matchapi",
         "storageAccountName": "[concat('ofstor', uniquestring(resourceGroup().id))]",
+        "lookupTableName": "lookup",
         "functionWorkerRuntime": "dotnet",
         "storageAccountType": "Standard_LRS",
         "systemTypeTag": {
@@ -26,6 +30,42 @@
         }
     },
     "resources": [
+        // Lookup table resources
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2019-06-01",
+            "name": "[parameters('LookupStorageName')]",
+            "tags": "[parameters('resourceTags')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "[variables('storageAccountType')]"
+            },
+            "kind": "Storage"
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(parameters('LookupStorageName'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('LookupStorageName'))]"
+            ],
+            "properties": {
+                "cors": {
+                    "corsRules": []
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(parameters('LookupStorageName'), '/default/', variables('lookupTableName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('LookupStorageName'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('LookupStorageName'), 'default')]"
+            ]
+        },
+
+        // Orchestrator function app resources
         {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2019-06-01",
@@ -64,7 +104,8 @@
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('LookupStorageName'))]"
             ],
             "properties": {
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
@@ -122,6 +163,15 @@
                         {
                             "name": "StateApiUriStrings",
                             "value": "[parameters('StateApiUriStrings')]"
+                        },
+                        // Bind lookup table storage
+                        {
+                            "name": "LookupConnectionString",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('LookupStorageName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('LookupStorageName')), '2019-06-01').keys[0].value)]"
+                        },
+                        {
+                            "name": "LookupTableName",
+                            "value": "[variables('lookupTableName')]"
                         }
                     ]
                 }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -33,6 +33,9 @@ set_constants () {
   QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
   QUERY_TOOL_FRONTDOOR_NAME=querytool
 
+  # Base name of lookup API storage account
+  LOOKUP_STORAGE_NAME=stlookupapi${ENV}
+
   # Display name of service principal account responsible for CI/CD tasks
   SP_NAME_CICD=piipan-cicd
 
@@ -403,6 +406,7 @@ main () {
       --parameters \
         resourceTags="$RESOURCE_TAGS" \
         location=$LOCATION \
+        LookupStorageName=$LOOKUP_STORAGE_NAME \
         StateApiUriStrings=$match_api_uris)
 
   echo "Waiting to publish function app"


### PR DESCRIPTION
[Azure Table Storage](https://docs.microsoft.com/en-us/azure/storage/tables/table-storage-overview#:~:text=Azure%20Table%20storage%20is%20a,needs%20of%20your%20application%20evolve.) seems like the right initial fit for storing queries that will later be retrieved via the lookup API. This PR modifies the IaC to create the necessary storage account and table resource, and bind the storage account to the orchestrator. Binding is done via a connection string — future work should switch to using shared access signatures (see #213).

Partially addresses #195 and #452.