### PR TITLE
create single openapi spec for apim api; generate markdown docs

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -1,0 +1,28 @@
+> :warning Developer documentation only
+
+# State-facing API Specification
+
+## Prerequisites
+- [Swagger/OpenAPI CLI](https://github.com/APIDevTools/swagger-cli)
+- [Swagger Markdown tool](https://www.npmjs.com/package/swagger-markdown)
+
+This is the OpenAPI specification for our state-facing API. This spec mirrors what's found in our Azure API Management (APIM) instance as the "Duplication Participation" API.
+
+The goal of this spec is to generate documentation that states will use to integrate with our system.
+
+## Directory Structure
+
+Within the top-level `openapi` directory, there's an OpenAPI spec representing the Duplicate Participation API. Since this API is essentially a compilation of our various subsystem API's, this spec is composed of paths from various subsystem OpenAPI specs. The subsystem specs are managed in their own subdirectories as the single source of truth, and merely referenced here.
+
+The top-level directory also has a tools directory for automatic documentation generation.
+
+Generating documentation will alter the contents of the `generated` directory.
+
+## Generating Documentation
+
+from piipan project root, `cd docs/openapi` then run:
+```
+./tools/generate-docs.bash
+```
+
+This creates a markdown file within the `generated` directory that's used for external documentation.

--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -1,5 +1,3 @@
-> :warning Developer documentation only
-
 # State-facing API Specification
 
 ## Prerequisites

--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -12,3 +12,11 @@ paths:
     $ref: '../../match/docs/openapi/orchestrator/query.yaml'
   /lookup_ids/{id}:
     $ref: '../../match/docs/openapi/lookup/id.yaml'
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Ocp-Apim-Subscription-Key

--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -1,10 +1,12 @@
 openapi: 3.0.0
 info:
   title: "Duplicate Participation API"
-  version: 0.1.0
+  version: 1.0.0
   description: "The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur"
 tags:
   - name: "Duplicate Participation API"
+servers:
+  - url: "/v1"
 paths:
   /query:
     $ref: '../../match/docs/openapi/orchestrator/query.yaml'

--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: "Duplicate Participation API"
+  version: 0.1.0
+  description: "The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur"
+tags:
+  - name: "Duplicate Participation API"
+paths:
+  /query:
+    $ref: '../../match/docs/openapi/orchestrator/query.yaml'
+  /lookup_ids/{id}:
+    $ref: '../../match/docs/openapi/lookup/id.yaml'

--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -3,8 +3,6 @@ info:
   title: "Duplicate Participation API"
   version: 1.0.0
   description: "The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur"
-tags:
-  - name: "Duplicate Participation API"
 servers:
   - url: "/v1"
 paths:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -1,10 +1,14 @@
 <!-- Generator: Widdershins v4.0.1 -->
 
-<h1 id="duplicate-participation-api">Duplicate Participation API v0.1.0</h1>
+<h1 id="duplicate-participation-api">Duplicate Participation API v1.0.0</h1>
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
 The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur
+
+Base URLs:
+
+* <a href="/v1">/v1</a>
 
 <h1 id="duplicate-participation-api-match">Match</h1>
 
@@ -14,7 +18,7 @@ The API for the Duplicate Participation system where bulk upload, matching, and 
 
 ```shell
 # You can also use wget
-curl -X POST /query \
+curl -X POST /v1/query \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json'
 
@@ -104,7 +108,7 @@ This operation does not require authentication
 
 ```shell
 # You can also use wget
-curl -X GET /lookup_ids/{id} \
+curl -X GET /v1/lookup_ids/{id} \
   -H 'Accept: application/json'
 
 ```

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -10,9 +10,16 @@ Base URLs:
 
 * <a href="/v1">/v1</a>
 
+# Authentication
+
+* API Key (ApiKeyAuth)
+    - Parameter Name: **Ocp-Apim-Subscription-Key**, in: header. 
+
 <h1 id="duplicate-participation-api-match">Match</h1>
 
-## post__query
+## Query for Matches
+
+<a id="opIdQuery for Matches"></a>
 
 > Code samples
 
@@ -20,7 +27,8 @@ Base URLs:
 # You can also use wget
 curl -X POST /v1/query \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Ocp-Apim-Subscription-Key: API_KEY'
 
 ```
 
@@ -44,12 +52,6 @@ Queries all state databases for any PII records that are an exact match to the f
 }
 ```
 
-<h3 id="post__query-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|body|body|object|true|none|
-
 > Example responses
 
 > 200 Response
@@ -72,14 +74,14 @@ Queries all state databases for any PII records that are an exact match to the f
 }
 ```
 
-<h3 id="post__query-responses">Responses</h3>
+<h3 id="query-for-matches-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Matching PII records, if any exist|Inline|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Missing one of the required properties in the request body.|None|
 
-<h3 id="post__query-responseschema">Response Schema</h3>
+<h3 id="query-for-matches-responseschema">Response Schema</h3>
 
 Status Code **200**
 
@@ -96,20 +98,24 @@ Status Code **200**
 |»» state_abbr|string|false|none|State/territory two-letter postal abbreviation|
 |»» exception|string|false|none|Placeholder for value indicating special processing instructions|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+ApiKeyAuth
 </aside>
 
 <h1 id="duplicate-participation-api-lookup">Lookup</h1>
 
-## get__lookup_ids_{id}
+## Get Lookups by ID
+
+<a id="opIdGet Lookups by ID"></a>
 
 > Code samples
 
 ```shell
 # You can also use wget
 curl -X GET /v1/lookup_ids/{id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Ocp-Apim-Subscription-Key: API_KEY'
 
 ```
 
@@ -135,7 +141,7 @@ User can provide a Lookup ID and receive the match data associated with it
 }
 ```
 
-<h3 id="get__lookup_ids_{id}-responses">Responses</h3>
+<h3 id="get-lookups-by-id-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
@@ -143,9 +149,10 @@ User can provide a Lookup ID and receive the match data associated with it
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
 
-<h3 id="get__lookup_ids_{id}-responseschema">Response Schema</h3>
+<h3 id="get-lookups-by-id-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+ApiKeyAuth
 </aside>
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -1,0 +1,147 @@
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="duplicate-participation-api">Duplicate Participation API v0.1.0</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur
+
+<h1 id="duplicate-participation-api-match">Match</h1>
+
+## post__query
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X POST /query \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json'
+
+```
+
+`POST /query`
+
+*Search for all matching PII records*
+
+Queries all state databases for any PII records that are an exact match to the full name, date of birth, and social security number in the request body's `query` property.
+
+> Body parameter
+
+```json
+{
+  "query": {
+    "first": "string",
+    "middle": "string",
+    "last": "string",
+    "ssn": "string",
+    "dob": "2019-08-24"
+  }
+}
+```
+
+<h3 id="post__query-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|object|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "lookup_id": "string",
+  "matches": [
+    {
+      "first": "string",
+      "middle": "string",
+      "last": "string",
+      "ssn": "string",
+      "dob": "2019-08-24",
+      "state_name": "string",
+      "state_abbr": "string",
+      "exception": "string"
+    }
+  ]
+}
+```
+
+<h3 id="post__query-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Matching PII records, if any exist|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Missing one of the required properties in the request body.|None|
+
+<h3 id="post__query-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|» lookup_id|string¦null|false|none|the identifier of the match request|
+|» matches|[object]|false|none|none|
+|»» first|string|false|none|First name|
+|»» middle|string|false|none|Middle name|
+|»» last|string|true|none|Last name|
+|»» ssn|string|true|none|Social Security number|
+|»» dob|string(date)|true|none|Date of birth|
+|»» state_name|string|false|none|Full state/territory name|
+|»» state_abbr|string|false|none|State/territory two-letter postal abbreviation|
+|»» exception|string|false|none|Placeholder for value indicating special processing instructions|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+<h1 id="duplicate-participation-api-lookup">Lookup</h1>
+
+## get__lookup_ids_{id}
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET /lookup_ids/{id} \
+  -H 'Accept: application/json'
+
+```
+
+`GET /lookup_ids/{id}`
+
+*get the original match data related to a Lookup ID*
+
+User can provide a Lookup ID and receive the match data associated with it
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "first": "string",
+    "middle": "string",
+    "last": "string",
+    "ssn": "string",
+    "dob": "2019-08-24"
+  }
+}
+```
+
+<h3 id="get__lookup_ids_{id}-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|original active match data|Inline|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
+
+<h3 id="get__lookup_ids_{id}-responseschema">Response Schema</h3>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -10,6 +10,7 @@ servers:
 paths:
   /query:
     post:
+      operationId: Query for Matches
       tags:
         - Match
       summary: Search for all matching PII records
@@ -99,6 +100,7 @@ paths:
           description: Bad request. Missing one of the required properties in the request body.
   '/lookup_ids/{id}':
     get:
+      operationId: Get Lookups by ID
       tags:
         - Lookup
       summary: get the original match data related to a Lookup ID
@@ -119,3 +121,11 @@ paths:
           description: Bad request
         '404':
           description: Not Found
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Ocp-Apim-Subscription-Key

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -1,10 +1,12 @@
 openapi: 3.0.0
 info:
   title: Duplicate Participation API
-  version: 0.1.0
+  version: 1.0.0
   description: 'The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur'
 tags:
   - name: Duplicate Participation API
+servers:
+  - url: /v1
 paths:
   /query:
     post:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -1,0 +1,119 @@
+openapi: 3.0.0
+info:
+  title: Duplicate Participation API
+  version: 0.1.0
+  description: 'The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur'
+tags:
+  - name: Duplicate Participation API
+paths:
+  /query:
+    post:
+      tags:
+        - Match
+      summary: Search for all matching PII records
+      description: 'Queries all state databases for any PII records that are an exact match to the full name, date of birth, and social security number in the request body''s `query` property.'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - query
+              properties:
+                query:
+                  type: object
+                  required:
+                    - first
+                    - last
+                    - dob
+                    - ssn
+                  properties:
+                    first:
+                      type: string
+                      description: PII record's first name
+                    middle:
+                      type: string
+                      description: PII record's middle name
+                    last:
+                      type: string
+                      description: PII record's last name
+                    ssn:
+                      type: string
+                      description: PII record's social security number
+                      pattern: '^\d{3}-\d{2}-\d{4}$'
+                    dob:
+                      type: string
+                      format: date
+                      description: PII record's date of birth
+      responses:
+        '200':
+          description: 'Matching PII records, if any exist'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lookup_id:
+                    type: string
+                    nullable: true
+                    description: the identifier of the match request
+                  matches:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - last
+                        - ssn
+                        - dob
+                      properties:
+                        first:
+                          type: string
+                          description: First name
+                        middle:
+                          type: string
+                          description: Middle name
+                        last:
+                          type: string
+                          description: Last name
+                        ssn:
+                          type: string
+                          description: Social Security number
+                          pattern: '^\d{3}-\d{2}-\d{4}$'
+                        dob:
+                          type: string
+                          format: date
+                          description: Date of birth
+                        state_name:
+                          type: string
+                          description: Full state/territory name
+                        state_abbr:
+                          type: string
+                          description: State/territory two-letter postal abbreviation
+                        exception:
+                          type: string
+                          description: Placeholder for value indicating special processing instructions
+        '400':
+          description: Bad request. Missing one of the required properties in the request body.
+  '/lookup_ids/{id}':
+    get:
+      tags:
+        - Lookup
+      summary: get the original match data related to a Lookup ID
+      description: User can provide a Lookup ID and receive the match data associated with it
+      responses:
+        '200':
+          description: original active match data
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/query'
+        '400':
+          description: Bad request
+        '404':
+          description: Not Found

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -3,8 +3,6 @@ info:
   title: Duplicate Participation API
   version: 1.0.0
   description: 'The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur'
-tags:
-  - name: Duplicate Participation API
 servers:
   - url: /v1
 paths:

--- a/docs/openapi/tools/generate-docs.bash
+++ b/docs/openapi/tools/generate-docs.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Validates and bundles Open Api spec for duplicate participation API
+# into a single openapi markdown file to serve as API documentation.
+#
+# Requires swagger-cli (https://github.com/APIDevTools/swagger-cli)
+# Requires widdershins cli (https://github.com/Mermade/widdershins/tree/master)
+#
+# usage (from project root):
+# cd docs/openapi
+# ./tools/generate-docs.bash
+
+set -e
+set -u
+
+main () {
+    ./tools/generate-specs.bash
+    pushd ./generated/duplicate-participation-api/
+        widdershins \
+            --language_tabs 'shell:curl:request' \
+            --expandBody \
+            --omitHeader \
+            --shallowSchemas \
+            openapi.yaml \
+            -o openapi.md
+    popd
+}
+
+main

--- a/docs/openapi/tools/generate-docs.bash
+++ b/docs/openapi/tools/generate-docs.bash
@@ -18,7 +18,7 @@ main () {
     pushd ./generated/duplicate-participation-api/
         widdershins \
             --language_tabs 'shell:curl:request' \
-            --expandBody \
+            --omitBody \
             --omitHeader \
             --shallowSchemas \
             openapi.yaml \

--- a/docs/openapi/tools/generate-specs.bash
+++ b/docs/openapi/tools/generate-specs.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Validates a decomposed YAML OpenAPI spec and bundles it into a
+# single openapi.yaml file.
+#
+# Requires swagger-cli (https://github.com/APIDevTools/swagger-cli)
+#
+# usage: generate-spec.bash
+
+set -e
+set -u
+
+main () {
+    specs=(duplicate-participation-api)
+
+    for s in "${specs[@]}"
+    do
+        spec_path="./${s}.yaml"
+        generated_path="./generated/${s}/openapi.yaml"
+
+        echo "Validating ${spec_path}"
+        swagger-cli validate $spec_path
+
+        echo "Generating ${generated_path}"
+        swagger-cli bundle $spec_path -o $generated_path -t yaml
+    done
+}
+
+main

--- a/docs/quick-start-guide-states.md
+++ b/docs/quick-start-guide-states.md
@@ -24,7 +24,7 @@ These three elements translate to three main areas of the API that states will i
 
 ### Environments
 
-Seperate endpoints and credentials will be provoded for each environment.
+Seperate endpoints and credentials will be provided for each environment.
 
 | environment | purpose |
 |---|---|
@@ -34,16 +34,26 @@ Seperate endpoints and credentials will be provoded for each environment.
 
 ### Endpoints Overview
 
-| endpoint | description | Type | Parameters | Response | Authentication | Instructions |
+| Endpoint | Description | Type |
 |---|---|---|---|---|---|---|
-| `/BulkUpload` | uploads bulk participant data to the system | POST | a CSV file [in this format](../etl/docs/bulk-import.md) | [coming soon] | contact us | [link](./etl/docs/upload.md) |
-| [coming soon] | query for status on data processing from a bulk upload | POST | [coming soon] | [coming soon] | contact us | [coming soon] |
-| `/query` | query for active matches | POST | refer to the [OpenApi Schema](../match/docs/openapi/orchestrator/index.yaml) | refer to the [OpenApi Schema](../match/docs/openapi/orchestrator/index.yaml) | contact us | [coming soon] |
-| `lookup_ids/:id` | Returns PII for a Lookup ID | GET | Lookup ID | [coming soon] | contact us | [coming soon] |
+| `/BulkUpload` | uploads bulk participant data to the system | POST |
+| [coming soon] | query for status on data processing from a bulk upload | POST |
+| `/query` | query for active matches | POST |
+| `lookup_ids/:id` | Returns PII for a Lookup ID | GET |
+
+Detailed documentation for each endpoint can be found [here](./openapi/generated/duplicate-participation-api/openapi.md).
 
 ## Authentication
 
-To use all endpoints, states will need two sets of credentials: one for bulk uploading and another for the rest of the endpoints. Contact us for access.
+Users will obtain two API subscription keys that will be rotated on a rolling basis. Keys will be placed into request headers.
+
+Example using cURL:
+
+```
+curl --request PUT '<uri>' --header 'Ocp-Apim-Subscription-Key: <api-key>'
+```
+
+Different endpoints may require different sets of keys. Contact us for access to these keys.
 
 ## Feedback
 

--- a/docs/quick-start-guide-states.md
+++ b/docs/quick-start-guide-states.md
@@ -1,5 +1,6 @@
 # Quick-Start Guide for States
 
+> This documentation is for state use
 > ⚠️  Under construction
 
 For a high-level view of system architecture, go [here](../README.md).
@@ -20,7 +21,7 @@ These three elements translate to three main areas of the API that states will i
 
 1. States will upload participant data through a scheduled [CSV upload](../etl/README.md)
 2. Eligibility workers will conduct matches through [Active Matching](../match/README.md)
-3. Eligibility workers will be able to take action by referencing previous matches through [a Lookup ID](../match/docs/openapi/orchestrator/index.yaml)
+3. Eligibility workers will be able to take action by referencing previous matches through [a Lookup ID](./openapi/generated/duplicate-participation-api/openapi.md#Lookup)
 
 ### Environments
 
@@ -36,16 +37,15 @@ Seperate endpoints and credentials will be provided for each environment.
 
 | Endpoint | Description | Type |
 |---|---|---|---|---|---|---|
-| `/BulkUpload` | uploads bulk participant data to the system | POST |
-| [coming soon] | query for status on data processing from a bulk upload | POST |
+| `/<state-abbr>/upload` | uploads bulk participant data to the system | POST |
 | `/query` | query for active matches | POST |
-| `lookup_ids/:id` | Returns PII for a Lookup ID | GET |
+| `/lookup_ids/:id` | Returns PII for a Lookup ID | GET |
 
 Detailed documentation for each endpoint can be found [here](./openapi/generated/duplicate-participation-api/openapi.md).
 
 ## Authentication
 
-Users will obtain two API subscription keys that will be rotated on a rolling basis. Keys will be placed into request headers.
+States will be issued API keys that are placed into request headers to authenticate a web service call. The bulk upload API requires a separate API key from the query and lookup APIs.
 
 Example using cURL:
 
@@ -53,12 +53,10 @@ Example using cURL:
 curl --request PUT '<uri>' --header 'Ocp-Apim-Subscription-Key: <api-key>'
 ```
 
