### PR TITLE
Add lookup API endpoint

### DIFF
--- a/match/src/Piipan.Match.Orchestrator/Api.cs
+++ b/match/src/Piipan.Match.Orchestrator/Api.cs
@@ -79,6 +79,24 @@ namespace Piipan.Match.Orchestrator
             return (ActionResult)new JsonResult(response);
         }
 
+        /// <summary>
+        /// API endpoint for retrieving a MatchQuery using a lookup ID
+        /// </summary>
+        /// <param name="req">incoming HTTP request</param>
+        /// <param name="lookupId">lookup ID string (pulled from route)</param>
+        /// <param name="log">handle to the function log</param>
+        [FunctionName("lookup_ids")]
+        public async Task<IActionResult> LookupIds(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "lookups_ids/{lookupId}")] HttpRequest req,
+            string lookupId,
+            ILogger log)
+        {
+            LookupResponse response = new LookupResponse { Data = null };
+            response.Data = await Lookup.Retrieve(lookupId, _lookupStorage, log);
+
+            return (ActionResult)new JsonResult(response);
+        }
+
         private MatchQueryRequest Parse(string requestBody, ILogger log)
         {
             // Assume failure

--- a/match/src/Piipan.Match.Orchestrator/Lookup.cs
+++ b/match/src/Piipan.Match.Orchestrator/Lookup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Piipan.Match.Orchestrator
 {
@@ -46,6 +47,26 @@ namespace Piipan.Match.Orchestrator
             }
 
             throw new Exception($"Lookup table insert failed after {InsertRetries} retries.");
+        }
+
+        /// <summary>
+        /// Retrieve a row from storage using a lookup ID
+        /// </summary>
+        /// <returns>QueryEntity representing the retrieved row</returns>
+        /// <param name="lookupId">the unique lookup ID (RowKey) for the row</param>
+        /// <param name="tableStorage">handle to the table storage instance</param>
+        /// <param name="log">handle to the function log</param>
+        public static async Task<MatchQuery> Retrieve(string lookupId, ITableStorage<QueryEntity> tableStorage, ILogger log)
+        {
+            MatchQuery query = null;
+            var row = await tableStorage.PointQueryAsync(PartitionKey, lookupId);
+
+            if (row != null)
+            {
+                query = JsonConvert.DeserializeObject<MatchQuery>(row.Body);
+            }
+
+            return query;
         }
     }
 

--- a/match/src/Piipan.Match.Orchestrator/LookupResponse.cs
+++ b/match/src/Piipan.Match.Orchestrator/LookupResponse.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Piipan.Match.Orchestrator
+{
+    public class LookupResponse
+    {
+
+        [JsonProperty("data")]
+        public MatchQuery Data { get; set; }
+
+        public string ToJson()
+        {
+            return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
+        }
+    }
+}

--- a/match/tests/Piipan.Match.Orchestrator.Tests/LookupTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/LookupTests.cs
@@ -1,9 +1,24 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Piipan.Shared.Authentication;
 using Xunit;
 
 namespace Piipan.Match.Orchestrator.Tests
 {
     public class LookupTests
     {
+
+        static Api ConstructMockedApi()
+        {
+            var apiClient = Mock.Of<IAuthorizedApiClient>();
+            var lookupStorage = ApiTests.MockLookupStorage();
+            var api = new Api(apiClient, lookupStorage.Object);
+
+            return api;
+        }
 
         [Fact]
         public void LookupIdConformsToLength()
@@ -23,6 +38,43 @@ namespace Piipan.Match.Orchestrator.Tests
             {
                 Assert.False(id.Contains(c));
             }
+        }
+
+        [Fact]
+        public void LookupResponseJson()
+        {
+            var mq = new MatchQuery
+            {
+                First = "first",
+                Middle = "middle",
+                Last = "last",
+                Dob = new DateTime(1970, 1, 1),
+                Ssn = "000-00-0000"
+            };
+            var lr = new LookupResponse { Data = mq };
+
+            Assert.Contains("\"first\": \"first\"", lr.ToJson());
+            Assert.Contains("\"middle\": \"middle\"", lr.ToJson());
+            Assert.Contains("\"last\": \"last\"", lr.ToJson());
+            Assert.Contains("\"dob\": \"1970-01-01\"", lr.ToJson());
+            Assert.Contains("\"ssn\": \"000-00-0000\"", lr.ToJson());
+        }
+
+        [Fact]
+        public async void SuccessfulApiCall()
+        {
+            // Arrange
+            var api = ConstructMockedApi();
+
+            // Act
+            var result = await api.LookupIds(Mock.Of<HttpRequest>(), "ABC1234", Mock.Of<ILogger>());
+            var jsonResult = result as JsonResult;
+            var lookupResponse = jsonResult.Value as LookupResponse;
+
+            // Assert
+            Assert.IsType<JsonResult>(result);
+            Assert.IsType<LookupResponse>(jsonResult.Value);
+            Assert.IsType<MatchQuery>(lookupResponse.Data);
         }
     }
 }

