### PR TITLE
Generate lookup ID upon orchestrator match

### DIFF
--- a/match/src/Piipan.Match.Orchestrator/Api.cs
+++ b/match/src/Piipan.Match.Orchestrator/Api.cs
@@ -60,6 +60,11 @@ namespace Piipan.Match.Orchestrator
             try
             {
                 response.Matches = await Match(request, log);
+
+                if (response.Matches.Count > 0)
+                {
+                    response.LookupId = LookupId.Generate(request.Query.ToJson());
+                }
             }
             catch (Exception ex)
             {

--- a/match/src/Piipan.Match.Orchestrator/Lookup.cs
+++ b/match/src/Piipan.Match.Orchestrator/Lookup.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Piipan.Match.Orchestrator
+{
+    static class LookupId
+    {
+        private const string Chars = "23456789BCDFGHJKLMNPQRSTVWXYZ";
+        private const int Length = 7;
+
+        /// <summary>
+        /// Generate a deterministic alphanumeric ID from a given string.
+        /// IDs are encoded using a limited alphabet and fixed length.
+        /// </summary>
+        /// <param name="value">The string value used to generate the ID</param>
+        /// <returns>An alpha-numeric ID string</returns>
+        public static string Generate(string value)
+        {
+            var idString = new StringBuilder();
+            var md5 = MD5.Create();
+            var hashBytes = md5.ComputeHash(Encoding.UTF8.GetBytes(value));
+
+            // Reduce hash to 32 bits to fit into 7 encoded characters (29^7 > 2^32)
+            long hashInt = BitConverter.ToUInt32(hashBytes, 0);
+
+            // Encode using custom alphabet
+            do
+            {
+                idString.Insert(0, Chars[(int)(hashInt % Chars.Length)]);
+                hashInt = (long)(hashInt / Chars.Length);
+            } while (hashInt > 0);
+
+            // Returned IDs should always be `Length` length
+            return idString.ToString().PadLeft(Length, Chars[0]);
+        }
+    }
+}

--- a/match/src/Piipan.Match.Orchestrator/Lookup.cs
+++ b/match/src/Piipan.Match.Orchestrator/Lookup.cs
@@ -21,7 +21,7 @@ namespace Piipan.Match.Orchestrator
             var md5 = MD5.Create();
             var hashBytes = md5.ComputeHash(Encoding.UTF8.GetBytes(value));
 
-            // Reduce hash to 32 bits to fit into 7 encoded characters (29^7 > 2^32)
+            // Only keep the first 32-bits from the 128-bit hash so as to fit into 7 encoded characters (29^7 > 2^32)
             long hashInt = BitConverter.ToUInt32(hashBytes, 0);
 
             // Encode using custom alphabet

--- a/match/src/Piipan.Match.Orchestrator/MatchRequest.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchRequest.cs
@@ -32,5 +32,10 @@ namespace Piipan.Match.Orchestrator
 
         [JsonProperty("ssn", Required = Required.Always)]
         public string Ssn { get; set; }
+
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.None);
+        }
     }
 }

--- a/match/tests/Piipan.Match.Orchestrator.Tests/LookupTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/LookupTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Piipan.Match.Orchestrator.Tests
+{
+    public class LookupTests
+    {
+        const string json = "{last: 'Last', first: 'First', middle: 'Middle', dob: '2020-01-01', ssn: '000-00-0000'}";
+        const string json2 = "{last: 'last', first: 'first', middle: 'middle', dob: '2021-01-01', ssn: '000-11-1111'}";
+
+        [Fact]
+        public void Deterministic()
+        {
+            var str = json;
+            var id = LookupId.Generate(str);
+
+            Assert.Equal(id, LookupId.Generate(str));
+        }
+
+        [Theory]
+        [InlineData(json)]
+        [InlineData(json2)]
+        [InlineData("ABC123")]
+        [InlineData("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")]
+        public void ConformsToLength(string value)
+        {
+            var id = LookupId.Generate(value);
+
+            Assert.Equal(7, id.Length);
+        }
+
+        [Theory]
+        [InlineData(json)]
+        [InlineData(json2)]
+        [InlineData("ABC123")]
+        [InlineData("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")]
+        public void ConformsToAlphabet(string value)
+        {
+            var disallowed = "01AEIOUabcdefghijklmnopqrstuvwxyz";
+            var id = LookupId.Generate(value);
+
+            foreach (char c in disallowed)
+            {
+                Assert.False(id.Contains(c));
+            }
+        }
+
+        [Fact]
+        public void Collisions()
+        {
+            var ids = new List<string>{
+                LookupId.Generate(json),
+                LookupId.Generate(json + " "),
+                LookupId.Generate(json2),
+                LookupId.Generate(json2 + " ")
+            };
+
+            Assert.Equal(ids.Distinct().Count(), ids.Count);
+        }
+    }
+}


### PR DESCRIPTION
Initial approach for generating a lookup ID:
1. Hashes the query (as a serialized JSON string)
1. Reduces hash to 32 bits (to conform to a 7 character length in our custom alphabet)
1. Encodes using our custom alphabet
1. If necessary, pads the encoded string to ensure a consistent length

**Considerations**:
- The ID is 7 characters rather than 6 (which is specified in the issue's AC #452). 7 characters happens to work nicely with a 32-bit integer, which can be easily derived from the hash using `ToUInt32()`. 6 characters is doable, but increases the chance of collisions and requires a little extra finagling to drop the 32-bit integer to the proper size (29-bits).
- Dropping the hash down to 32 bits (or lower if we go with 6 characters), presumably increases the chance of collision. I'm unsure if this means we would need to check for collisions when storing a query, and, if so, how we recover from a collision.

Partially addresses #452. IDs not yet guaranteed to be unique and are currently 7 instead of 6 characters.