### PR TITLE
Switch to randomly generated lookup ID

### DIFF
--- a/match/src/Piipan.Match.Orchestrator/Api.cs
+++ b/match/src/Piipan.Match.Orchestrator/Api.cs
@@ -63,7 +63,7 @@ namespace Piipan.Match.Orchestrator
 
                 if (response.Matches.Count > 0)
                 {
-                    response.LookupId = LookupId.Generate(request.Query.ToJson());
+                    response.LookupId = LookupId.Generate();
                 }
             }
             catch (Exception ex)

--- a/match/src/Piipan.Match.Orchestrator/Lookup.cs
+++ b/match/src/Piipan.Match.Orchestrator/Lookup.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Security.Cryptography;
-using System.Text;
-
 namespace Piipan.Match.Orchestrator
 {
     static class LookupId
@@ -10,29 +6,13 @@ namespace Piipan.Match.Orchestrator
         private const int Length = 7;
 
         /// <summary>
-        /// Generate a deterministic alphanumeric ID from a given string.
-        /// IDs are encoded using a limited alphabet and fixed length.
+        /// Generate a random alphanumeric ID that conforms to a limited alphabet
+        /// limited alphabet and fixed length.
         /// </summary>
-        /// <param name="value">The string value used to generate the ID</param>
-        /// <returns>An alpha-numeric ID string</returns>
-        public static string Generate(string value)
+        /// <returns>A random 7-character alpha-numeric ID string</returns>
+        public static string Generate()
         {
-            var idString = new StringBuilder();
-            var md5 = MD5.Create();
-            var hashBytes = md5.ComputeHash(Encoding.UTF8.GetBytes(value));
-
-            // Only keep the first 32-bits from the 128-bit hash so as to fit into 7 encoded characters (29^7 > 2^32)
-            long hashInt = BitConverter.ToUInt32(hashBytes, 0);
-
-            // Encode using custom alphabet
-            do
-            {
-                idString.Insert(0, Chars[(int)(hashInt % Chars.Length)]);
-                hashInt = (long)(hashInt / Chars.Length);
-            } while (hashInt > 0);
-
-            // Returned IDs should always be `Length` length
-            return idString.ToString().PadLeft(Length, Chars[0]);
+            return Nanoid.Nanoid.Generate(Chars, Length);
         }
     }
 }

--- a/match/src/Piipan.Match.Orchestrator/Piipan.Match.Orchestrator.csproj
+++ b/match/src/Piipan.Match.Orchestrator/Piipan.Match.Orchestrator.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.13" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Nanoid" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
   </ItemGroup>
   <ItemGroup>

--- a/match/src/Piipan.Match.Orchestrator/packages.lock.json
+++ b/match/src/Piipan.Match.Orchestrator/packages.lock.json
@@ -42,6 +42,12 @@
           "Newtonsoft.Json": "11.0.2"
         }
       },
+      "Nanoid": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "V0eSnsq+Oeqf9uVPBH02kYE5p92s6Revskt4Cmqg3DIsiDoqrKKdlmqXvaFaehO3pS1Osu9BTtl3lMSRqPlbzw=="
+      },
       "Newtonsoft.Json.Schema": {
         "type": "Direct",
         "requested": "[3.0.14, )",

--- a/match/tests/Piipan.Match.Orchestrator.Tests/LookupTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/LookupTests.cs
@@ -1,62 +1,28 @@
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace Piipan.Match.Orchestrator.Tests
 {
     public class LookupTests
     {
-        const string json = "{last: 'Last', first: 'First', middle: 'Middle', dob: '2020-01-01', ssn: '000-00-0000'}";
-        const string json2 = "{last: 'last', first: 'first', middle: 'middle', dob: '2021-01-01', ssn: '000-11-1111'}";
 
         [Fact]
-        public void Deterministic()
+        public void LookupIdConformsToLength()
         {
-            var str = json;
-            var id = LookupId.Generate(str);
-
-            Assert.Equal(id, LookupId.Generate(str));
-        }
-
-        [Theory]
-        [InlineData(json)]
-        [InlineData(json2)]
-        [InlineData("ABC123")]
-        [InlineData("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")]
-        public void ConformsToLength(string value)
-        {
-            var id = LookupId.Generate(value);
+            var id = LookupId.Generate();
 
             Assert.Equal(7, id.Length);
         }
 
-        [Theory]
-        [InlineData(json)]
-        [InlineData(json2)]
-        [InlineData("ABC123")]
-        [InlineData("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")]
-        public void ConformsToAlphabet(string value)
+        [Fact]
+        public void LookupIdConformsToAlphabet()
         {
             var disallowed = "01AEIOUabcdefghijklmnopqrstuvwxyz";
-            var id = LookupId.Generate(value);
+            var id = LookupId.Generate();
 
             foreach (char c in disallowed)
             {
                 Assert.False(id.Contains(c));
             }
-        }
-
-        [Fact]
-        public void Collisions()
-        {
-            var ids = new List<string>{
-                LookupId.Generate(json),
-                LookupId.Generate(json + " "),
-                LookupId.Generate(json2),
-                LookupId.Generate(json2 + " ")
-            };
-
-            Assert.Equal(ids.Distinct().Count(), ids.Count);
         }
     }
 }

--- a/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/packages.lock.json
@@ -669,6 +669,11 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "Nanoid": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "V0eSnsq+Oeqf9uVPBH02kYE5p92s6Revskt4Cmqg3DIsiDoqrKKdlmqXvaFaehO3pS1Osu9BTtl3lMSRqPlbzw=="
+      },
       "ncrontab.signed": {
         "type": "Transitive",
         "resolved": "3.3.0",
@@ -1803,6 +1808,7 @@
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
           "Microsoft.Extensions.Http": "3.1.13",
           "Microsoft.NET.Sdk.Functions": "3.0.11",
+          "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
           "Piipan.Shared": "1.0.0"
         }


### PR DESCRIPTION
Per conversation in #604, switches lookup ID to be a randomly generated 7-character string that conforms to our custom alphabet.

Uses the C# implementation of Nanoid (a popular [JavaScript tool](https://www.npmjs.com/package/nanoid)).