### PR TITLE
Update Azure.Core dependency and add query-tool to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,3 +74,13 @@ updates:
     interval: daily
     time: "09:00"
   open-pull-requests-limit: 10
+- package-ecosystem: nuget
+  directory: "/query-tool/src/Piipan.QueryTool"
+  schedule:
+    interval: daily
+    time: "09:00"
+- package-ecosystem: nuget
+  directory: "/query-tool/tests/Piipan.QueryTool.Tests"
+  schedule:
+    interval: daily
+    time: "09:00"

--- a/match/src/Piipan.Match.Orchestrator/packages.lock.json
+++ b/match/src/Piipan.Match.Orchestrator/packages.lock.json
@@ -53,8 +53,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.11.0",
-        "contentHash": "yzA3cdN69MNr+UsPxg5R/11JYXi7N4aCNlUqBA03hRVCwIp4tdrEbujKKYSj2j/9yGGrKYKTOSWgw9Z2kihswQ==",
+        "resolved": "1.12.0",
+        "contentHash": "ugGtSfCu6dk3+qnYKsl10ImutPD8OKWwmtKHMeUi//rK5XHC4HDVouyhepB9OTB4DV0O4uKnUknXP30cSZtfhg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.0",
@@ -1582,7 +1582,7 @@
       "piipan.shared": {
         "type": "Project",
         "dependencies": {
-          "Azure.Core": "1.11.0",
+          "Azure.Core": "1.12.0",
           "Azure.Identity": "1.3.0"
         }
       }

--- a/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
@@ -53,8 +53,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.11.0",
-        "contentHash": "yzA3cdN69MNr+UsPxg5R/11JYXi7N4aCNlUqBA03hRVCwIp4tdrEbujKKYSj2j/9yGGrKYKTOSWgw9Z2kihswQ==",
+        "resolved": "1.12.0",
+        "contentHash": "ugGtSfCu6dk3+qnYKsl10ImutPD8OKWwmtKHMeUi//rK5XHC4HDVouyhepB9OTB4DV0O4uKnUknXP30cSZtfhg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.0",
@@ -1810,7 +1810,7 @@
       "piipan.shared": {
         "type": "Project",
         "dependencies": {
-          "Azure.Core": "1.11.0",
+          "Azure.Core": "1.12.0",
           "Azure.Identity": "1.3.0"
         }
       }

--- a/query-tool/src/Piipan.QueryTool/packages.lock.json
+++ b/query-tool/src/Piipan.QueryTool/packages.lock.json
@@ -10,8 +10,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.11.0",
-        "contentHash": "yzA3cdN69MNr+UsPxg5R/11JYXi7N4aCNlUqBA03hRVCwIp4tdrEbujKKYSj2j/9yGGrKYKTOSWgw9Z2kihswQ==",
+        "resolved": "1.12.0",
+        "contentHash": "ugGtSfCu6dk3+qnYKsl10ImutPD8OKWwmtKHMeUi//rK5XHC4HDVouyhepB9OTB4DV0O4uKnUknXP30cSZtfhg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.0",
@@ -97,7 +97,7 @@
       "piipan.shared": {
         "type": "Project",
         "dependencies": {
-          "Azure.Core": "1.11.0",
+          "Azure.Core": "1.12.0",
           "Azure.Identity": "1.3.0"
         }
       }

--- a/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
+++ b/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
@@ -53,8 +53,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.11.0",
-        "contentHash": "yzA3cdN69MNr+UsPxg5R/11JYXi7N4aCNlUqBA03hRVCwIp4tdrEbujKKYSj2j/9yGGrKYKTOSWgw9Z2kihswQ==",
+        "resolved": "1.12.0",
+        "contentHash": "ugGtSfCu6dk3+qnYKsl10ImutPD8OKWwmtKHMeUi//rK5XHC4HDVouyhepB9OTB4DV0O4uKnUknXP30cSZtfhg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.0",
@@ -1293,7 +1293,7 @@
       "piipan.shared": {
         "type": "Project",
         "dependencies": {
-          "Azure.Core": "1.11.0",
+          "Azure.Core": "1.12.0",
           "Azure.Identity": "1.3.0"
         }
       }

--- a/shared/src/Piipan.Shared/Piipan.Shared.csproj
+++ b/shared/src/Piipan.Shared/Piipan.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.11.0" />
+    <PackageReference Include="Azure.Core" Version="1.12.0" />
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
   </ItemGroup>
 

--- a/shared/src/Piipan.Shared/packages.lock.json
+++ b/shared/src/Piipan.Shared/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "Azure.Core": {
         "type": "Direct",
-        "requested": "[1.11.0, )",
-        "resolved": "1.11.0",
-        "contentHash": "yzA3cdN69MNr+UsPxg5R/11JYXi7N4aCNlUqBA03hRVCwIp4tdrEbujKKYSj2j/9yGGrKYKTOSWgw9Z2kihswQ==",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "ugGtSfCu6dk3+qnYKsl10ImutPD8OKWwmtKHMeUi//rK5XHC4HDVouyhepB9OTB4DV0O4uKnUknXP30cSZtfhg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.0",

--- a/shared/tests/Piipan.Shared.Tests/Piipan.Shared.Tests.csproj
+++ b/shared/tests/Piipan.Shared.Tests/Piipan.Shared.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.11.0" />
+    <PackageReference Include="Azure.Core" Version="1.12.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/shared/tests/Piipan.Shared.Tests/packages.lock.json
+++ b/shared/tests/Piipan.Shared.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "Azure.Core": {
         "type": "Direct",
-        "requested": "[1.11.0, )",
-        "resolved": "1.11.0",
-        "contentHash": "yzA3cdN69MNr+UsPxg5R/11JYXi7N4aCNlUqBA03hRVCwIp4tdrEbujKKYSj2j/9yGGrKYKTOSWgw9Z2kihswQ==",
+        "requested": "[1.12.0, )",
+        "resolved": "1.12.0",
+        "contentHash": "ugGtSfCu6dk3+qnYKsl10ImutPD8OKWwmtKHMeUi//rK5XHC4HDVouyhepB9OTB4DV0O4uKnUknXP30cSZtfhg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.0",
@@ -1706,7 +1706,7 @@
       "piipan.shared": {
         "type": "Project",
         "dependencies": {
-          "Azure.Core": "1.11.0",
+          "Azure.Core": "1.12.0",
           "Azure.Identity": "1.3.0"
         }
       }


### PR DESCRIPTION
When updating the Azure.Core dependency the projects in `query-tool` were updated despite not being in the list of projects flagged by dependabot's PRs. They were missed because the paths were not in the dependabot config.

This adds the paths to the config and updates Azure.Core in all projects.

Reference: [Updating .NET dependencies](https://github.com/18F/piipan/blob/main/docs/update-deps.md)