--- a/match/tools/test-lookup-api.bash
+++ b/match/tools/test-lookup-api.bash
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Basic integration test tool for the lookup API. Sends a curl request to the
+# API's lookup_ids endpoint and writes result to stdout. Requires that the user
+# has been added to the OrchestratorApi.Query application role for the orchestrator
+# function app (see match/docs/orchestrator-match.md#remote-testing).
+#
+# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# See iac/env for available environments.
+#
+# lookup-id is the lookup ID string.
+#
+# usage: test-lookup-api.bash <azure-env> <lookup-id>
+
+source $(dirname "$0")/../../tools/common.bash || exit
+source $(dirname "$0")/../../iac/iac-common.bash || exit
+
+LOOKUP_API_FUNC_NAME="lookup_ids"
+
+main () {
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source $(dirname "$0")/../../iac/env/${azure_env}.bash
+  verify_cloud
+
+  lookup_id=$2
+
+  name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
+  resource_uri=$(\
+    az functionapp show \
+      -g $MATCH_RESOURCE_GROUP \
+      -n $name \
+      --query defaultHostName \
+      -o tsv)
+  resource_uri="https://${resource_uri}"
+
+  echo "Retrieving access token from ${resource_uri}"
+  token=$(\
+    az account get-access-token \
+      --resource ${resource_uri} \
+      --query accessToken \
+      -o tsv
+  )
+
+  endpoint_uri=$(\
+    az functionapp function show \
+      -g $MATCH_RESOURCE_GROUP \
+      -n $name \
+      --function-name $LOOKUP_API_FUNC_NAME \
+      --query invokeUrlTemplate \
+      -o tsv)
+  endpoint_uri=$(echo $endpoint_uri | sed "s/{lookupid}/$lookup_id/")
+
+  echo "Submitting request to ${endpoint_uri}"
+  curl \
+    --request GET "${endpoint_uri}" \
+    --header "Authorization: Bearer ${token}" \
+    --include
+
+  echo "\n"
+
+  script_completed
+
+}
+
+main "$@"


### PR DESCRIPTION
- Updates orchestrator Function App with `LookupIds` entry point
  - Queries table storage for a row with `RowKey` matching the incoming `lookupId`
  - Returns a response containing the matching query or `null` if none
- Adds a simple bash script for manual integration testing (as a precursor to #578)

**Question**: Should the incoming lookup ID be validated according to our schema (and presumably trigger `400` responses if invalid)?

Partially addresses #259 — API will be added to APIM instance as follow on work.

---

This work can be tested locally (with a connection to the remote lookup table) using the following steps:
1. Fetch app settings for the orchestrator app (to get down binding details for the lookup table):
```
cd match/src/Piipan.Match.Orchestrator
func azure functionapp fetch-app-settings <orchestrator-name>
```
2. Start up the orchestrator app:
```
func start
```
3. Send a `GET` request to the local endpoint (e.g., `http://localhost:7071/api/v1/lookups_ids/{lookupId}`)

Remote tests can be run using the simple integration test script at `match/tools/test-lookup-api.bash`:
1. (If not already completed) Add your CLI user to `OrchestratorApi.Query` application role for the orchestrator app:
```
# project root
./tools/assign-app-role.bash tts/dev <orchestrator-name> OrchestratorApi.Query
```
2. Run the integration test:
```
./match/tools/test-lookup-api.bash tts/dev <lookup-id>
```

You can find existing lookup IDs at Portal > Storage Accounts > stlookupapidev > Storage Explorer > Tables > lookup.