### PR TITLE
Exclude cshtml files from code coverage

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,3 +20,18 @@ checks:
     enabled: false
   identical-code:
     enabled: false
+exclude_patterns:
+- "config/"
+- "db/"
+- "dist/"
+- "features/"
+- "**/node_modules/"
+- "script/"
+- "**/spec/"
+- "**/test/"
+- "**/tests/"
+- "Tests/"
+- "**/vendor/"
+- "**/*_test.go"
+- "**/*.d.ts"
+- "**/*.cshtml"


### PR DESCRIPTION
- Uses [default code climate exclusion list](https://docs.codeclimate.com/docs/excluding-files-and-folders#auto-generated-file-and-folder-exclusions)
- Adds `.cshtml` files to list

CodeClimate does not seem to offer a method of previewing the impact of changes to the config file. Code coverage metrics should be reviewed if/after merged. 