### PR TITLE
Set up private network for database and function apps in iac

### DIFF
--- a/iac/arm-templates/app-service-plan.json
+++ b/iac/arm-templates/app-service-plan.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "type": "string",
+            "defaultValue": "[concat('webApp-', uniqueString(resourceGroup().id))]",
+            "minLength": 2,
+            "metadata": {
+                "description": "App Service Plan name."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "sku": {
+            "type": "string",
+            "defaultValue": "F1",
+            "metadata": {
+                "description": "The SKU of App Service Plan."
+            }
+        },
+        "kind": {
+            "type": "string",
+            "defaultValue": "functionapp",
+            "metadata": {
+                "description": "The type of App Service Plan."
+            }
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Web/serverfarms",
+            "apiVersion": "2020-06-01",
+            "name": "[parameters('name')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "[parameters('sku')]"
+            },
+            "kind": "[parameters('kind')]",
+            "properties": {
+                "reserved": false // must be false for Windows Operating Systems
+            }
+        }
+    ]
+}

--- a/iac/arm-templates/function-state-match.json
+++ b/iac/arm-templates/function-state-match.json
@@ -5,6 +5,9 @@
         "resourceTags": {
             "type": "object"
         },
+        "stateAbbr": {
+            "type": "string"
+        },
         "stateName": {
             "type": "string"
         },
@@ -146,6 +149,10 @@
                         {
                             "name": "CloudName",
                             "value": "[parameters('cloudName')]"
+                        },
+                        {
+                            "name": "StateAbbr",
+                            "value": "[parameters('stateAbbr')]"
                         }
                     ]
                 }

--- a/iac/arm-templates/function-state-match.json
+++ b/iac/arm-templates/function-state-match.json
@@ -8,9 +8,6 @@
         "stateName": {
             "type": "string"
         },
-        "stateAbbr": {
-            "type": "string"
-        },
         "location": {
             "type": "string"
         },
