### PR TITLE
Update dependabot with integration tests project, fix package lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,11 @@ updates:
     interval: daily
     time: "09:00"
 - package-ecosystem: nuget
+  directory: "/match/tests/Piipan.Match.State.IntegrationTests"
+  schedule:
+    interval: daily
+    time: "09:00"
+- package-ecosystem: nuget
   directory: "/match/tests/Piipan.Match.Orchestrator.Tests"
   schedule:
     interval: daily

--- a/match/tests/Piipan.Match.State.IntegrationTests/packages.lock.json
+++ b/match/tests/Piipan.Match.State.IntegrationTests/packages.lock.json
@@ -87,8 +87,8 @@
       },
       "FluentValidation": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "LqEYHuF5gXBJzG9/aUQS50TJP5cZgh/twvPLV7iTtFFGF6isGBkNXOhr9VwmSjlFRIVOqcMtkGuHwuPbU+XpoQ=="
+        "resolved": "10.1.0",
+        "contentHash": "RxhhfY9IcEY2qUMYjoUxegInbuE5Bwll7dVLsXpiJf25g0ztmzUK+HHqtPcub1caPemhMJsC+NwjHei+NgAkvA=="
       },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
@@ -1920,7 +1920,7 @@
         "type": "Project",
         "dependencies": {
           "Dapper": "2.0.78",
-          "FluentValidation": "10.0.4",
+          "FluentValidation": "10.1.0",
           "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
           "Microsoft.NET.Sdk.Functions": "3.0.11",
           "Newtonsoft.Json.Schema": "3.0.14",


### PR DESCRIPTION
Dependencies were updated prior to merging #744, resulting in a `error NU1004: The packages lock file is inconsistent [...]` error when running tests.