### PR TITLE
Add GetAsync method to AuthorizedJsonApiClient

### DIFF
--- a/shared/src/Piipan.Shared/Authentication.cs
+++ b/shared/src/Piipan.Shared/Authentication.cs
@@ -49,7 +49,6 @@ namespace Piipan.Shared.Authentication
         /// Send an asynchronous GET request to an API endpoint
         /// </summary>
         /// <param name="uri">URI of the API endpoint</param>
-        /// <remarks>Not yet implemented</remarks>
         Task<HttpResponseMessage> GetAsync(Uri uri);
     }
 
@@ -99,9 +98,12 @@ namespace Piipan.Shared.Authentication
             return response;
         }
 
-        public Task<HttpResponseMessage> GetAsync(Uri uri)
+        public async Task<HttpResponseMessage> GetAsync(Uri uri)
         {
-            throw new NotImplementedException("GetAsync method not yet implemented.");
+            var requestMessage = await PrepareRequest(uri, HttpMethod.Get);
+            var response = await _client.SendAsync(requestMessage);
+
+            return response;
         }
     }
 }


### PR DESCRIPTION
Implements `GetAsync` method on `Shared.Authentication.AuthorizedJsonApiClient`. Necessary for making `GET` calls to internal APIs (e.g., lookup API).

Example intended usage:
```
var api = new AuthorizedJsonApiClient(httpClient, tokenProvider);
var response = await api.GetAsync(new Uri("<api-uri>/lookup_ids/AAAAAAA"));
var lookup = await response.Content.ReadAsAsync<LookupResponse>();
```

Closes #657