@@ -25,12 +22,24 @@
         },
         "cloudName": {
             "type": "string"
+        },
+        "functionAppName": {
+            "type": "string"
+        },
+        "storageAccountName": {
+            "type": "string"
+        },
+        "managedIdentityName": {
+            "type": "string"
+        },
+        "appServicePlanName": {
+            "type": "string"
         }
     },
     "variables": {
-        "functionAppName": "[concat(parameters('stateAbbr'), 'func', uniqueString(resourceGroup().id))]",
-        "hostingPlanName": "matchapi",
-        "storageAccountName": "[concat(parameters('stateAbbr'), 'fstor', uniquestring(resourceGroup().id))]",
+        "functionAppName": "[parameters('functionAppName')]",
+        "storageAccountName": "[parameters('storageAccountName')]",
+        "managedIdentityName": "[parameters('managedIdentityName')]",
         "functionWorkerRuntime": "dotnet",
         "storageAccountType": "Standard_LRS",
         "systemTypeTag": {
@@ -39,7 +48,7 @@
         "applicationInsightsTag": {
             "[concat('hidden-link:', resourceId('Microsoft.Web/sites', variables('functionAppName')))]": "Resource"
         },
-        "identityName": "[concat(parameters('stateAbbr'), 'admin')]"
+        "identityName": "[variables('managedIdentityName')]"
     },
     "resources": [
         {
@@ -52,21 +61,6 @@
                 "name": "[variables('storageAccountType')]"
             },
             "kind": "Storage"
-        },
-        {
-            "type": "Microsoft.Web/serverfarms",
-            "apiVersion": "2020-06-01",
-            "name": "[variables('hostingPlanName')]",
-            "tags": "[parameters('resourceTags')]",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "Y1",
-                "tier": "Dynamic"
-            },
-            "properties": {
-                "name": "[variables('hostingPlanName')]",
-                "computeMode": "Dynamic"
-            }
         },
         {
             "type": "Microsoft.Web/sites",
@@ -82,11 +76,10 @@
                 }
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "properties": {
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
                 "httpsOnly": true,
                 "siteConfig": {
                     "ftpsState": "Disabled",
@@ -141,10 +134,6 @@
                         {
                             "name": "StateName",
                             "value": "[parameters('stateName')]"
-                        },
-                        {
-                            "name": "StateAbbr",
-                            "value": "[parameters('stateAbbr')]"
                         },
                         {
                             "name": "AzureServicesAuthConnectionString",

--- a/iac/arm-templates/function-storage.json
+++ b/iac/arm-templates/function-storage.json
@@ -2,10 +2,8 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "stateAbbreviation": {
-            "type": "string",
-            "minLength": 2,
-            "maxLength": 2
+        "uniqueStorageName": {
+            "type": "string"
         },
         "resourceTags": {
             "type": "object"
@@ -15,7 +13,7 @@
         }
     },
     "variables": {
-        "uniqueStorageName": "[concat(toLower(parameters('stateAbbreviation')), 'fstor', uniqueString(resourceGroup().id))]"
+        "uniqueStorageName": "[parameters('uniqueStorageName')]"
     },
     "resources": [
         {

--- a/iac/arm-templates/participant-records.json
+++ b/iac/arm-templates/participant-records.json
@@ -34,6 +34,12 @@
             "type": "string"
         },
         "subnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the subnet the database will use."
+            }
+        },
+        "privateEndpointName": {
             "type": "string"
         }
     },
@@ -71,28 +77,19 @@
                         "resourceTags": {
                             "type": "object"
                         },
-                        "subnetPrefix": {
-                            "type": "string",
-                            "defaultValue": "10.0.0.0/24",
-                            "metadata": {
-                                "description": "The address space for the subnet."
-                            }
-                        },
-                        "vnetAddressPrefix": {
-                            "type": "string",
-                            "defaultValue": "10.0.0.0/16",
-                            "metadata": {
-                                "description": "The address space reserved for this virtual network in CIDR notation."
-                            }
-                        },
                         "vnetName": {
                             "type": "string"
                         },
                         "subnetName": {
                             "type": "string"
+                        },
+                        "privateEndpointName": {
+                            "type": "string"
                         }
                     },
                     "variables": {
+                        "privateDnsZoneName": "privatelink.postgres.database.azure.com",
+                        "pvtendpointdnsgroupname": "[concat(parameters('privateEndpointName'),'/dnsgroup')]",
                         "firewallrules": {
                             "batch": {
                                 "rules": [
@@ -112,33 +109,7 @@
                         }
                     },
                     "resources": [
-                        {
-                            "type": "Microsoft.Network/virtualNetworks",
-                            "apiVersion": "2020-06-01",
-                            "name": "[parameters('vnetName')]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "addressSpace": {
-                                    "addressPrefixes": [
-                                        "[parameters('vnetAddressPrefix')]"
-                                    ]
-                                }
-                            },
-                            "resources": [
-                                {
-                                    "type": "subnets",
-                                    "apiVersion": "2020-06-01",
-                                    "name": "[parameters('subnetName')]",
-                                    "location": "[parameters('location')]",
-                                    "dependsOn": [
-                                        "[parameters('vnetName')]"
-                                    ],
-                                    "properties": {
-                                        "addressPrefix": "[parameters('subnetPrefix')]"
-                                    }
-                                }
-                            ]
-                        },
+                        // Postgres server
                         {
                             "type": "Microsoft.DBforPostgreSQL/servers",
                             "apiVersion": "2017-12-01-preview",
@@ -157,7 +128,8 @@
                                     "storageAutoGrow": "Enabled"
                                 },
                                 "previewFeature": "",
-                                "infrastructureEncryption": "Disabled"
+                                "infrastructureEncryption": "Disabled",
+                                "publicNetworkAccess": "Enabled" // This gets disabled later in iac
                             },
                             /* VNet Rules only work for GeneralPurpose and above tiers */
                             "sku": {
@@ -166,22 +138,9 @@
                                 "capacity": 2,
                                 "size": 5120,
                                 "family": "Gen5"
-                            },
-                            "resources": [
-                                {
-                                    "type": "virtualNetworkRules",
-                                    "apiVersion": "2017-12-01",
-                                    "name": "vnetrule-participant-records-dev",
-                                    "dependsOn": [
-                                        "[resourceId('Microsoft.DBforPostgreSQL/servers/', parameters('serverName'))]"
-                                    ],
-                                    "properties": {
-                                        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]",
-                                        "ignoreMissingVnetServiceEndpoint": true
-                                    }
-                                }
-                            ]
+                            }
                         },