-Different endpoints may require different sets of keys. Contact us for access to these keys.
-
 ## Feedback
 
 We track API issues through [Github Issues](https://github.com/18F/piipan/issues).
 
-We also have a Slack channel for daily communication (forthcoming).
+We also have a Microsoft Teams channel for daily communication (forthcoming).
 
 

--- a/docs/quick-start-guide-states.md
+++ b/docs/quick-start-guide-states.md
@@ -37,7 +37,7 @@ Seperate endpoints and credentials will be provided for each environment.
 
 | Endpoint | Description | Type |
 |---|---|---|---|---|---|---|
-| `/<state-abbr>/upload` | uploads bulk participant data to the system | POST |
+| `/<state-abbreviation>/upload/:filename` | uploads bulk participant data to the system | POST |
 | `/query` | query for active matches | POST |
 | `/lookup_ids/:id` | Returns PII for a Lookup ID | GET |
 

--- a/docs/quick-start-guide-states.md
+++ b/docs/quick-start-guide-states.md
@@ -1,6 +1,7 @@
 # Quick-Start Guide for States
 
 > This documentation is for state use
+
 > ⚠️  Under construction
 
 For a high-level view of system architecture, go [here](../README.md).
@@ -36,7 +37,7 @@ Seperate endpoints and credentials will be provided for each environment.
 ### Endpoints Overview
 
 | Endpoint | Description | Type |
-|---|---|---|---|---|---|---|
+|---|---|---|
 | `/<state-abbreviation>/upload/:filename` | uploads bulk participant data to the system | POST |
 | `/query` | query for active matches | POST |
 | `/lookup_ids/:id` | Returns PII for a Lookup ID | GET |

--- a/match/docs/openapi/lookup/id.yaml
+++ b/match/docs/openapi/lookup/id.yaml
@@ -1,4 +1,5 @@
 get:
+  operationId: "Get Lookups by ID"
   tags:
     - "Lookup"
   summary: "get the original match data related to a Lookup ID"

--- a/match/docs/openapi/lookup/id.yaml
+++ b/match/docs/openapi/lookup/id.yaml
@@ -1,0 +1,16 @@
+get:
+  tags:
+    - "Lookup"
+  summary: "get the original match data related to a Lookup ID"
+  description: "User can provide a Lookup ID and receive the match data associated with it"
+  responses:
+    '200':
+      description: "original active match data"
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/lookup.yaml#/LookupIdResponse'
+    '400':
+      description: "Bad request"
+    '404':
+      description: "Not Found"

--- a/match/docs/openapi/lookup/index.yaml
+++ b/match/docs/openapi/lookup/index.yaml
@@ -6,23 +6,8 @@ info:
   description: "API for providing a Lookup ID and receiving the original match data"
 servers:
   - url: "/v1"
+tags:
+  - name: "Lookup"
 paths:
   /lookup_ids/{id}:
-    get:
-      summary: "get the original match data related to a Lookup ID"
-      description: "User can provide a Lookup ID and receive the match data associated with it"
-      responses:
-        '200':
-          description: "original active match data"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LookupIdResponse'
-        '400':
-          description: "Bad request"
-        '404':
-          description: "Not Found"
-components:
-  schemas:
-    LookupIdResponse:
-      $ref: '../schemas/lookup.yaml#/LookupIdResponse'
+    $ref: './id.yaml'

--- a/match/docs/openapi/orchestrator/index.yaml
+++ b/match/docs/openapi/orchestrator/index.yaml
@@ -10,29 +10,4 @@ servers:
   - url: "/v1"
 paths:
   /query:
-    post:
-      tags:
-        - "Match"
-      summary: "Search for all matching PII records"
-      description: "Queries all state databases for any PII records that are an exact match to the full name, date of birth, and social security number in the request body's `query` property."
-      requestBody:
-        $ref: '#/components/requestBodies/MatchQueryRequest'
-      responses:
-        '200':
-          description: "Matching PII records, if any exist"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MatchQueryResponse'
-        '400':
-          description: "Bad request. Missing one of the required properties in the request body."
-components:
-  requestBodies:
-    MatchQueryRequest:
-      $ref: '../schemas/match-query.yaml#/MatchQueryRequest'
-  schemas:
-    MatchQueryResponse:
-      $ref: '../schemas/match-query.yaml#/MatchQueryResponse'
-    PiiRecord:
-      $ref: '../schemas/pii-record.yaml#/PiiRecord'
-
+    $ref: './query.yaml'

--- a/match/docs/openapi/orchestrator/query.yaml
+++ b/match/docs/openapi/orchestrator/query.yaml
@@ -1,4 +1,5 @@
 post:
+  operationId: "Query for Matches"
   tags:
     - "Match"
   summary: "Search for all matching PII records"

--- a/match/docs/openapi/orchestrator/query.yaml
+++ b/match/docs/openapi/orchestrator/query.yaml
@@ -1,0 +1,16 @@
+post:
+  tags:
+    - "Match"
+  summary: "Search for all matching PII records"
+  description: "Queries all state databases for any PII records that are an exact match to the full name, date of birth, and social security number in the request body's `query` property."
+  requestBody:
+    $ref: '../schemas/match-query.yaml#/MatchQueryRequest'
+  responses:
+    '200':
+      description: "Matching PII records, if any exist"
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/match-query.yaml#/MatchQueryResponse'
+    '400':
+      description: "Bad request. Missing one of the required properties in the request body."

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -5,6 +5,8 @@ MatchQueryRequest:
     application/json:
       schema:
         type: object
+        required:
+            - query
         properties:
           query:
             $ref: '#/MatchQuery'
@@ -45,4 +47,4 @@ MatchQueryResponse:
     matches:
       type: array
       items:
-        $ref: 'pii-record.yaml#/PiiRecord'
+        $ref: './pii-record.yaml#/PiiRecord'


### PR DESCRIPTION
Addresses 2nd and 3rd items of #623 

- Creates a top-level OpenAPI spec to represent the Duplicate Participation API managed by APIM
- Adds a script to generate markdown documentation for this spec
- Links to this markdown documentation in State Quickstart Guide

Considerations:
- The swagger-markdown tool I originally wanted to use is incompatible with OpenApi 3.0—the generated markdown wasn't showing any info about request parameters. So I found another cli tool called [widdershins](https://github.com/Mermade/widdershins). It's normally used for generating markdown for [Slate](https://github.com/slatedocs/slate) Docs, but produces sufficient markdown on its own. Some refinement's still needed (like around the generated authentication instructions), but this was the prettiest and most flexible MD generator I could find that was compatible with 3.0. 
- Open to thoughts on how to generate these docs automatically for the repo (in CI, in a pre-commit hook, etc). 