### PR TITLE
Add VNet resources and connect them to participant-records db

### DIFF
--- a/iac/arm-templates/participant-records.json
+++ b/iac/arm-templates/participant-records.json
@@ -29,6 +29,12 @@
         },
         "resourceTags": {
             "type": "object"
+        },
+        "vnetName": {
+            "type": "string"
+        },
+        "subnetName": {
+            "type": "string"
         }
     },
     "variables": {
@@ -63,7 +69,27 @@
                             "type": "string"
                         },
                         "resourceTags": {
-                            "type": "object",
+                            "type": "object"
+                        },
+                        "subnetPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.0.0/24",
+                            "metadata": {
+                                "description": "The address space for the subnet."
+                            }
+                        },
+                        "vnetAddressPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.0.0/16",
+                            "metadata": {
+                                "description": "The address space reserved for this virtual network in CIDR notation."
+                            }
+                        },
+                        "vnetName": {
+                            "type": "string"
+                        },
+                        "subnetName": {
+                            "type": "string"
                         }
                     },
                     "variables": {
@@ -87,6 +113,33 @@
                     },
                     "resources": [
                         {
+                            "type": "Microsoft.Network/virtualNetworks",
+                            "apiVersion": "2020-06-01",
+                            "name": "[parameters('vnetName')]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "addressSpace": {
+                                    "addressPrefixes": [
+                                        "[parameters('vnetAddressPrefix')]"
+                                    ]
+                                }
+                            },
+                            "resources": [
+                                {
+                                    "type": "subnets",
+                                    "apiVersion": "2020-06-01",
+                                    "name": "[parameters('subnetName')]",
+                                    "location": "[parameters('location')]",
+                                    "dependsOn": [
+                                        "[parameters('vnetName')]"
+                                    ],
+                                    "properties": {
+                                        "addressPrefix": "[parameters('subnetPrefix')]"
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "type": "Microsoft.DBforPostgreSQL/servers",
                             "apiVersion": "2017-12-01-preview",
                             "kind": "",
@@ -106,13 +159,28 @@
                                 "previewFeature": "",
                                 "infrastructureEncryption": "Disabled"
                             },
+                            /* VNet Rules only work for GeneralPurpose and above tiers */
                             "sku": {
-                                "name": "B_Gen5_1",
-                                "tier": "Basic",
-                                "capacity": 1,
+                                "name": "GP_Gen5_2",
+                                "tier": "GeneralPurpose",
+                                "capacity": 2,
                                 "size": 5120,
                                 "family": "Gen5"
-                            }
+                            },
+                            "resources": [
+                                {
+                                    "type": "virtualNetworkRules",
+                                    "apiVersion": "2017-12-01",
+                                    "name": "vnetrule-participant-records-dev",
+                                    "dependsOn": [
+                                        "[resourceId('Microsoft.DBforPostgreSQL/servers/', parameters('serverName'))]"
+                                    ],
+                                    "properties": {
+                                        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]",
+                                        "ignoreMissingVnetServiceEndpoint": true
+                                    }
+                                }
+                            ]
                         },
                         {
                             "type": "Microsoft.DBforPostgreSQL/servers/firewallRules",
@@ -155,6 +223,12 @@
                             },
                             "secretName": "[parameters('secretName')]"
                         }
+                    },
+                    "vnetName": {
+                        "value": "[parameters('vnetName')]"
+                    },
+                    "subnetName": {
+                        "value": "[parameters('subnetName')]"
                     }
                 }
             }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -29,6 +29,10 @@ set_constants () {
   # Name of PostgreSQL server
   PG_SERVER_NAME=participant-records
 
+  # Names of participant records database Vnet and Subnet
+  VNET_NAME=$PREFIX-vnet-$PG_SERVER_NAME-$ENV
+  SUBNET_NAME=$PREFIX-snet-$PG_SERVER_NAME-$ENV
+
   # Base name of query tool app
   QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
   QUERY_TOOL_FRONTDOOR_NAME=querytool
@@ -147,7 +151,9 @@ main () {
       serverName=$PG_SERVER_NAME \
       secretName=$PG_SECRET_NAME \
       vaultName=$VAULT_NAME \
-      resourceTags="$RESOURCE_TAGS"
+      resourceTags="$RESOURCE_TAGS" \
+      vnetName=$VNET_NAME \
+      subnetName=$SUBNET_NAME
 
   # The AD admin can't be specified in the PostgreSQL ARM template,
   # unlike in Azure SQL


### PR DESCRIPTION
Addresses #11 

See Comments on #11. Adding vnet rules required upgrading the database from Basic to GeneralPurpose tier. In order to upgrade, I had to drop and recreate the database server resource. 

I'm still not sure how the current firewall rules (Azure and GSA networks only) relate to the vnet/subnet. 

Todo:
- [x] incorporate vnet and subnet info into top-level iac