### PR TITLE
Add lookup ID display and search to Query Tool

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -510,12 +510,12 @@ main () {
   echo "Front Door iD: ${front_door_id}"
 
   orch_api_uri=$(\
-    az functionapp function show \
+    az functionapp show \
       -g $MATCH_RESOURCE_GROUP \
       -n $orch_name \
-      --function-name Query \
-      --query invokeUrlTemplate \
+      --query defaultHostName \
       -o tsv)
+  orch_api_uri="https://${orch_api_uri}/api/v1/"
 
   az deployment group create \
     --name $QUERY_TOOL_APP_NAME \

--- a/query-tool/src/Piipan.QueryTool/IQueryable.cs
+++ b/query-tool/src/Piipan.QueryTool/IQueryable.cs
@@ -1,0 +1,11 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Piipan.QueryTool
+{
+    public interface IQueryable
+    {
+        string LookupId { get; set; }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool/Lookup.cs
+++ b/query-tool/src/Piipan.QueryTool/Lookup.cs
@@ -8,7 +8,7 @@ namespace Piipan.QueryTool
     {
         [Required]
         [Display(Name = "Lookup ID")]
-        [JsonPropertyName("lookupId")]
+        [JsonPropertyName("lookup_id")]
         public string LookupId { get; set; }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Lookup.cs
+++ b/query-tool/src/Piipan.QueryTool/Lookup.cs
@@ -1,0 +1,14 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Piipan.QueryTool
+{
+    public class Lookup : IQueryable
+    {
+        [Required]
+        [Display(Name = "Lookup ID")]
+        [JsonPropertyName("lookupId")]
+        public string LookupId { get; set; }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
+++ b/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
@@ -20,10 +20,10 @@ namespace Piipan.QueryTool
         }
 
         public string RequestUrl;
-        public Dictionary<string, PiiRecord> Query = new Dictionary<string, PiiRecord>();
+        public Dictionary<string, IQueryable> Query = new Dictionary<string, IQueryable>();
         private readonly IAuthorizedApiClient _apiClient;
 
-        public async Task<List<PiiRecord>> SendQuery(string url, PiiRecord query)
+        public async Task<List<PiiRecord>> SendQuery(string url, IQueryable query)
         {
             RequestUrl = url;
             Query.Add("query", query);

--- a/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
+++ b/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
@@ -20,13 +20,18 @@ namespace Piipan.QueryTool
         }
 
         public string RequestUrl;
-        public Dictionary<string, IQueryable> Query = new Dictionary<string, IQueryable>();
+        public Dictionary<string, object> Query = new Dictionary<string, object>();
         private readonly IAuthorizedApiClient _apiClient;
 
         public async Task<List<PiiRecord>> SendQuery(string url, IQueryable query)
         {
             RequestUrl = url;
-            Query.Add("query", query);
+
+            if (query is PiiRecord) {
+                Query.Add("query", query as PiiRecord);
+            } else if (query is Lookup) {
+                Query.Add("query", query as Lookup);
+            }
             return await QueryOrchestrator();
         }
 

--- a/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
+++ b/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
@@ -20,16 +20,19 @@ namespace Piipan.QueryTool
         }
 
         public string RequestUrl;
-        public Dictionary<string, object> Query = new Dictionary<string, object>();
+        public Dictionary<string, IQueryable> Query = new Dictionary<string, IQueryable>();
         private readonly IAuthorizedApiClient _apiClient;
 
         public async Task<List<PiiRecord>> SendQuery(string url, IQueryable query)
         {
             RequestUrl = url;
 
-            if (query is PiiRecord) {
+            if (query is PiiRecord)
+            {
                 Query.Add("query", query as PiiRecord);
-            } else if (query is Lookup) {
+            }
+            else if (query is Lookup)
+            {
                 Query.Add("query", query as Lookup);
             }
             return await QueryOrchestrator();

--- a/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
+++ b/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
@@ -23,50 +23,111 @@ namespace Piipan.QueryTool
         public Dictionary<string, IQueryable> Query = new Dictionary<string, IQueryable>();
         private readonly IAuthorizedApiClient _apiClient;
 
-        public async Task<List<PiiRecord>> SendQuery(string url, IQueryable query)
+        public async Task<Dictionary<string, object>> SendQuery(string url, Lookup query)
         {
             RequestUrl = url;
             Query.Add("query", query);
             return await QueryOrchestrator();
         }
 
-        public List<PiiRecord> Matches { get; private set; }
+        public async Task<Dictionary<string, object>> SendQuery(string url, PiiRecord query)
+        {
+            RequestUrl = url;
+            Query.Add("query", query);
+            return await QueryOrchestrator();
+        }
 
-        private async Task<List<PiiRecord>> QueryOrchestrator()
+        public Dictionary<string, object> ResponseDict { get; private set; }
+
+        private async Task<Dictionary<string, object>> QueryOrchestrator()
         {
             try
             {
                 _logger.LogInformation("Querying Orchestrator API");
-                var requestUri = new Uri(RequestUrl);
-                var jsonString = JsonSerializer.Serialize(Query);
-                var requestBody = new StringContent(jsonString, Encoding.UTF8, "application/json");
-                HttpResponseMessage resp = null;
 
                 if (Query["query"] is Lookup)
                 {
-                    var lookup = Query["query"] as Lookup;
-                    requestUri = new Uri(requestUri, $"lookup_ids/{lookup.LookupId}");
-                    resp = await _apiClient.GetAsync(requestUri);
+                    List<PiiRecord> matches;
+                    matches = await SendLookupIdQuery();
+                    ResponseDict.Add("matches", matches);
                 }
                 else if (Query["query"] is PiiRecord)
                 {
-                    resp = await _apiClient.PostAsync(requestUri, requestBody);
+                    ResponseDict = await SendPiiQuery();
                 }
-
-                var streamTask = await resp.Content.ReadAsStreamAsync();
-                var json = await JsonSerializer.DeserializeAsync<OrchestratorApiResponse>(streamTask);
-                Matches = json.matches;
             }
             catch (Exception exception)
             {
                 _logger.LogError(exception, exception.Message);
             }
+            return ResponseDict;
+        }
+
+        private async Task<List<PiiRecord>> SendLookupIdQuery()
+        {
+            List<PiiRecord> Matches = new List<PiiRecord>();
+
+            try
+            {
+                _logger.LogInformation("Sending LookupID query");
+                var requestUri = new Uri(RequestUrl);
+                var jsonString = JsonSerializer.Serialize(Query);
+                Console.WriteLine(jsonString);
+                var lookup = Query["query"] as Lookup;
+                requestUri = new Uri(requestUri, $"lookup_ids/{lookup.LookupId}");
+                var resp = await _apiClient.GetAsync(requestUri);
+                Console.WriteLine(resp.ToString());
+                Console.WriteLine(resp.Content.ReadAsStringAsync().Result);
+                var content = await resp.Content.ReadAsStringAsync();
+                var streamTask = await resp.Content.ReadAsStreamAsync();
+                var json = await JsonSerializer.DeserializeAsync<LookupApiResponse>(streamTask);
+                Console.WriteLine(json);
+                if (json.data != null)
+                {
+                    Matches.Add(json.data);
+                }
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, exception.Message);
+            }
+
             return Matches;
+        }
+
+        private async Task<Dictionary<string, object>> SendPiiQuery()
+        {
+            Dictionary<string, object> Response = new Dictionary<string, object>();
+
+            try
+            {
+                _logger.LogInformation("Sending PII-based query");
+                var requestUri = new Uri(RequestUrl);
+                var jsonString = JsonSerializer.Serialize(Query);
+                var requestBody = new StringContent(jsonString, Encoding.UTF8, "application/json");
+                var resp = await _apiClient.PostAsync(requestUri, requestBody);
+                var streamTask = await resp.Content.ReadAsStreamAsync();
+                var json = await JsonSerializer.DeserializeAsync<PiiApiResponse>(streamTask);
+                Response.Add("matches", json.matches);
+                Response.Add("lookupId", json.lookupId);
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, exception.Message);
+            }
+
+            return Response;
         }
     }
 
-    public class OrchestratorApiResponse
+    public class PiiApiResponse
     {
+        public virtual string lookupId { get; set; }
         public virtual List<PiiRecord> matches { get; set; }
+    }
+
+    public class LookupApiResponse
+    {
+        public virtual PiiRecord data { get; set; }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
+++ b/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Piipan.Shared.Authentication;
@@ -12,122 +12,61 @@ namespace Piipan.QueryTool
     public class OrchestratorApiRequest
     {
         private readonly ILogger _logger;
+        private readonly IAuthorizedApiClient _apiClient;
+        private readonly Uri _baseUri;
 
-        public OrchestratorApiRequest(IAuthorizedApiClient apiClient, ILogger logger)
+        public OrchestratorApiRequest(IAuthorizedApiClient apiClient, Uri baseUri, ILogger logger)
         {
             _apiClient = apiClient;
+            _baseUri = baseUri;
             _logger = logger;
         }
 
-        public string RequestUrl;
-        public Dictionary<string, IQueryable> Query = new Dictionary<string, IQueryable>();
-        private readonly IAuthorizedApiClient _apiClient;
-
-        public async Task<Dictionary<string, object>> SendQuery(string url, Lookup query)
+        public async Task<MatchResponse> Match(PiiRecord query)
         {
-            RequestUrl = url;
-            Query.Add("query", query);
-            return await QueryOrchestrator();
+            const string Endpoint = "query";
+
+            var request = new MatchRequest { Query = query };
+            var json = JsonSerializer.Serialize(request);
+            var response = await _apiClient.PostAsync(
+                new Uri(_baseUri, Endpoint),
+                new StringContent(json)
+            );
+
+            response.EnsureSuccessStatusCode();
+
+            var matchJson = await response.Content.ReadAsStringAsync();
+            var matchResponse = JsonSerializer.Deserialize<MatchResponse>(matchJson);
+
+            return matchResponse;
         }
 
-        public async Task<Dictionary<string, object>> SendQuery(string url, PiiRecord query)
+        public async Task<LookupResponse> Lookup(string lookupId)
         {
-            RequestUrl = url;
-            Query.Add("query", query);
-            return await QueryOrchestrator();
-        }
+            const string Endpoint = "lookup_ids";
 
-        public Dictionary<string, object> ResponseDict { get; private set; }
+            var uri = new Uri(_baseUri, $"{Endpoint}/{lookupId}");
+            var response = await _apiClient.GetAsync(uri);
 
-        private async Task<Dictionary<string, object>> QueryOrchestrator()
-        {
-            try
-            {
-                _logger.LogInformation("Querying Orchestrator API");
+            response.EnsureSuccessStatusCode();
 
-                if (Query["query"] is Lookup)
-                {
-                    List<PiiRecord> matches;
-                    matches = await SendLookupIdQuery();
-                    ResponseDict.Add("matches", matches);
-                }
-                else if (Query["query"] is PiiRecord)
-                {
-                    ResponseDict = await SendPiiQuery();
-                }
-            }
-            catch (Exception exception)
-            {
-                _logger.LogError(exception, exception.Message);
-            }
-            return ResponseDict;
-        }
+            var lookupJson = await response.Content.ReadAsStringAsync();
+            var lookupResponse = JsonSerializer.Deserialize<LookupResponse>(lookupJson);
 
-        private async Task<List<PiiRecord>> SendLookupIdQuery()
-        {
-            List<PiiRecord> Matches = new List<PiiRecord>();
-
-            try
-            {
-                _logger.LogInformation("Sending LookupID query");
-                var requestUri = new Uri(RequestUrl);
-                var jsonString = JsonSerializer.Serialize(Query);
-                Console.WriteLine(jsonString);
-                var lookup = Query["query"] as Lookup;
-                requestUri = new Uri(requestUri, $"lookup_ids/{lookup.LookupId}");
-                var resp = await _apiClient.GetAsync(requestUri);
-                Console.WriteLine(resp.ToString());
-                Console.WriteLine(resp.Content.ReadAsStringAsync().Result);
-                var content = await resp.Content.ReadAsStringAsync();
-                var streamTask = await resp.Content.ReadAsStreamAsync();
-                var json = await JsonSerializer.DeserializeAsync<LookupApiResponse>(streamTask);
-                Console.WriteLine(json);
-                if (json.data != null)
-                {
-                    Matches.Add(json.data);
-                }
-            }
-            catch (Exception exception)
-            {
-                _logger.LogError(exception, exception.Message);
-            }
-
-            return Matches;
-        }
-
-        private async Task<Dictionary<string, object>> SendPiiQuery()
-        {
-            Dictionary<string, object> Response = new Dictionary<string, object>();
-
-            try
-            {
-                _logger.LogInformation("Sending PII-based query");
-                var requestUri = new Uri(RequestUrl);
-                var jsonString = JsonSerializer.Serialize(Query);
-                var requestBody = new StringContent(jsonString, Encoding.UTF8, "application/json");
-                var resp = await _apiClient.PostAsync(requestUri, requestBody);
-                var streamTask = await resp.Content.ReadAsStreamAsync();
-                var json = await JsonSerializer.DeserializeAsync<PiiApiResponse>(streamTask);
-                Response.Add("matches", json.matches);
-                Response.Add("lookupId", json.lookupId);
-            }
-            catch (Exception exception)
-            {
-                _logger.LogError(exception, exception.Message);
-            }
-
-            return Response;
+            return lookupResponse;
         }
     }
 
-    public class PiiApiResponse
+    public class MatchResponse
     {
+        [JsonPropertyName("lookup_id")]
         public virtual string lookupId { get; set; }
         public virtual List<PiiRecord> matches { get; set; }
     }
 
-    public class LookupApiResponse
+    public class LookupResponse
     {
+        [JsonPropertyName("data")]
         public virtual PiiRecord data { get; set; }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
@@ -54,30 +54,5 @@
             <input class="usa-button" type="submit" value="Submit" />
         </fieldset>
     </form>
-    @if (Model.QueryResult != null && Model.QueryResult.Any())
-    {
-        <h2>Results</h2>
-        <table class="usa-table">
-            <thead>
-                <tr>
-                    <th scope="col">Name</th>
-                    <th scope="col">DOB</th>
-                    <th scope="col">SSN</th>
-                    <th scope="col">State</th>
-                </tr>
-            </thead>
-            <tbody>
-        @foreach (var record in @Model.QueryResult)
-            {
-                <tr>
-                    <td>@record.FirstName @record.MiddleName @record.LastName</td>
-                    <td>@record.DateOfBirth</td>
-                    <td>@record.SocialSecurityNum</td>
-                    <td>@record.StateName</td>
-                </tr>
-            }
-            </tbody>
-        </table>
-    }
-
+    <partial name="_ResultsTable" model="Model.QueryResult"/>
 </div>

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
@@ -8,20 +8,21 @@
     <h2>@Model.Title</h2>
     <form asp-page="Index" class="usa-form">
         <fieldset class="usa-fieldset">
-            @if (!string.IsNullOrEmpty(Model.RequestError)) {
-                    <div class="usa-alert usa-alert--error usa-alert--slim">
-                        <div class="usa-alert__body">
-                            <p class="usa-alert__text">@Model.RequestError</p>
-                        </div>
+            @if (!string.IsNullOrEmpty(Model.RequestError))
+            {
+                <div class="usa-alert usa-alert--error usa-alert--slim">
+                    <div class="usa-alert__body">
+                        <p class="usa-alert__text">@Model.RequestError</p>
                     </div>
+                </div>
             }
             else if (Model.NoResults)
             {
-                    <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--validation">
-                        <div class="usa-alert__body">
-                            <p class="usa-alert__text">Your search did not return any results.</p>
-                        </div>
+                <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--validation">
+                    <div class="usa-alert__body">
+                        <p class="usa-alert__text">Your search did not return any results.</p>
                     </div>
+                </div>
             }
 
             @if (!ViewData.ModelState.IsValid)
@@ -54,5 +55,5 @@
             <input class="usa-button" type="submit" value="Submit" />
         </fieldset>
     </form>
-    <partial name="_ResultsTable" model="Model.Records"/>
+    <partial name="_ResultsTable" model="Model.QueryResult" />
 </div>

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
@@ -54,5 +54,5 @@
             <input class="usa-button" type="submit" value="Submit" />
         </fieldset>
     </form>
-    <partial name="_ResultsTable" model="Model.QueryResult"/>
+    <partial name="_ResultsTable" model="Model.Records"/>
 </div>

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -19,33 +18,28 @@ namespace Piipan.QueryTool.Pages
         {
             _logger = logger;
             _apiClient = apiClient;
-            _apiRequest = new OrchestratorApiRequest(_apiClient, _logger);
+            var apiBaseUri = new Uri(Environment.GetEnvironmentVariable("OrchApiUri"));
+            _apiRequest = new OrchestratorApiRequest(_apiClient, apiBaseUri, _logger);
         }
 
         [BindProperty]
         public PiiRecord Query { get; set; }
-
-        public Dictionary<string, object> QueryResult { get; private set; } = new Dictionary<string,object>();
-        public List<PiiRecord> Records { get; private set; }
-
+        public MatchResponse QueryResult { get; private set; }
         public String RequestError { get; private set; }
         public bool NoResults = false;
 
-        public async Task<IActionResult> OnPostAsync(PiiRecord query)
+        public async Task<IActionResult> OnPostAsync()
         {
             if (ModelState.IsValid)
             {
-                QueryResult = await _apiRequest.SendQuery(
-                    Environment.GetEnvironmentVariable("OrchApiUri"),
-                    query
-                );
-
                 try
                 {
                     _logger.LogInformation("Query form submitted");
-                    var matches = QueryResult["matches"] as List<PiiRecord>;
-                    NoResults = matches.Count == 0;
-                    Records = matches;
+
+                    MatchResponse result = await _apiRequest.Match(Query);
+
+                    QueryResult = result;
+                    NoResults = QueryResult.matches.Count == 0;
                     Title = "NAC Query Results";
                 }
                 catch (Exception exception)
@@ -54,6 +48,7 @@ namespace Piipan.QueryTool.Pages
                     RequestError = "There was an error running your search";
                 }
             }
+
             return Page();
         }
 

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -25,7 +25,9 @@ namespace Piipan.QueryTool.Pages
         [BindProperty]
         public PiiRecord Query { get; set; }
 
-        public List<PiiRecord> QueryResult { get; private set; } = new List<PiiRecord>();
+        public Dictionary<string, object> QueryResult { get; private set; } = new Dictionary<string,object>();
+        public List<PiiRecord> Records { get; private set; }
+
         public String RequestError { get; private set; }
         public bool NoResults = false;
 
@@ -41,7 +43,9 @@ namespace Piipan.QueryTool.Pages
                 try
                 {
                     _logger.LogInformation("Query form submitted");
-                    NoResults = QueryResult.Count == 0;
+                    var matches = QueryResult["matches"] as List<PiiRecord>;
+                    NoResults = matches.Count == 0;
+                    Records = matches;
                     Title = "NAC Query Results";
                 }
                 catch (Exception exception)

--- a/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
@@ -47,5 +47,5 @@
             <input class="usa-button" type="submit" value="Submit" />
         </fieldset>
     </form>
-    <partial name="_ResultsTable" model="Model.QueryResult" />
+    <partial name="_ResultsTable" model="Model.Records" />
 </div>

--- a/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
@@ -1,0 +1,50 @@
+@page
+@model LookupByIdModel
+
+@{
+    ViewData["Title"] = "NAC Query Tool";
+}
+<div class="grid-container">
+    <h2>@Model.Title</h2>
+    <form asp-page="Index" class="usa-form">
+        <fieldset class="usa-fieldset">
+            @if (!string.IsNullOrEmpty(Model.RequestError)) {
+                    <div class="usa-alert usa-alert--error usa-alert--slim">
+                        <div class="usa-alert__body">
+                            <p class="usa-alert__text">@Model.RequestError</p>
+                        </div>
+                    </div>
+            }
+            else if (Model.NoResults)
+            {
+                    <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--validation">
+                        <div class="usa-alert__body">
+                            <p class="usa-alert__text">Your search did not return any results.</p>
+                        </div>
+                    </div>
+            }
+
+            @if (!ViewData.ModelState.IsValid)
+            {
+                <div class="usa-alert usa-alert--error usa-alert--validation">
+                    <div class="usa-alert__body">
+                        <ul>
+                            @foreach (var modelState in ViewData.ModelState.Values)
+                            {
+                                @foreach (var error in modelState.Errors)
+                                {
+                                    <li>@error.ErrorMessage</li>
+                                }
+                            }
+                        </ul>
+                    </div>
+                </div>
+            }
+            <legend class="usa-legend">Search by Lookup ID</legend>
+            <label class="usa-label" asp-for="Query.LookupId"></label>
+            <input class="usa-input" type="text" asp-for="Query.LookupId" />
+            <input class="usa-button" type="submit" value="Submit" />
+        </fieldset>
+    </form>
+    <partial name="_ResultsTable" model="Model.QueryResult"/>
+</div>

--- a/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
@@ -47,5 +47,5 @@
             <input class="usa-button" type="submit" value="Submit" />
         </fieldset>
     </form>
-    <partial name="_ResultsTable" model="Model.Records" />
+    <partial name="_LookupResultTable" model="Model.Record" />
 </div>

--- a/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
@@ -8,20 +8,21 @@
     <h2>@Model.Title</h2>
     <form asp-page="LookupById" class="usa-form">
         <fieldset class="usa-fieldset">
-            @if (!string.IsNullOrEmpty(Model.RequestError)) {
-                    <div class="usa-alert usa-alert--error usa-alert--slim">
-                        <div class="usa-alert__body">
-                            <p class="usa-alert__text">@Model.RequestError</p>
-                        </div>
+            @if (!string.IsNullOrEmpty(Model.RequestError))
+            {
+                <div class="usa-alert usa-alert--error usa-alert--slim">
+                    <div class="usa-alert__body">
+                        <p class="usa-alert__text">@Model.RequestError</p>
                     </div>
+                </div>
             }
             else if (Model.NoResults)
             {
-                    <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--validation">
-                        <div class="usa-alert__body">
-                            <p class="usa-alert__text">Your search did not return any results.</p>
-                        </div>
+                <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--validation">
+                    <div class="usa-alert__body">
+                        <p class="usa-alert__text">Your search did not return any results.</p>
                     </div>
+                </div>
             }
 
             @if (!ViewData.ModelState.IsValid)
@@ -46,5 +47,5 @@
             <input class="usa-button" type="submit" value="Submit" />
         </fieldset>
     </form>
-    <partial name="_ResultsTable" model="Model.QueryResult"/>
+    <partial name="_ResultsTable" model="Model.QueryResult" />
 </div>

--- a/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml
@@ -6,7 +6,7 @@
 }
 <div class="grid-container">
     <h2>@Model.Title</h2>
-    <form asp-page="Index" class="usa-form">
+    <form asp-page="LookupById" class="usa-form">
         <fieldset class="usa-fieldset">
             @if (!string.IsNullOrEmpty(Model.RequestError)) {
                     <div class="usa-alert usa-alert--error usa-alert--slim">

--- a/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml.cs
@@ -25,7 +25,9 @@ namespace Piipan.QueryTool.Pages
         [BindProperty]
         public Lookup Query { get; set; }
 
-        public List<PiiRecord> QueryResult { get; private set; } = new List<PiiRecord>();
+        public Dictionary<string,object> QueryResult { get; private set; } = new Dictionary<string,object>();
+        public List<PiiRecord> Records { get; private set; }
+
         public String RequestError { get; private set; }
         public bool NoResults = false;
 
@@ -41,7 +43,9 @@ namespace Piipan.QueryTool.Pages
                 try
                 {
                     _logger.LogInformation("Query form submitted");
-                    NoResults = QueryResult.Count == 0;
+                    var matches = QueryResult["matches"] as List<PiiRecord>;
+                    NoResults = matches.Count == 0;
+                    Records = matches;
                     Title = "NAC Query Results";
                 }
                 catch (Exception exception)

--- a/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/LookupById.cshtml.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using Piipan.Shared.Authentication;
+
+namespace Piipan.QueryTool.Pages
+{
+    public class LookupByIdModel : PageModel
+    {
+        private readonly ILogger<LookupByIdModel> _logger;
+        private readonly IAuthorizedApiClient _apiClient;
+        private readonly OrchestratorApiRequest _apiRequest;
+
+        public LookupByIdModel(ILogger<LookupByIdModel> logger,
+                          IAuthorizedApiClient apiClient)
+        {
+            _logger = logger;
+            _apiClient = apiClient;
+            _apiRequest = new OrchestratorApiRequest(_apiClient, _logger);
+        }
+
+        [BindProperty]
+        public Lookup Query { get; set; }
+
+        public List<PiiRecord> QueryResult { get; private set; } = new List<PiiRecord>();
+        public String RequestError { get; private set; }
+        public bool NoResults = false;
+
+        public async Task<IActionResult> OnPostAsync(Lookup query)
+        {
+            if (ModelState.IsValid)
+            {
+                QueryResult = await _apiRequest.SendQuery(
+                    Environment.GetEnvironmentVariable("OrchApiUri"),
+                    query
+                );
+
+                try
+                {
+                    _logger.LogInformation("Query form submitted");
+                    NoResults = QueryResult.Count == 0;
+                    Title = "NAC Query Results";
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogError(exception, exception.Message);
+                    RequestError = "There was an error running your search";
+                }
+            }
+            return Page();
+        }
+
+        public string Title { get; private set; } = "";
+
+        public void OnGet()
+        {
+            Title = "NAC Query Tool";
+        }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_LookupResultTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_LookupResultTable.cshtml
@@ -1,0 +1,25 @@
+@model LookupResponse
+@if (Model != null && Model.data != null)
+{
+    <h2>Result</h2>
+    <table class="usa-table">
+    <thead>
+        <tr>
+            <th scope="col">First name</th>
+            <th scope="col">Middle name</th>
+            <th scope="col">Last name</th>
+            <th scope="col">DOB</th>
+            <th scope="col">SSN</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>@Model.data.FirstName</td>
+            <td>@Model.data.MiddleName</td>
+            <td>@Model.data.LastName</td>
+            <td>@Model.data.DateOfBirth</td>
+            <td>@Model.data.SocialSecurityNum</td>
+        </tr>
+    </tbody>
+</table>
+}

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -1,28 +1,26 @@
 @model List<PiiRecord>
 @if (Model != null && Model.Any())
 {
-      <h2>Results</h2>
-      <table class="usa-table">
-          <thead>
-              <tr>
-                  <th scope="col">Name</th>
-                  <th scope="col">DOB</th>
-                  <th scope="col">SSN</th>
-                  <th scope="col">State</th>
-                  <th scope="col">Lookup ID</th>
-              </tr>
-          </thead>
-          <tbody>
+    <h2>Results</h2>
+    <table class="usa-table">
+    <thead>
+        <tr>
+            <th scope="col">Name</th>
+            <th scope="col">DOB</th>
+            <th scope="col">SSN</th>
+            <th scope="col">State</th>
+        </tr>
+    </thead>
+    <tbody>
         @foreach (var record in @Model)
-      {
-              <tr>
-                  <td>@record.FirstName @record.MiddleName @record.LastName</td>
-                  <td>@record.DateOfBirth</td>
-                  <td>@record.SocialSecurityNum</td>
-                  <td>@record.StateName</td>
-                  <td>@record.LookupId</td>
-              </tr>
-      }
-          </tbody>
-      </table>
+            {
+                <tr>
+                    <td>@record.FirstName @record.MiddleName @record.LastName</td>
+                    <td>@record.DateOfBirth</td>
+                    <td>@record.SocialSecurityNum</td>
+                    <td>@record.StateName</td>
+                </tr>
+            }
+        </tbody>
+    </table>
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -1,8 +1,9 @@
-@model List<PiiRecord>
-@if (Model != null && Model.Any())
+@model MatchResponse
+@if (Model != null && Model.matches.Any())
 {
     <h2>Results</h2>
     <table class="usa-table">
+    <caption>Lookup ID: @Model.lookupId</caption>
     <thead>
         <tr>
             <th scope="col">Name</th>
@@ -12,7 +13,7 @@
         </tr>
     </thead>
     <tbody>
-        @foreach (var record in @Model)
+        @foreach (var record in @Model.matches)
             {
                 <tr>
                     <td>@record.FirstName @record.MiddleName @record.LastName</td>

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -1,0 +1,26 @@
+@model List<PiiRecord>
+@if (Model != null && Model.Any())
+{
+    <h2>Results</h2>
+    <table class="usa-table">
+        <thead>
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">DOB</th>
+                <th scope="col">SSN</th>
+                <th scope="col">State</th>
+            </tr>
+        </thead>
+        <tbody>
+      @foreach (var record in @Model)
+      {
+          <tr>
+              <td>@record.FirstName @record.MiddleName @record.LastName</td>
+              <td>@record.DateOfBirth</td>
+              <td>@record.SocialSecurityNum</td>
+              <td>@record.StateName</td>
+          </tr>
+      }
+        </tbody>
+    </table>
+}

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -1,26 +1,28 @@
 @model List<PiiRecord>
 @if (Model != null && Model.Any())
 {
-    <h2>Results</h2>
-    <table class="usa-table">
-        <thead>
-            <tr>
-                <th scope="col">Name</th>
-                <th scope="col">DOB</th>
-                <th scope="col">SSN</th>
-                <th scope="col">State</th>
-            </tr>
-        </thead>
-        <tbody>
-      @foreach (var record in @Model)
+      <h2>Results</h2>
+      <table class="usa-table">
+          <thead>
+              <tr>
+                  <th scope="col">Name</th>
+                  <th scope="col">DOB</th>
+                  <th scope="col">SSN</th>
+                  <th scope="col">State</th>
+                  <th scope="col">Lookup ID</th>
+              </tr>
+          </thead>
+          <tbody>
+        @foreach (var record in @Model)
       {
-          <tr>
-              <td>@record.FirstName @record.MiddleName @record.LastName</td>
-              <td>@record.DateOfBirth</td>
-              <td>@record.SocialSecurityNum</td>
-              <td>@record.StateName</td>
-          </tr>
+              <tr>
+                  <td>@record.FirstName @record.MiddleName @record.LastName</td>
+                  <td>@record.DateOfBirth</td>
+                  <td>@record.SocialSecurityNum</td>
+                  <td>@record.StateName</td>
+                  <td>@record.LookupId</td>
+              </tr>
       }
-        </tbody>
-    </table>
+          </tbody>
+      </table>
 }

--- a/query-tool/src/Piipan.QueryTool/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool/PiiRecord.cs
@@ -43,7 +43,7 @@ namespace Piipan.QueryTool
         public string StateAbbr { get; set; }
 
         [Display(Name = "Lookup ID")]
-        [JsonPropertyName("lookupId")]
+        [JsonPropertyName("lookup_id")]
         public string LookupId {get; set;}
     }
 }

--- a/query-tool/src/Piipan.QueryTool/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool/PiiRecord.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Piipan.QueryTool
 {
-    public class PiiRecord
+    public class PiiRecord : IQueryable
     {
         [Required]
         [Display(Name = "First Name")]
@@ -41,5 +41,9 @@ namespace Piipan.QueryTool
         [Display(Name = "StateAbbr")]
         [JsonPropertyName("state_abbr")]
         public string StateAbbr { get; set; }
+
+        [Display(Name = "Lookup ID")]
+        [JsonPropertyName("lookupId")]
+        public string LookupId {get; set;}
     }
 }

--- a/query-tool/src/Piipan.QueryTool/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool/PiiRecord.cs
@@ -4,6 +4,12 @@ using System.Text.Json.Serialization;
 
 namespace Piipan.QueryTool
 {
+    public class MatchRequest
+    {
+        [JsonPropertyName("query")]
+        public PiiRecord Query { get; set; }
+    }
+
     public class PiiRecord : IQueryable
     {
         [Required]
@@ -44,6 +50,6 @@ namespace Piipan.QueryTool
 
         [Display(Name = "Lookup ID")]
         [JsonPropertyName("lookup_id")]
-        public string LookupId {get; set;}
+        public string LookupId { get; set; }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -15,21 +10,31 @@ namespace Piipan.QueryTool
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
+        public Startup(IConfiguration configuration, IWebHostEnvironment env)
         {
             Configuration = configuration;
+            _env = env;
         }
 
         public IConfiguration Configuration { get; }
+        private readonly IWebHostEnvironment _env;
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
-
-            ITokenProvider tokenProvider = new EasyAuthTokenProvider();
             services.AddSingleton<IAuthorizedApiClient>((s) =>
             {
+                ITokenProvider tokenProvider;
+                if (_env.IsDevelopment())
+                {
+                    tokenProvider = new CliTokenProvider();
+                }
+                else
+                {
+                    tokenProvider = new EasyAuthTokenProvider();
+                }
+
                 return new AuthorizedJsonApiClient(new HttpClient(), tokenProvider);
             });
         }

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Piipan.QueryTool.Pages;
@@ -8,10 +12,33 @@ namespace Piipan.QueryTool.Tests
 {
     public class IndexPageTests
     {
+        public IndexPageTests()
+        {
+            Environment.SetEnvironmentVariable("OrchApiUri", "https://localhost/");
+        }
+
+        public static IAuthorizedApiClient clientMock(HttpStatusCode statusCode, string returnValue)
+        {
+            var clientMock = new Mock<IAuthorizedApiClient>();
+            clientMock
+                .Setup(c => c.PostAsync(
+                    It.Is<Uri>(u => u.ToString().Contains("/query")),
+                    It.IsAny<StringContent>()
+                ))
+                .Returns(Task.FromResult(new HttpResponseMessage()
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(returnValue)
+                }));
+
+            return clientMock.Object;
+        }
+
         [Fact]
         public void TestBeforeOnGet()
         {
             // arrange
+
             var mockApiClient = Mock.Of<IAuthorizedApiClient>();
             var pageModel = new IndexModel(
                 new NullLogger<IndexModel>(),
@@ -33,6 +60,94 @@ namespace Piipan.QueryTool.Tests
 
             // assert
             Assert.Equal("NAC Query Tool", pageModel.Title);
+        }
+
+        [Fact]
+        public async void MatchSetsResults()
+        {
+            // arrange
+            var returnValue = @"{
+                ""lookup_id"": ""BBB2222"",
+                ""matches"": [{
+                    ""first"": ""Theodore"",
+                    ""middle"": ""Carri"",
+                    ""last"": ""Farrington"",
+                    ""ssn"": ""000-00-0000"",
+                    ""dob"": ""2021-01-01"",
+                    ""state_abbr"": ""ea"",
+                    ""state_name"": ""Echo Alpha""
+                }]
+            }";
+            var requestPii = new PiiRecord
+            {
+                FirstName = "Theodore",
+                LastName = "Farrington",
+                SocialSecurityNum = "000-00-0000",
+                DateOfBirth = new DateTime(2021, 1, 1)
+            };
+            var mockClient = clientMock(HttpStatusCode.OK, returnValue);
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient);
+            pageModel.Query = requestPii;
+
+            // act
+            await pageModel.OnPostAsync();
+
+            // assert
+            Assert.IsType<MatchResponse>(pageModel.QueryResult);
+            Assert.NotNull(pageModel.QueryResult);
+            Assert.NotNull(pageModel.QueryResult.matches);
+            Assert.False(pageModel.NoResults);
+        }
+
+        [Fact]
+        public async void MatchNoResults()
+        {
+            // arrange
+            var returnValue = @"{
+                ""lookup_id"": null,
+                ""matches"": []
+            }";
+            var requestPii = new PiiRecord
+            {
+                FirstName = "Theodore",
+                LastName = "Farrington",
+                SocialSecurityNum = "000-00-0000",
+                DateOfBirth = new DateTime(2021, 1, 1)
+            };
+            var mockClient = clientMock(HttpStatusCode.OK, returnValue);
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient);
+            pageModel.Query = requestPii;
+
+            // act
+            await pageModel.OnPostAsync();
+
+            // assert
+            Assert.IsType<MatchResponse>(pageModel.QueryResult);
+            Assert.Null(pageModel.QueryResult.lookupId);
+            Assert.Empty(pageModel.QueryResult.matches);
+            Assert.True(pageModel.NoResults);
+        }
+
+        [Fact]
+        public async void MatchCapturesApiError()
+        {
+            // arrange
+            var requestPii = new PiiRecord
+            {
+                FirstName = "Theodore",
+                LastName = "Farrington",
+                SocialSecurityNum = "000-00-0000",
+                DateOfBirth = new DateTime(2021, 1, 1)
+            };
+            var mockClient = clientMock(HttpStatusCode.BadRequest, "");
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient);
+            pageModel.Query = requestPii;
+
+            // act
+            await pageModel.OnPostAsync();
+
+            // assert
+            Assert.NotNull(pageModel.RequestError);
         }
     }
 }

--- a/query-tool/tests/Piipan.QueryTool.Tests/LookupByIdPageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/LookupByIdPageTest.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Piipan.QueryTool.Pages;
+using Piipan.Shared.Authentication;
+using Xunit;
+
+namespace Piipan.QueryTool.Tests
+{
+    public class LookupByIdPageTests
+    {
+        [Fact]
+        public void TestBeforeOnGet()
+        {
+            // arrange
+            var mockApiClient = Mock.Of<IAuthorizedApiClient>();
+            var pageModel = new LookupByIdModel(
+                new NullLogger<LookupByIdModel>(),
+                mockApiClient
+                );
+            // act
+            // assert
+            Assert.Equal("", pageModel.Title);
+        }
+        [Fact]
+        public void TestAfterOnGet()
+        {
+            // arrange
+            var mockApiClient = Mock.Of<IAuthorizedApiClient>();
+            var pageModel = new LookupByIdModel(new NullLogger<LookupByIdModel>(), mockApiClient);
+
+            // act
+            pageModel.OnGet();
+
+            // assert
+            Assert.Equal("NAC Query Tool", pageModel.Title);
+        }
+    }
+}

--- a/query-tool/tests/Piipan.QueryTool.Tests/LookupByIdPageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/LookupByIdPageTest.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Piipan.QueryTool.Pages;
@@ -8,6 +12,25 @@ namespace Piipan.QueryTool.Tests
 {
     public class LookupByIdPageTests
     {
+        public LookupByIdPageTests()
+        {
+            Environment.SetEnvironmentVariable("OrchApiUri", "https://localhost/");
+        }
+
+        public static IAuthorizedApiClient clientMock(HttpStatusCode statusCode, string returnValue)
+        {
+            var clientMock = new Mock<IAuthorizedApiClient>();
+            clientMock
+                .Setup(c => c.GetAsync(It.Is<Uri>(u => u.ToString().Contains("lookup_ids/"))))
+                .Returns(Task.FromResult(new HttpResponseMessage()
+                {
+                    StatusCode = statusCode,
+                    Content = new StringContent(returnValue)
+                }));
+
+            return clientMock.Object;
+        }
+
         [Fact]
         public void TestBeforeOnGet()
         {
@@ -21,6 +44,7 @@ namespace Piipan.QueryTool.Tests
             // assert
             Assert.Equal("", pageModel.Title);
         }
+
         [Fact]
         public void TestAfterOnGet()
         {
@@ -33,6 +57,68 @@ namespace Piipan.QueryTool.Tests
 
             // assert
             Assert.Equal("NAC Query Tool", pageModel.Title);
+        }
+
+        [Fact]
+        public async void LookupSetsRecord()
+        {
+            // arrange
+            var returnValue = @"{
+                ""data"": {
+                    ""first"": ""Theodore"",
+                    ""middle"": ""Carri"",
+                    ""last"": ""Farrington"",
+                    ""ssn"": ""000-00-0000"",
+                    ""dob"": ""2021-01-01""
+                }
+            }";
+            var mockClient = clientMock(HttpStatusCode.OK, returnValue);
+            var pageModel = new LookupByIdModel(new NullLogger<LookupByIdModel>(), mockClient);
+            pageModel.Query = new Lookup { LookupId = "BCD2345" };
+
+            // act
+            await pageModel.OnPostAsync();
+
+            // assert
+            Assert.IsType<LookupResponse>(pageModel.Record);
+            Assert.NotNull(pageModel.Record);
+            Assert.NotNull(pageModel.Record.data);
+            Assert.False(pageModel.NoResults);
+        }
+
+        [Fact]
+        public async void LookupNoResults()
+        {
+            // arrange
+            var returnValue = @"{
+                ""data"": null
+            }";
+            var mockClient = clientMock(HttpStatusCode.OK, returnValue);
+            var pageModel = new LookupByIdModel(new NullLogger<LookupByIdModel>(), mockClient);
+            pageModel.Query = new Lookup { LookupId = "BCD2345" };
+
+            // act
+            await pageModel.OnPostAsync();
+
+            // assert
+            Assert.IsType<LookupResponse>(pageModel.Record);
+            Assert.Null(pageModel.Record.data);
+            Assert.True(pageModel.NoResults);
+        }
+
+        [Fact]
+        public async void LookupCapturesApiError()
+        {
+            // arrange
+            var mockClient = clientMock(HttpStatusCode.BadRequest, "");
+            var pageModel = new LookupByIdModel(new NullLogger<LookupByIdModel>(), mockClient);
+            pageModel.Query = new Lookup { LookupId = "BCD2345" };
+
+            // act
+            await pageModel.OnPostAsync();
+
+            // assert
+            Assert.NotNull(pageModel.RequestError);
         }
     }
 }


### PR DESCRIPTION
This PR does a few things to get the Query Tool ready to do queries based on Lookup IDs:

* Create a new page with a one-field form
* Extract the results table into a partial to share between both forms
* Adds the lookup ID field to the `PiiRecord` class
* Makes a new `Lookup` class
* Relates `Lookup` and `PiiRecord` through a `IQueryable` interface

To that last point, I opted to use an interface rather than inheritance because while both classes needed a field for the Lookup ID, it needs to be required on one but not the other, and the only ways I could think of doing that via inheritance would've required method overrides that defeated the purpose of inheritance.

Finally, while I did do a `OnPostAsync` method that returned a dummy record when you submitted the Lookup ID form, I did not include it in this PR because I didn't think it should actually ship.