### PR TITLE
Case insensitive matching

### DIFF
--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -98,8 +98,8 @@ namespace Piipan.Match.State
                 first = request.Query.First,
             };
             var sql = "SELECT upload_id, first, last, middle, dob, ssn, exception FROM participants " +
-                        "WHERE ssn=@ssn AND dob=@dob AND last=@last AND first=@first " +
-                        "AND upload_id=(SELECT id FROM uploads WHERE created_at = (SELECT MAX(created_at) FROM uploads))";
+                        "WHERE ssn=@ssn AND dob=@dob AND upper(last)=upper(@last) AND upper(first)=upper(@first) " +
+                        "AND upload_id=(SELECT id FROM uploads ORDER BY id DESC LIMIT 1)";
 
             return (sql, p);
         }

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -238,7 +238,23 @@ namespace Piipan.Match.State.Tests
             (var sql, var parameters) = Api.Prepare(request, logger);
 
             // Assert
-            Assert.Contains("first=@first", sql);
+            Assert.Contains("upper(first)=upper(@first)", sql);
+        }
+
+        [Fact]
+        public void SqlHasNormlizedName()
+        {
+            // Arrange
+            var body = JsonBody(@"{last:'Last', first: 'First', middle: 'Middle', dob: '1970-01-01', ssn: '000-00-0000'}");
+            var logger = Mock.Of<ILogger>();
+
+            // Act
+            MatchQueryRequest request = Api.Parse(body, logger);
+            (var sql, var parameters) = Api.Prepare(request, logger);
+
+            // Assert
+            Assert.Contains("upper(last)=upper(@last)", sql);
+            Assert.Contains("upper(first)=upper(@first)", sql);
         }
 
         [Fact]

--- a/match/tools/test-match-api.bash
+++ b/match/tools/test-match-api.bash
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Basic integration test tool for the orchestrator and per-state APIs. Sends a curl
+# request with a pre-set PII query to the API's query endpoint and writes result to
+# stdout. Requires that the user has been added to the necessary application role
+# for the function app (see Remote Testing in match/docs/orchestrator-match.md and
+# match/docs/state-match.md).
+#
+# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# See iac/env for available environments.
+#
+# function-name is the function app name in Azure.
+#
+# usage: test-lookup-api.bash <azure-env> <function-name>
+
+source $(dirname "$0")/../../tools/common.bash || exit
+source $(dirname "$0")/../../iac/iac-common.bash || exit
+
+QUERY_API_FUNC_NAME="query"
+JSON='{
+    "query": {
+        "last": "Lynn",
+        "dob": "1940-08-01",
+        "ssn": "000-12-3457",
+        "first": "Wesley",
+        "middle": "Eura"
+    }
+}'
+
+main () {
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source $(dirname "$0")/../../iac/env/${azure_env}.bash
+  verify_cloud
+
+  name=$2
+
+  resource_uri=$(\
+    az functionapp show \
+      -g $MATCH_RESOURCE_GROUP \
+      -n $name \
+      --query defaultHostName \
+      -o tsv)
+  resource_uri="https://${resource_uri}"
+
+  echo "Retrieving access token from ${resource_uri}"
+  token=$(\
+    az account get-access-token \
+      --resource ${resource_uri} \
+      --query accessToken \
+      -o tsv
+  )
+
+  endpoint_uri=$(\
+    az functionapp function show \
+      -g $MATCH_RESOURCE_GROUP \
+      -n $name \
+      --function-name $QUERY_API_FUNC_NAME \
+      --query invokeUrlTemplate \
+      -o tsv)
+
+  echo "Submitting request to ${endpoint_uri}"
+  curl \
+    --request POST "${endpoint_uri}" \
+    --header "Authorization: Bearer ${token}" \
+    --header 'Content-Type: application/json' \
+    --data-raw "$JSON" \
+    --include
+
+  echo "\n"
+
+  script_completed
+
+}
+
+main "$@"


### PR DESCRIPTION
- Normalize first and last to uppercase in query
- Optimize upload ID subquery
- Add manual integration test script

CSV with varying capitalization for the `Lynn,Wesley,Eura,8/01/1940,000-12-3457,` row has been uploaded to each state's participants db. The updated query can be tested using `match/tools/test-match-api.bash`.

@ryanhofdotgov I had forgotten that we already had an index on `(ssn, upload_id)`.  That is sufficient to keep the match query to an index scan, and adding an additional index on `ssn` alone seemed unnecessary.

Because of that index, normalizing with `upper()` did not have an effect on the cost:

```
-- Query without upper
 Index Scan using participants_ssn_idx on participants  (cost=0.33..2.55 rows=1 width=48)
   Index Cond: ((ssn = '000-12-3461'::text) AND (upload_id = $0))
   Filter: ((dob = '1913-04-04'::date) AND (last = 'Wallen'::text) AND (first = 'Homer'::text))
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..0.18 rows=1 width=4)
           ->  Index Only Scan Backward using uploads_pkey on uploads  (cost=0.15..30.30 rows=1130 width=4)
```

```
-- Query with upper
 Index Scan using participants_ssn_idx on participants  (cost=0.33..2.56 rows=1 width=48)
   Index Cond: ((ssn = '000-12-3461'::text) AND (upload_id = $0))
   Filter: ((dob = '1913-04-04'::date) AND (upper(last) = 'WALLEN'::text) AND (upper(first) = 'HOMER'::text))
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..0.18 rows=1 width=4)
           ->  Index Only Scan Backward using uploads_pkey on uploads  (cost=0.15..30.30 rows=1130 width=4)
```

Closes #551 