### PR TITLE
Initial documentation for bulk upload API

### DIFF
--- a/etl/README.md
+++ b/etl/README.md
@@ -6,3 +6,4 @@
 
 * [Extract-Transform-Load process for PII bulk import](./docs/etl.md)
 * [Bulk import format for participant records](./docs/bulk-import.md)
+* [Bulk upload API for importing participant records](./docs/api.md)

--- a/etl/docs/api.md
+++ b/etl/docs/api.md
@@ -1,0 +1,20 @@
+# Bulk upload API
+
+## Summary
+
+An external-facing API for uploading [bulk participant records](bulk-import.md). Designed as a frontend for the [Blob service REST API's](https://docs.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api) [`Put Blob` operation](https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob) that abstracts away authentication complexity.
+
+Implemented as one API for each per-state storage account, all managed in a single Azure API Management (APIM) instance. The APIM instance is shared with the [duplicate participation API](../../match/duplicate-participation-api.md).
+
+## APIM implementation
+
+The IaC creates _N_ per-state API version sets within the APIM instance. Each version set contains an API resource with a single `PUT` operation. The API resource is configured to require an active subscription.
+
+An [APIM policy](../../iac/apim-bulkupload-policy.xml) is applied to API to handle authentication and enrich the incoming request with required headers. Specifically, the policy:
+
+- Uses the `authentication-managed-identity` [policy](https://docs.microsoft.com/en-us/azure/api-management/api-management-authentication-policies#ManagedIdentity) to authenticate with the state storage account using the APIM instance's system-assigned identity and add the necessary `Autorization` header to the request.
+- Automatically adds the required `Date`, `x-ms-version`, and `x-ms-blob-type` headers and sets them to appropriate values.
+
+## Endpoints
+
+The bulk upload API consists of a single `/upload/{filename}` endpoint which receives `PUT` requests. See the [OpenAPI spec](openapi/openapi.yaml).

--- a/etl/docs/openapi/openapi.yaml
+++ b/etl/docs/openapi/openapi.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.0
+info:
+  title: Bulk upload API
+  version: 1.0.0
+  description: API for uploading bulk participant data
+tags:
+  - name: "Upload"
+paths:
+  '/upload/{filename}':
+    put:
+      summary: Upload a CSV file of bulk participant data
+      tags:
+        - "Upload"
+      parameters:
+        - name: filename
+          in: path
+          description: Name of file being uploaded
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Content-Length
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '201':
+          description: File uploaded
+        '401':
+          description: Access denied
+        '411':
+          description: Content-Length not provided
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Ocp-Apim-Subscription-Key

--- a/etl/docs/uploads.md
+++ b/etl/docs/uploads.md
@@ -1,8 +1,8 @@
 ## Uploading Participant Data
 
-> ⚠️ The service API for the bulk upload of PII data is not stable enough for client development. This documentation describes the nascent API and a _temporary_ approach that should allow states to quickly provide test data to our system with out expending development effort unnecessarily.
+> ⚠️ This documentation describes the bulk upload API and a _temporary_ upload approach using AzCopy that should allow states to quickly provide test data to our system with out expending development effort unnecessarily.
 
-Once you have [validated the format](./bulk-import.md) of your participant data CSV, you can upload the file to the system through AzCopy.
+Once you have [validated the format](./bulk-import.md) of your participant data CSV, you can upload the file to the system through the bulk upload API or AzCopy.
 
 ### AzCopy
 
@@ -56,8 +56,7 @@ The bulk upload API consists of a single HTTP `PUT` endpoint that you can use to
 
 Contact a project representative to gain the necessary information for calling the API. You will receive:
 - An API endpoint specific to your state, in the format `https://<api-domain>/<state-identifier>/upload/`
-- A primary API key
-- A secondary API key
+- An API key
 
 #### Uploading a file
 
@@ -69,14 +68,14 @@ https://<api-domain>/<state-identifer>/upload/bulk-data.csv
 ```
 
 Second, send a `PUT` request to the endpoint and include the following headers:
-- `Ocp-Apim-Subscription-Key: <api-key>` — where `<api-key>` is either your primary or secondary key.
-- `Content-Length: <filesize>` — where `<filesize>` is the size of the file you are uploading, in bytes. Many tools (like `curl` or [Postman](https://www.postman.com/)) will automatically include this header for you.
+- `Ocp-Apim-Subscription-Key: <api-key>` — where `<api-key>` is the API key you were provided.
+- `Content-Length: <filesize>` — where `<filesize>` is the size of the file you are uploading, in bytes. Many tools (like `curl`, Powershell's `Invoke-WebRequest`, or [Postman](https://www.postman.com/)) will automatically include this header for you.
 
 If your file is successfully uploaded you will receive an HTTP response with a `201 created` status.
 
 ##### Example using Powershell
 
-To call the API from Powershell using `Invoke-WebRequest`, run the following command substituting `<endpoint-url>` with the full endpoint URL (containing filename), `<api-key>` with your primary key, and `<path-to-csv>` with the path the CSV file you are uploading.
+To call the API from Powershell using `Invoke-WebRequest`, run the following command substituting `<endpoint-url>` with the full endpoint URL (containing filename), `<api-key>` with your API key, and `<path-to-csv>` with the path the CSV file you are uploading.
 
 ```
 $url = '<endpoint-url>'
@@ -91,7 +90,7 @@ Invoke-WebRequest -Uri $url -Method Put -Headers $headers -Body $body
 
 ##### Example using `curl`
 
-To call the API from a bash shell using `curl`, run the following command substituting `<endpoint-url>` with the full endpoint URL (containing filename), `<api-key>` with your primary key, and `<path-to-csv>` with the path the CSV file you are uploading.
+To call the API from a bash shell using `curl`, run the following command substituting `<endpoint-url>` with the full endpoint URL (containing filename), `<api-key>` with your API key, and `<path-to-csv>` with the path the CSV file you are uploading.
 
 ```
 curl --location --request PUT '<endpoint-url>' \
@@ -101,9 +100,3 @@ curl --location --request PUT '<endpoint-url>' \
 ```
 
 *Note: `curl` automatically includes the required `Content-Length` header.*
-
-#### Managing API keys
-
-In order to support credential rotation without downtime, you will be issued two API keys: one primary and one secondary. Either can be used to make API calls.
-
-For example: in the event your primary key needs to be regenerated, you can temporarily switch to using your secondary key until the updated primary key has been issued.

--- a/etl/docs/uploads.md
+++ b/etl/docs/uploads.md
@@ -1,8 +1,9 @@
 ## Uploading Participant Data
 
-> ⚠️ The service API for the bulk upload of PII data is not stable enough for client development. This documentation describes a _temporary_ approach that should allow states to quickly provide test data to our system with out expending development effort unnecessarily.
+> ⚠️ The service API for the bulk upload of PII data is not stable enough for client development. This documentation describes the nascent API and a _temporary_ approach that should allow states to quickly provide test data to our system with out expending development effort unnecessarily.
 
 Once you have [validated the format](./bulk-import.md) of your participant data CSV, you can upload the file to the system through AzCopy.
+
 ### AzCopy
 
 AzCopy is a Microsoft-supported command line utility that you can use to upload files to Azure blob storage resources.
@@ -46,3 +47,63 @@ $ azcopy copy 'name-of-file.csv' 'https://my-storage-account-name.blob.core.wind
 ```
 
 For more details on uploading files through AzCopy, visit the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-blobs-upload).
+
+### Bulk upload API
+
+The bulk upload API consists of a single HTTP `PUT` endpoint that you can use to upload the participant data CSV file.
+
+#### Authorization
+
+Contact a project representative to gain the necessary information for calling the API. You will receive:
+- An API endpoint specific to your state, in the format `https://<api-domain>/<state-identifier>/upload/`
+- A primary API key
+- A secondary API key
+
+#### Uploading a file
+
+To upload a file, make an API call that conforms to the [API spec](openapi/openapi.yaml).
+
+First, construct the URL for the API call by appending the filename to endpoint you were given. For example:
+```
+https://<api-domain>/<state-identifer>/upload/bulk-data.csv
+```
+
+Second, send a `PUT` request to the endpoint and include the following headers:
+- `Ocp-Apim-Subscription-Key: <api-key>` — where `<api-key>` is either your primary or secondary key.
+- `Content-Length: <filesize>` — where `<filesize>` is the size of the file you are uploading, in bytes. Many tools (like `curl` or [Postman](https://www.postman.com/)) will automatically include this header for you.
+
+If your file is successfully uploaded you will receive an HTTP response with a `201 created` status.
+
+##### Example using Powershell
+
+To call the API from Powershell using `Invoke-WebRequest`, run the following command substituting `<endpoint-url>` with the full endpoint URL (containing filename), `<api-key>` with your primary key, and `<path-to-csv>` with the path the CSV file you are uploading.
+
+```
+$url = '<endpoint-url>'
+$headers = @{
+    'Ocp-Apim-Subscription-Key' = '<api-key>'
+}
+$body = Get-Content <path-to-csv> -Raw
+Invoke-WebRequest -Uri $url -Method Put -Headers $headers -Body $body
+```
+
+*Note: `Invoke-WebRequest` automatically includes the required `Content-Length` header.*
+
+##### Example using `curl`
+
+To call the API from a bash shell using `curl`, run the following command substituting `<endpoint-url>` with the full endpoint URL (containing filename), `<api-key>` with your primary key, and `<path-to-csv>` with the path the CSV file you are uploading.
+
+```
+curl --location --request PUT '<endpoint-url>' \
+--header 'Ocp-Apim-Subscription-Key: <api-key>' \
+--upload-file "<path-to-csv>"  \
+--include
+```
+
+*Note: `curl` automatically includes the required `Content-Length` header.*
+
+#### Managing API keys
+
+In order to support credential rotation without downtime, you will be issued two API keys: one primary and one secondary. Either can be used to make API calls.
+
+For example: in the event your primary key needs to be regenerated, you can temporarily switch to using your secondary key until the updated primary key has been issued.


### PR DESCRIPTION
- Add state-facing instructions
- Add OpenAPI spec
- Add developer-facing documentation

Wasn't sure if the `curl` and Powershell instructions were necessary, but included them to match the format of the AzCopy instructions.

Follow-on work to #682.