### PR TITLE
Add context to match API README

### DIFF
--- a/match/README.md
+++ b/match/README.md
@@ -1,11 +1,18 @@
-# Active Match API
+# Duplicate Participation APIs
 
-*Piipan subsystem for active matching during program participant (re)certification*
+A collection of externally-available and internal APIs that:
+* Allow Piipan to find duplicate participation during participant certification or recertification
+* Allow agencies to find PII of individuals involved in a match using a Lookup ID
 
-## Documentation
+All APIs adhere to [OpenAPI specifications](./docs/openapi.md).
 
+## External APIs
+APIs that are made available to state systems integrating with Piipan make up the [Duplicate Participation API](./docs/duplicate-participation-api.md).
+
+These include:
+* [Orchestrator PII matching API](./docs/orchestrator-match.md) for learning whether an individual matches against other state participant records
+* [Lookup ID API](./docs/lookup.md) for retrieving PII involved in a match
+
+## Internal APIs
+APIs that Piipan uses internally but does not expose to agencies.
 * [Per-state PII matching API](./docs/state-match.md)
-* [Orchestrator PII matching API](./docs/orchestrator-match.md)
-* [Match ID Lookup](./docs/lookup.md)
-* [OpenAPI specifications](./docs/openapi.md)
-* [Duplicate participation API](./docs/duplicate-participation-api.md)


### PR DESCRIPTION
Clarify which APIs are internal-only vs. exposed externally.  Added a little context about the APIs.  Attempted to standardize on current naming conventions.  One possible further improvement would be to fold the links to the orchestrator and lookup ID APIs into /docs/duplicate-participation-api.md