+                        // firewall rules
                         {
                             "type": "Microsoft.DBforPostgreSQL/servers/firewallRules",
                             "apiVersion": "2017-12-01",
@@ -199,6 +158,82 @@
                             "properties": {
                                 "startIpAddress": "[variables('firewallrules').batch.rules[copyIndex()].StartIpAddress]",
                                 "endIpAddress": "[variables('firewallrules').batch.rules[copyIndex()].EndIpAddress]"
+                            }
+                        },
+                        // privateEndpoint
+                        {
+                            "type": "Microsoft.Network/privateEndpoints",
+                            "apiVersion": "2020-06-01",
+                            "name": "[parameters('privateEndpointName')]",
+                            "location": "[parameters('location')]",
+                            "dependsOn": [
+                                "[parameters('serverName')]"
+                            ],
+                            "properties": {
+                                "subnet": {
+                                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]"
+                                },
+                                "privateLinkServiceConnections": [
+                                    {
+                                        "name": "[parameters('privateEndpointName')]",
+                                        "properties": {
+                                            "privateLinkServiceId": "[resourceId('Microsoft.DBforPostgreSQL/servers',parameters('ServerName'))]",
+                                            "groupIds": [
+                                                "postgresqlServer"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        // privateDnsZone
+                        {
+                            "type": "Microsoft.Network/privateDnsZones",
+                            "apiVersion": "2020-01-01",
+                            "name": "[variables('privateDnsZoneName')]",
+                            "location": "global",
+                            "dependsOn": [
+                            ],
+                            "properties": ""
+                        },
+                        // link private DNS zone to virtual network
+                        {
+                            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+                            "apiVersion": "2020-01-01",
+                            "name": "[concat(variables('privateDnsZoneName'), '/', variables('privateDnsZoneName'), '-link')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                            ],
+                            "properties": {
+                                "registrationEnabled": false,
+                                "virtualNetwork": {
+                                    "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+                                }
+                            }
+                        },
+                        /***
+                        The dns group configures the private endpoint to the private DNS zone.
+                        In portal, see private endpoint -> DNS Configuration
+                        ***/
+                        {
+                            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                            "apiVersion": "2020-06-01",
+                            "name": "[variables('pvtendpointdnsgroupname')]",
+                            "location": "[parameters('location')]",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
+                                "[parameters('privateEndpointName')]"
+                            ],
+                            "properties": {
+                                "privateDnsZoneConfigs": [
+                                    {
+                                        "name": "config1",
+                                        "properties": {
+                                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                                        }
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -229,6 +264,9 @@
                     },
                     "subnetName": {
                         "value": "[parameters('subnetName')]"
+                    },
+                    "privateEndpointName": {
+                        "value": "[parameters('privateEndpointName')]"
                     }
                 }
             }

--- a/iac/arm-templates/participant-records.json
+++ b/iac/arm-templates/participant-records.json
@@ -29,6 +29,12 @@
         },
         "resourceTags": {
             "type": "object"
+        },
+        "vnetName": {
+            "type": "string"
+        },
+        "subnetName": {
+            "type": "string"
         }
     },
     "variables": {
@@ -63,7 +69,27 @@
                             "type": "string"
                         },
                         "resourceTags": {
-                            "type": "object",
+                            "type": "object"
+                        },
+                        "subnetPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.0.0/24",
+                            "metadata": {
+                                "description": "The address space for the subnet."
+                            }
+                        },
+                        "vnetAddressPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.0.0/16",
+                            "metadata": {
+                                "description": "The address space reserved for this virtual network in CIDR notation."
+                            }
+                        },
+                        "vnetName": {
+                            "type": "string"
+                        },
+                        "subnetName": {
+                            "type": "string"
                         }
                     },
                     "variables": {
@@ -87,6 +113,33 @@
                     },
                     "resources": [
                         {
+                            "type": "Microsoft.Network/virtualNetworks",
+                            "apiVersion": "2020-06-01",
+                            "name": "[parameters('vnetName')]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "addressSpace": {
+                                    "addressPrefixes": [
+                                        "[parameters('vnetAddressPrefix')]"
+                                    ]
+                                }
+                            },
+                            "resources": [
+                                {
+                                    "type": "subnets",
+                                    "apiVersion": "2020-06-01",
+                                    "name": "[parameters('subnetName')]",
+                                    "location": "[parameters('location')]",
+                                    "dependsOn": [
+                                        "[parameters('vnetName')]"
+                                    ],
+                                    "properties": {
+                                        "addressPrefix": "[parameters('subnetPrefix')]"
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "type": "Microsoft.DBforPostgreSQL/servers",
                             "apiVersion": "2017-12-01-preview",
                             "kind": "",
@@ -106,13 +159,28 @@
                                 "previewFeature": "",
                                 "infrastructureEncryption": "Disabled"
                             },
+                            /* VNet Rules only work for GeneralPurpose and above tiers */
                             "sku": {
-                                "name": "B_Gen5_1",
-                                "tier": "Basic",
-                                "capacity": 1,
+                                "name": "GP_Gen5_2",
+                                "tier": "GeneralPurpose",
+                                "capacity": 2,
                                 "size": 5120,
                                 "family": "Gen5"
-                            }
+                            },
+                            "resources": [
+                                {
+                                    "type": "virtualNetworkRules",
+                                    "apiVersion": "2017-12-01",
+                                    "name": "vnetrule-participant-records-dev",
+                                    "dependsOn": [
+                                        "[resourceId('Microsoft.DBforPostgreSQL/servers/', parameters('serverName'))]"
+                                    ],
+                                    "properties": {
+                                        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]",
+                                        "ignoreMissingVnetServiceEndpoint": true
+                                    }
+                                }
+                            ]
                         },
                         {
                             "type": "Microsoft.DBforPostgreSQL/servers/firewallRules",
@@ -155,6 +223,12 @@
                             },
                             "secretName": "[parameters('secretName')]"
                         }
+                    },
+                    "vnetName": {
+                        "value": "[parameters('vnetName')]"
+                    },
+                    "subnetName": {
+                        "value": "[parameters('subnetName')]"
                     }
                 }
             }

