### PR TITLE
remove first name from match query in state match api

### DIFF
--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -98,7 +98,7 @@ namespace Piipan.Match.State
                 first = request.Query.First,
             };
             var sql = "SELECT upload_id, first, last, middle, dob, ssn, exception FROM participants " +
-                        "WHERE ssn=@ssn AND dob=@dob AND upper(last)=upper(@last) AND upper(first)=upper(@first) " +
+                        "WHERE ssn=@ssn AND dob=@dob AND upper(last)=upper(@last) " +
                         "AND upload_id=(SELECT id FROM uploads ORDER BY id DESC LIMIT 1)";
 
             return (sql, p);

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -302,6 +302,7 @@ namespace Piipan.Match.State.Tests
             Assert.Equal(expected, response.ToJson());
         }
 
+        // XXX Match occurs on same last name but different first name
         // XXX Connection string contains appropriate config
         // XXX Valid request returns JsonResult
     }

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -238,7 +238,7 @@ namespace Piipan.Match.State.Tests
             (var sql, var parameters) = Api.Prepare(request, logger);
 
             // Assert
-            Assert.Contains("upper(first)=upper(@first)", sql);
+            Assert.Contains("upper(last)=upper(@last)", sql);
         }
 
         [Fact]
@@ -254,7 +254,6 @@ namespace Piipan.Match.State.Tests
 
             // Assert
             Assert.Contains("upper(last)=upper(@last)", sql);
-            Assert.Contains("upper(first)=upper(@first)", sql);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #708 

[Manual testing](https://github.com/18F/piipan/blob/main/match/docs/state-match.md#remote-testing) with a different first name (i.e. Teddy instead of Theodore) should return results for all states:
```
curl -X POST -i \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer ${TOKEN}" \
  -d '{"query": { "first": "Teddy", "last": "Farrington", "dob": "1931-10-13", "ssn": "000-12-3456" }}' \
  https://ofunchaaz7alkqwuvo.azurewebsites.net/api/v1/query\?