### PR TITLE
Set example env var for query tool when a11y testing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,8 @@ jobs:
   accessibility_query_tool:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:3.1
+    environment:
+      OrchApiUri: "http://example.com"
     steps:
       - run_pa11y:
           directory: query-tool/src/Piipan.QueryTool


### PR DESCRIPTION
Having any value for OrchApiUri will allow the home page to load when navigated to by pa11y. 

Example of a successful CI build with this config can be found [here](https://app.circleci.com/pipelines/github/18F/piipan/1020/workflows/015983ca-1972-4579-b95b-9bce825b24a1/jobs/2285).

It's worth considering as another issue whether we should start having pa11y test things like query results, which would require a useable API uri. 