--- a/iac/arm-templates/virtual-network.json
+++ b/iac/arm-templates/virtual-network.json
@@ -57,7 +57,7 @@
                                 "description": "The address space for the subnet."
                             }
                         },
-                        "etlSubnetPrefix": {
+                        "funcSubnetPrefix": {
                             "type": "string",
                             "defaultValue": "10.0.1.0/24",
                             "metadata": {
@@ -114,7 +114,7 @@
                                     {
                                         "name": "[parameters('funcSubnetName')]",
                                         "properties": {
-                                            "addressPrefix": "[parameters('etlSubnetPrefix')]",
+                                            "addressPrefix": "[parameters('funcSubnetPrefix')]",
                                             "privateEndpointNetworkPolicies": "Disabled",
                                             "delegations": [
                                                 {

--- a/iac/arm-templates/virtual-network.json
+++ b/iac/arm-templates/virtual-network.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "The location where the resources will be deployed."
+            }
+        },
+        "resourceTags": {
+            "type": "object"
+        },
+        "vnetName": {
+            "type": "string"
+        },
+        "databaseSubnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the subnet the database will use."
+            }
+        },
+        "funcSubnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the subnet etl apps will use."
+            }
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "vnetdeployment",
+            "properties": {
+                "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "template": {
+
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "location": {
+                            "type": "string"
+                        },
+                        "resourceTags": {
+                            "type": "object"
+                        },
+                        "subnetPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.0.0/24",
+                            "metadata": {
+                                "description": "The address space for the subnet."
+                            }
+                        },
+                        "etlSubnetPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.1.0/24",
+                            "metadata": {
+                                "description": "The address space for the function app subnet."
+                            }
+                        },
+                        "matchSubnetPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.2.0/24",
+                            "metadata": {
+                                "description": "The address space for the function app subnet."
+                            }
+                        },
+                        "vnetAddressPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.0.0/16",
+                            "metadata": {
+                                "description": "The address space reserved for this virtual network in CIDR notation."
+                            }
+                        },
+                        "vnetName": {
+                            "type": "string"
+                        },
+                        "databaseSubnetName": {
+                            "type": "string"
+                        },
+                        "funcSubnetName": {
+                            "type": "string"
+                        }
+                    },
+                    "variables": {},
+                    "resources": [
+                        // virtualNetwork
+                        {
+                            "type": "Microsoft.Network/virtualNetworks",
+                            "apiVersion": "2020-06-01",
+                            "tags": "[parameters('resourceTags')]",
+                            "name": "[parameters('vnetName')]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "addressSpace": {
+                                    "addressPrefixes": [
+                                        "[parameters('vnetAddressPrefix')]"
+                                    ]
+                                },
+                                "subnets": [
+                                    {
+                                        "name": "[parameters('databaseSubnetName')]",
+                                        "properties": {
+                                            "addressPrefix": "[parameters('subnetPrefix')]",
+                                            "privateEndpointNetworkPolicies": "Disabled"
+                                        }
+                                    },
+                                    {
+                                        "name": "[parameters('funcSubnetName')]",
+                                        "properties": {
+                                            "addressPrefix": "[parameters('etlSubnetPrefix')]",
+                                            "privateEndpointNetworkPolicies": "Disabled",
+                                            "delegations": [
+                                                {
+                                                    "name": "serverfarms",
+                                                    "properties": {
+                                                        "serviceName": "Microsoft.Web/serverfarms"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "parameters": {
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "resourceTags": {
+                        "value": "[parameters('resourceTags')]"
+                    },
+                    "vnetName": {
+                        "value": "[parameters('vnetName')]"
+                    },
+                    "databaseSubnetName": {
+                        "value": "[parameters('databaseSubnetName')]"
+                    },
+                    "funcSubnetName": {
+                        "value": "[parameters('funcSubnetName')]"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/iac/arm-templates/virtual-network.json
+++ b/iac/arm-templates/virtual-network.json
@@ -64,13 +64,6 @@
                                 "description": "The address space for the function app subnet."
                             }
                         },
-                        "matchSubnetPrefix": {
-                            "type": "string",
-                            "defaultValue": "10.0.2.0/24",
-                            "metadata": {
-                                "description": "The address space for the function app subnet."
-                            }
-                        },
                         "vnetAddressPrefix": {
                             "type": "string",
                             "defaultValue": "10.0.0.0/16",

--- a/iac/configure-easy-auth.bash
+++ b/iac/configure-easy-auth.bash
@@ -253,7 +253,7 @@ main () {
   ORCH_API_APP_ROLE='OrchestratorApi.Query'
 
   match_func_names=($(\
-    get_resources $PER_STATE_MATCH_API_TAG $MATCH_RESOURCE_GROUP))
+    get_resources $PER_STATE_MATCH_API_TAG $RESOURCE_GROUP))
 
   orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
 
@@ -286,7 +286,7 @@ main () {
   do
     echo "Configure Easy Auth for PerStateMatchApi:${func} and OrchestratorApi"
     configure_easy_auth_pair \
-      $func $MATCH_RESOURCE_GROUP \
+      $func $RESOURCE_GROUP \
       $STATE_API_APP_ROLE \
       $orch_identity
   done

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -30,13 +30,13 @@ set_constants () {
   PG_SERVER_NAME=participant-records
 
   # Names of participant records database Vnet and Subnet
-  VNET_NAME=$PREFIX-vnet-core-$ENV
-  DB_SUBNET_NAME=$PREFIX-snet-core-$ENV # Subnet database private endpoint uses
-  FUNC_SUBNET_NAME=$PREFIX-snet-functionapps-$ENV # Subnet function apps uses
-  PRIVATE_ENDPOINT_NAME=$PREFIX-pe-$PG_SERVER_NAME-$ENV
+  VNET_NAME=vnet-core-$ENV
+  DB_SUBNET_NAME=snet-core-$ENV # Subnet database private endpoint uses
+  FUNC_SUBNET_NAME=snet-functionapps-$ENV # Subnet function apps uses
+  PRIVATE_ENDPOINT_NAME=pe-$PG_SERVER_NAME-$ENV
 
   # Base name of query tool app
-  QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
+  QUERY_TOOL_APP_NAME=app-query-tool-${ENV}
   QUERY_TOOL_FRONTDOOR_NAME=querytool
 
   # Base name of lookup API storage account
@@ -49,7 +49,7 @@ set_constants () {
   TENANT_ID=$(az account show --query homeTenantId -o tsv)
 
   # App service plan name for function apps
-  APP_SERVICE_PLAN_FUNC_NAME="${PREFIX}-plan-functionapps-${ENV}"
+  APP_SERVICE_PLAN_FUNC_NAME="plan-functionapps-${ENV}"
   APP_SERVICE_PLAN_FUNC_SKU=P1V2
   APP_SERVICE_PLAN_FUNC_KIND=functionapp
 }
@@ -274,10 +274,10 @@ main () {
     abbr=`echo "$abbr" | tr '[:upper:]' '[:lower:]'`
 
     # Per-state Function App
-    func_app=${PREFIX}-func-${abbr}etl-${ENV}
+    func_app=func-${abbr}etl-${ENV}
 
     # Storage account for the Function app for its own use;
-    func_stor=${PREFIX}stor${abbr}etl${ENV}
+    func_stor=stor${abbr}etl${ENV}
 
     # Managed identity to access database
     identity=`state_managed_id_name $abbr`
@@ -408,8 +408,8 @@ main () {
         --output tsv)
     db_conn_str=`pg_connection_string $PG_SERVER_NAME $db_name $identity`
     az_serv_str=`az_connection_string $RESOURCE_GROUP $identity`
-    func_app_name=${PREFIX}-func-${abbr}match-${ENV}
-    storage_acct_name=${PREFIX}stor${abbr}match${ENV}
+    func_app_name=func-${abbr}match-${ENV}
+    storage_acct_name=stor${abbr}match${ENV}
 
     echo "Deploying ${name} function resources"
     func_name=$(\
@@ -542,7 +542,7 @@ main () {
   ./configure-easy-auth.bash $azure_env
 
   echo "Secure database connection"
-  ./secure-resources.bash \
+  ./remove-external-network.bash \
     $azure_env \
     $RESOURCE_GROUP \
     $PG_SERVER_NAME

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -424,6 +424,7 @@ main () {
           identityGroup=$RESOURCE_GROUP \
           location=$LOCATION \
           azAuthConnectionString=$az_serv_str \
+          stateAbbr="$abbr" \
           stateName="$name" \
           functionAppName="$func_app_name" \
           storageAccountName="$storage_acct_name" \

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -29,6 +29,10 @@ set_constants () {
   # Name of PostgreSQL server
   PG_SERVER_NAME=participant-records
 
+  # Names of participant records database Vnet and Subnet
+  VNET_NAME=$PREFIX-vnet-$PG_SERVER_NAME-$ENV
+  SUBNET_NAME=$PREFIX-snet-$PG_SERVER_NAME-$ENV
+
   # Base name of query tool app
   QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
   QUERY_TOOL_FRONTDOOR_NAME=querytool
@@ -147,7 +151,9 @@ main () {
       serverName=$PG_SERVER_NAME \
       secretName=$PG_SECRET_NAME \
       vaultName=$VAULT_NAME \
-      resourceTags="$RESOURCE_TAGS"
+      resourceTags="$RESOURCE_TAGS" \
+      vnetName=$VNET_NAME \
+      subnetName=$SUBNET_NAME
 
   # The AD admin can't be specified in the PostgreSQL ARM template,
   # unlike in Azure SQL

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -15,7 +15,7 @@ source $(dirname "$0")/iac-common.bash || exit
 
 set_constants () {
   # Name of Key Vault
-  VAULT_NAME=secret-keeper
+  VAULT_NAME=secret-keeper-$ENV
 
   # Name of secret used to store the PostgreSQL server admin password
   PG_SECRET_NAME=particpants-records-admin
@@ -30,8 +30,10 @@ set_constants () {
   PG_SERVER_NAME=participant-records
 
   # Names of participant records database Vnet and Subnet
-  VNET_NAME=$PREFIX-vnet-$PG_SERVER_NAME-$ENV
-  SUBNET_NAME=$PREFIX-snet-$PG_SERVER_NAME-$ENV
+  VNET_NAME=$PREFIX-vnet-core-$ENV
+  DB_SUBNET_NAME=$PREFIX-snet-core-$ENV # Subnet database private endpoint uses
+  FUNC_SUBNET_NAME=$PREFIX-snet-functionapps-$ENV # Subnet function apps uses
+  PRIVATE_ENDPOINT_NAME=$PREFIX-pe-$PG_SERVER_NAME-$ENV
 
   # Base name of query tool app
   QUERY_TOOL_APP_NAME=${PREFIX}-app-query-tool-${ENV}
@@ -45,6 +47,11 @@ set_constants () {
 
   # App Service Authentication is done at the Azure tenant level
   TENANT_ID=$(az account show --query homeTenantId -o tsv)
+
+  # App service plan name for function apps
+  APP_SERVICE_PLAN_FUNC_NAME="${PREFIX}-plan-functionapps-${ENV}"
+  APP_SERVICE_PLAN_FUNC_SKU=P1V2
+  APP_SERVICE_PLAN_FUNC_KIND=functionapp
 }
 
 # Generate the storage account connection string for the corresponding
@@ -80,6 +87,13 @@ az_connection_string () {
     echo "RunAs=App;AppId=${client_id}"
 }
 
+# creating a function for this since we need it in a few different iterations
+state_managed_id_name () {
+  abbr=$1
+
+  echo "${abbr}admin"
+}
+
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
@@ -89,6 +103,21 @@ main () {
   set_constants
 
   ./create-resource-groups.bash $azure_env
+
+  # Virtual network is used to secure connections between
+  # participant records database and all apps that communicate with it.
+  # Apps will be integrated with VNet as they're created.
+  echo "Creating Virtual Network and Subnets"
+  az deployment group create \
+    --name $VNET_NAME \
+    --resource-group $RESOURCE_GROUP \
+      --template-file ./arm-templates/virtual-network.json \
+      --parameters \
+        location=$LOCATION \
+        resourceTags="$RESOURCE_TAGS" \
+        vnetName=$VNET_NAME \
+        databaseSubnetName=$DB_SUBNET_NAME \
+        funcSubnetName=$FUNC_SUBNET_NAME
 
   # uniqueString is used pervasively in our ARM templates to create globally
   # identifiers from the resource group id, but it is not available in the CLI.
@@ -153,7 +182,9 @@ main () {
       vaultName=$VAULT_NAME \
       resourceTags="$RESOURCE_TAGS" \
       vnetName=$VNET_NAME \
-      subnetName=$SUBNET_NAME
+      subnetName=$DB_SUBNET_NAME \
+      privateEndpointName=$PRIVATE_ENDPOINT_NAME
+
 
   # The AD admin can't be specified in the PostgreSQL ARM template,
   # unlike in Azure SQL
@@ -169,7 +200,7 @@ main () {
   while IFS=, read -r abbr name ; do
       echo "Creating managed identity for $name ($abbr)"
       abbr=`echo "$abbr" | tr '[:upper:]' '[:lower:]'`
-      identity=${abbr}admin
+      identity=`state_managed_id_name $abbr`
       az identity create -g $RESOURCE_GROUP -n $identity
   done < states.csv
 
@@ -223,6 +254,18 @@ main () {
   # This is a subscription-level resource provider
   az provider register --wait --namespace Microsoft.EventGrid
 
+  # Function apps need an app service plan with private endpoint abilities
+  echo "Creating app service plan ${APP_SERVICE_PLAN_FUNC_NAME}"
+  az deployment group create \
+    --name $APP_SERVICE_PLAN_FUNC_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --template-file ./arm-templates/app-service-plan.json \
+    --parameters \
+      name=$APP_SERVICE_PLAN_FUNC_NAME \
+      location=$LOCATION \
+      kind=$APP_SERVICE_PLAN_FUNC_KIND \
+      sku=$APP_SERVICE_PLAN_FUNC_SKU
+
   # Create per-state Function apps and assign corresponding managed identity for
   # access to the per-state blob-storage and database, set up system topics and
   # event subscription to bulk upload (blob creation) events
@@ -231,14 +274,13 @@ main () {
     abbr=`echo "$abbr" | tr '[:upper:]' '[:lower:]'`
 
     # Per-state Function App
-    func_app=${abbr}func${DEFAULT_UNIQ_STR}
+    func_app=${PREFIX}-func-${abbr}etl-${ENV}
 
     # Storage account for the Function app for its own use;
-    # matches name generated in function-storage.json
-    func_stor=${abbr}fstor${DEFAULT_UNIQ_STR}
+    func_stor=${PREFIX}stor${abbr}etl${ENV}
 
     # Managed identity to access database
-    identity=${abbr}admin
+    identity=`state_managed_id_name $abbr`
 
     # Per-state database
     db_name=${abbr}
@@ -261,11 +303,11 @@ main () {
     # e.g., bindings state, keys, function code. Keep this separate from
     # the storage account used to upload data for better isolation.
     az deployment group create \
-      --name "${abbr}-func-storage" \
+      --name $func_stor \
       --resource-group $RESOURCE_GROUP \
       --template-file ./arm-templates/function-storage.json \
       --parameters \
-        stateAbbreviation=$abbr \
+        uniqueStorageName=$func_stor \
         resourceTags="$RESOURCE_TAGS" \
         location=$LOCATION
 
@@ -274,13 +316,21 @@ main () {
     # working with Windows as underlying OS
     az functionapp create \
       --resource-group $RESOURCE_GROUP \
-      --consumption-plan-location $LOCATION \
+      --plan $APP_SERVICE_PLAN_FUNC_NAME \
       --tags Project=$PROJECT_TAG \
       --runtime dotnet \
       --functions-version 3 \
       --os-type Windows \
       --name $func_app \
       --storage-account $func_stor
+
+    # Integrate function app into Virtual Network
+    echo "Integrating ${func_app} into virtual network"
+    az functionapp vnet-integration add \
+      --name $func_app \
+      --resource-group $RESOURCE_GROUP \
+      --subnet $FUNC_SUBNET_NAME \
+      --vnet $VNET_NAME
 
     # XXX Assumes if any identity is set, it is the one we are specifying below
     exists=`az functionapp identity show \
@@ -348,7 +398,7 @@ main () {
     echo "Creating match API function app for $name ($abbr)"
     abbr=`echo "$abbr" | tr '[:upper:]' '[:lower:]'`
 
-    identity=${abbr}admin
+    identity=`state_managed_id_name $abbr`
     db_name=${abbr}
     client_id=$(\
       az identity show \
@@ -358,12 +408,14 @@ main () {
         --output tsv)
     db_conn_str=`pg_connection_string $PG_SERVER_NAME $db_name $identity`
     az_serv_str=`az_connection_string $RESOURCE_GROUP $identity`
+    func_app_name=${PREFIX}-func-${abbr}match-${ENV}
+    storage_acct_name=${PREFIX}stor${abbr}match${ENV}
 
     echo "Deploying ${name} function resources"
     func_name=$(\
       az deployment group create \
         --name match-api \
-        --resource-group $MATCH_RESOURCE_GROUP \
+        --resource-group $RESOURCE_GROUP \
         --template-file  ./arm-templates/function-state-match.json \
         --query properties.outputs.functionAppName.value \
         --output tsv \
@@ -373,15 +425,26 @@ main () {
           location=$LOCATION \
           azAuthConnectionString=$az_serv_str \
           stateName="$name" \
-          stateAbbr="$abbr" \
+          functionAppName="$func_app_name" \
+          storageAccountName="$storage_acct_name" \
+          managedIdentityName="$identity" \
           dbConnectionString="$db_conn_str" \
-          cloudName="$CLOUD_NAME")
+          cloudName="$CLOUD_NAME" \
+          appServicePlanName="$APP_SERVICE_PLAN_FUNC_NAME")
 
     # Store function names for future auth configuration
     match_func_names+=("$func_name")
 
     echo "Waiting to publish function app"
     sleep 60
+
+    # Integrate Function app into virtual network
+    echo "Integrating ${func_app_name} into virtual network"
+    az functionapp vnet-integration add \
+      --name $func_app_name \
+      --resource-group $RESOURCE_GROUP \
+      --subnet $FUNC_SUBNET_NAME \
+      --vnet $VNET_NAME
 
     echo "Publishing ${name} function app"
     pushd ../match/src/Piipan.Match.State
@@ -391,7 +454,7 @@ main () {
     # Store API query URIs as a JSON array to be bound to orchestrator API
     func_uri=$(\
       az functionapp function show \
-        --resource-group $MATCH_RESOURCE_GROUP \
+        --resource-group $RESOURCE_GROUP \
         --name $func_name \
         --function-name $MATCH_API_QUERY_NAME \
         --query invokeUrlTemplate \
@@ -472,6 +535,12 @@ main () {
   #   - PerStateMatchApi and OrchestratorApi
   #   - OrchestratorApi and QueryApp
   ./configure-easy-auth.bash $azure_env
+
+  echo "Secure database connection"
+  ./secure-resources.bash \
+    $azure_env \
+    $RESOURCE_GROUP \
+    $PG_SERVER_NAME
 
   script_completed
 }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -532,6 +532,10 @@ main () {
   # Establish metrics sub-system
   ./create-metrics-resources.bash $azure_env
 
+  # If running full iac script for the first time in new resource groups,
+  # un-comment this line:
+  # ./create-apim.bash $azure_env $APIM_EMAIL
+
   # Configures App Service Authentication between:
   #   - PerStateMatchApi and OrchestratorApi
   #   - OrchestratorApi and QueryApp

--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -1,20 +1,20 @@
+# Deployment environment for resource identifiers
+ENV=$(basename "${BASH_SOURCE%.*}")
+
 # Default location
 LOCATION=westus
 
 # Default resource group
-RESOURCE_GROUP=rg-core-dev
+RESOURCE_GROUP=rg-core-$ENV
 
 # Resource group for matching API
-MATCH_RESOURCE_GROUP=rg-match-dev
+MATCH_RESOURCE_GROUP=rg-match-$ENV
 
 # Resource group for metrics
-METRICS_RESOURCE_GROUP=rg-metrics-dev
+METRICS_RESOURCE_GROUP=rg-metrics-$ENV
 
 # Prefix for resource identifiers
 PREFIX=fns
-
-# Deployment environment for resource identifiers
-ENV=$(basename "${BASH_SOURCE%.*}")
 
 # Either AzureCloud or AzureUSGovernment
 CLOUD_NAME=AzureCloud

--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -18,3 +18,6 @@ PREFIX=fns
 
 # Either AzureCloud or AzureUSGovernment
 CLOUD_NAME=AzureCloud
+
+# used to create API Management resources
+APIM_EMAIL="<your email here>"

--- a/iac/remove-external-network.bash
+++ b/iac/remove-external-network.bash
@@ -9,7 +9,7 @@
 #   server_name (eg: fns-db-participant-records-dev)
 #
 # Usage:
-# ./iac/secure-resources.bash tts/dev rg-core-dev fns-db-participant-records-dev
+# ./iac/remove-external-network.bash tts/dev rg-core-dev fns-db-participant-records-dev
 
 source $(dirname "$0")/../tools/common.bash || exit
 source $(dirname "$0")/iac-common.bash || exit
@@ -29,7 +29,7 @@ main () {
 		--query "[].id" \
 		--output tsv`
 
-	len=`echo $ids | awk '{print length}'`
+	len=${#ids}
 	if [ $len -gt 1 ]; then
 		echo "Remove all firewall rules from database"
 		az postgres server firewall-rule delete \

--- a/iac/secure-resources.bash
+++ b/iac/secure-resources.bash
@@ -1,0 +1,48 @@
+#!/bin/bash
+# This script removes all firewall policies from database before
+# denying public access to database.
+# Once done, the only access to database would be through its private endpoint.
+#
+# Arguments:
+#   env (eg: tts/dev)
+#   resource_group (eg: rg-core-dev)
+#   server_name (eg: fns-db-participant-records-dev)
+#
+# Usage:
+# ./iac/secure-resources.bash tts/dev rg-core-dev fns-db-participant-records-dev
+
+source $(dirname "$0")/../tools/common.bash || exit
+source $(dirname "$0")/iac-common.bash || exit
+
+main () {
+  azure_env=$1
+  source $(dirname "$0")/env/${azure_env}.bash
+  verify_cloud
+
+  resource_group=$2
+  server_name=$3
+
+	echo "Collect all firewall rules on database"
+	ids=`az postgres server firewall-rule list \
+		--resource-group $resource_group \
+		--server-name $server_name \
+		--query "[].id" \
+		--output tsv`
+
+	len=`echo $ids | awk '{print length}'`
+	if [ $len -gt 1 ]; then
+		echo "Remove all firewall rules from database"
+		az postgres server firewall-rule delete \
+			--yes \
+			--ids $ids
+	fi
+
+	echo "Deny public access to database"
+	az postgres server update \
+		--name $server_name \
+		--resource-group $resource_group \
+		--public-network-access Disabled
+
+  script_completed
+}
+main "$@"


### PR DESCRIPTION
Reworking of #601, closes issues #11 and #659

Does the following:

- Shifts match api apps to core resource group (because VNets are resource-group-specific)
- Creates a single premium app service plan; puts both ETL and Match apps onto it (VNet integration is only available on premium plans or higher)
- Creates virtual network resource in separate ARM template with 2 subnets: one for the database private link, the other for the function apps
- Configures private endpoint on VNet when creating participant-records database
- Integrates ETL and Match apps with VNet
- Locks down public access to database at the end of iac by removing firewalls and changing DenyPublicAccess setting on it

Todo:
- [X]  Run on tts/dev `-dev` resources