### PR TITLE
Add lookup API to APIM, update documentation

### DIFF
--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -139,6 +139,57 @@
                 "value": "[parameters('policyXml')]",
                 "format": "xml"
             }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis/operations",
+            "apiVersion": "2020-06-01-preview",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/get-lookup')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]",
+                "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('matchSetName'))]"
+            ],
+            "properties": {
+                "displayName": "Retrieve original match data",
+                "method": "GET",
+                "urlTemplate": "/lookup_ids/{lookupId}",
+                "description": "Get the original match data related to a lookup ID. User can provide a lookup ID and receive the match data associated with it.",
+                "templateParameters": [
+                    {
+                        "name": "lookupId",
+                        "description": "User-provided lookup ID",
+                        "type": "string",
+                        "required": true
+                    }
+                ],
+                "responses": [
+                    {
+                        "statusCode": 200,
+                        "description": "Original active match data"
+                    },
+                    {
+                        "statusCode": 400,
+                        "description": "bad request"
+                    },
+                    {
+                        "statusCode": 404,
+                        "description": "not found"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/apis/operations/policies",
+            "apiVersion": "2020-06-01-preview",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/get-lookup/policy')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('apiName'), variables('matchSetName'), 'get-lookup')]",
+                "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('matchSetName'))]",
+                "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]"
+            ],
+            "properties": {
+                "value": "[parameters('policyXml')]",
+                "format": "xml"
+            }
         }
     ],
     "outputs": {

--- a/match/docs/duplicate-participation-api.md
+++ b/match/docs/duplicate-participation-api.md
@@ -4,7 +4,12 @@
 
 The duplicate participation API is intended as a collection of external-facing endpoints for consumption by state systems. It is managed as an Azure API Management (APIM) instance and deployed by the [IaC](../../docs/iac.md).
 
-Currently the API includes a single endpoint which maps to the [orchestrator](orchestrator-match.md) API's query endpoint.
+The API includes the following endpoints:
+
+| Endpoint | Backend | Function |
+|---|---|---|
+| `/query` | [Orchestrator Function App](orchestrator-match.md) | `Query` |
+| `/lookup_ids/{lookupId}` | [Orchestrator Function App](orchestrator-match.md) | `LookupIds`|
 
 For a general overview of APIM, refer to [Microsoft's documentation](https://docs.microsoft.com/en-us/azure/api-management/). Piipan makes use of the following concepts:
 

--- a/match/docs/lookup.md
+++ b/match/docs/lookup.md
@@ -1,7 +1,16 @@
 # Lookup ID API
 
+## Prerequisites
+- [Azure Command Line Interface (CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [.NET Core SDK 3.1](https://dotnet.microsoft.com/download)
+- [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
 ## Summary
 
-The Lookup ID API will be a web-based API request to query the PII associated with an opaque Lookup ID provided through other API requests.
+An API for querying the PII associated with an opaque lookup ID. The lookup ID is provided in responses from the orchestrator matching API when a match has been detected.
 
-This endpoint is under active development. Refer to the [OpenApi specification](./openapi/lookup.index.yaml) for details.
+The lookup ID API is implemented in the `Piipan.Match.Orchestrator` project and deployed to an Azure Function App.
+
+## Deployment and testing
+
+As the lookup ID and orchestrator match APIs share a codebase, see [orchestrator-match.md](orchestrator-match.md) for deployment and testing details.

--- a/match/docs/orchestrator-match.md
+++ b/match/docs/orchestrator-match.md
@@ -8,7 +8,11 @@
 ## Summary
 
 An initial API for matching PII data across all participating states.
-1. JSON `POST` request that conforms to the [OpenApi spec](openapi.md) is sent to the orchestrator API endpoint.
+
+The orchestrator matching API is implemented in the `Piipan.Match.Orchestrator` project and deployed to an Azure Function App.
+
+To query the API:
+1. A JSON `POST` request that conforms to the [OpenApi spec](openapi.md) is sent to the orchestrator API endpoint.
 1. The `POST` event triggers a function named `Query` in the orchestrator Function App.
     - If the request is unauthorized (does not include a valid bearer token), the function returns a `401` response.
     - If the request is not valid (malformed, missing required data, etc), the function returns a `400` response. Currently no error messaging is included in the response.
@@ -17,7 +21,7 @@ An initial API for matching PII data across all participating states.
 
 ## Environment variables
 
-The following environment variables are required by `Query` and are set by the [IaC](../../docs/iac.md):
+The following environment variables are required by the orchestrator and are set by the [IaC](../../docs/iac.md):
 
 | Name | |
 |---|---|


### PR DESCRIPTION
Adds a new operation for the lookup API to the existing APIM instance. To test, send a conforming request to the API endpoint and include an active [API/subscription key](https://github.com/18F/piipan/blob/main/match/docs/duplicate-participation-api.md#calling-the-api) in the request's header. E.g.,
```
curl --location --request GET 'https://apim-duppartapi-dev.azure-api.net/v1/lookup_ids/<lookup-id>' \
  --header 'Content-Type: application/json' \
  --header 'Ocp-Apim-Subscription-Key: <api-key>'
```

This PR also includes some barebones documentation for the lookup API. I created #639 to take a comprehensive pass over the documentation now that most of the details have come into focus.