### PR TITLE
Update per-state APIs to ignore middle name when performing match

### DIFF
--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -96,11 +96,9 @@ namespace Piipan.Match.State
                 dob = request.Query.Dob,
                 last = request.Query.Last,
                 first = request.Query.First,
-                middle = request.Query.Middle
             };
             var sql = "SELECT upload_id, first, last, middle, dob, ssn, exception FROM participants " +
                         "WHERE ssn=@ssn AND dob=@dob AND last=@last AND first=@first " +
-                        "AND " + (p.middle == null ? "middle IS NULL" : "middle=@middle") + " " +
                         "AND upload_id=(SELECT id FROM uploads WHERE created_at = (SELECT MAX(created_at) FROM uploads))";
 
             return (sql, p);

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -225,22 +225,6 @@ namespace Piipan.Match.State.Tests
             Assert.Equal(bodyFormatted, request.ToJson());
         }
 
-        // SQL contains null
-        [Fact]
-        public void SqlHasIsNullCondition()
-        {
-            // Arrange
-            var body = JsonBody(@"{last:'Last', first: 'First', dob: '1970-01-01', ssn: '000-00-0000'}");
-            var logger = Mock.Of<ILogger>();
-
-            // Act
-            MatchQueryRequest request = Api.Parse(body, logger);
-            (var sql, var parameters) = Api.Prepare(request, logger);
-
-            // Assert
-            Assert.Contains("middle IS NULL", sql);
-        }
-
         // SQL contains strings
         [Fact]
         public void SqlHasEqualCondition()
@@ -254,7 +238,6 @@ namespace Piipan.Match.State.Tests
             (var sql, var parameters) = Api.Prepare(request, logger);
 
             // Assert
-            Assert.Contains("middle=@middle", sql);
             Assert.Contains("first=@first", sql);
         }
 


### PR DESCRIPTION
Updates per-state APIs to ignore middle name when performing match.

To test, follow the [directions to use the duplicate participation API](https://github.com/18F/piipan/blob/main/match/docs/duplicate-participation-api.md#calling-the-api) or submit a request directly to the [orchestrator API](https://github.com/18F/piipan/blob/main/match/docs/orchestrator-match.md#remote-testing). Example.csv has been uploaded to each state with a varying middle name for the `Lynn,Wesley,Eura,8/01/1940,000-12-3457,` row. Submitting a request for, for example:
```
{
    "query": {
        "last": "Lynn",
        "dob": "1940-08-01",
        "ssn": "000-12-3457",
        "first": "Wesley",
        "middle": "E"
    }
}
```

Should return the following results (note the differing `middle` property):

```
{
    "lookup_id": "...",
    "matches": [
        {
            "last": "Lynn",
            "first": "Wesley",
            "middle": null,
            "ssn": "000-12-3457",
            "dob": "1940-08-01",
            "exception": null,
            "state_name": "Echo Alpha",
            "state_abbr": "ea"
        },
        {
            "last": "Lynn",
            "first": "Wesley",
            "middle": "Eura",
            "ssn": "000-12-3457",
            "dob": "1940-08-01",
            "exception": null,
            "state_name": "Echo Bravo",
            "state_abbr": "eb"
        },
        {
            "last": "Lynn",
            "first": "Wesley",
            "middle": "E",
            "ssn": "000-12-3457",
            "dob": "1940-08-01",
            "exception": null,
            "state_name": "Echo Charlie",
            "state_abbr": "ec"
        }
    ]
}
```

Closes #550