### PR TITLE
Integrate Metrics Resources in Virtual Network

### DIFF
--- a/etl/tools/grant-blob.bash
+++ b/etl/tools/grant-blob.bash
@@ -10,12 +10,12 @@
 # usage: grant-blob.bash <azure-env> <storage-account>
 
 source $(dirname "$0")/../../tools/common.bash || exit
-source $(dirname "$0")/../../iac/iac-common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/../../iac/env/${azure_env}.bash
+  source $(dirname "$0")/../../iac/iac-common.bash
   verify_cloud
 
   storage_account=$2

--- a/etl/tools/upload.bash
+++ b/etl/tools/upload.bash
@@ -11,12 +11,12 @@
 # usage: upload.bash <azure-env> <path-to-file> <storage-account>
 
 source $(dirname "$0")/../../tools/common.bash || exit
-source $(dirname "$0")/../../iac/iac-common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/../../iac/env/${azure_env}.bash
+  source $(dirname "$0")/../../iac/iac-common.bash
   verify_cloud
 
   file_path=$2

--- a/iac/add-front-door-to-app.bash
+++ b/iac/add-front-door-to-app.bash
@@ -13,11 +13,11 @@
 # ./iac/add-front-door-to-app.bash tts/dev rg-core-dev dashboard my-dashboard-123.azurewebsites.net
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 main () {
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   resource_group=$2

--- a/iac/arm-templates/database-metrics.json
+++ b/iac/arm-templates/database-metrics.json
@@ -22,13 +22,6 @@
                 "description": "Resource Tags for project"
             }
         },
-        "systemTypeTag": {
-            "type": "string",
-            "defaultValue": "Metrics",
-            "metadata": {
-                "description": "Tag used to identify related resources for a subsystem"
-            }
-        },
         "secretName": {
             "type": "string",
             "metadata": {
@@ -119,13 +112,6 @@
                                 "description": "Server Name for Azure database for PostgreSQL"
                             }
                         },
-                        "systemTypeTag": {
-                            "type": "string",
-                            "defaultValue": "Metrics",
-                            "metadata": {
-                                "description": "Tag used to identify related resources for a subsystem"
-                            }
-                        },
                         "privateEndpointName": {
                             "type": "string"
                         },
@@ -158,9 +144,6 @@
                                 ]
                             }
                         },
-                        "systemTypeTag": {
-                            "SysType": "[parameters('systemTypeTag')]"
-                        },
                         "pvtendpointdnsgroupname": "[concat(parameters('privateEndpointName'),'/dnsgroup')]"
                     },
                     "resources": [
@@ -170,7 +153,7 @@
                             "apiVersion": "2017-12-01-preview",
                             "name": "[parameters('serverName')]",
                             "location": "[parameters('location')]",
-                            "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
+                            "tags": "[parameters('resourceTags')]",
                             "sku": {
                                 "name": "GP_Gen5_2",
                                 "tier": "GeneralPurpose",

--- a/iac/arm-templates/database-metrics.json
+++ b/iac/arm-templates/database-metrics.json
@@ -78,6 +78,10 @@
             "metadata": {
                 "description": "name of the Virtual Network subnet delegated to the private endpoint"
             }
+        },
+        "privateDnsZoneName": {
+            "type": "string",
+            "defaultValue": "privatelink.postgres.database.azure.com"
         }
     },
     "resources": [
@@ -130,6 +134,9 @@
                         },
                         "subnetName": {
                             "type": "string"
+                        },
+                        "privateDnsZoneName": {
+                            "type": "string"
                         }
                     },
                     "variables": {
@@ -154,7 +161,6 @@
                         "systemTypeTag": {
                             "SysType": "[parameters('systemTypeTag')]"
                         },
-                        "privateDnsZoneName": "privatelink.postgres.database.azure.com",
                         "pvtendpointdnsgroupname": "[concat(parameters('privateEndpointName'),'/dnsgroup')]"
                     },
                     "resources": [
@@ -237,7 +243,7 @@
                         {
                             "type": "Microsoft.Network/privateDnsZones",
                             "apiVersion": "2020-01-01",
-                            "name": "[variables('privateDnsZoneName')]",
+                            "name": "[parameters('privateDnsZoneName')]",
                             "location": "global",
                             "dependsOn": [
                             ],
@@ -247,10 +253,10 @@
                         {
                             "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
                             "apiVersion": "2020-01-01",
-                            "name": "[concat(variables('privateDnsZoneName'), '/', variables('privateDnsZoneName'), '-link')]",
+                            "name": "[concat(parameters('privateDnsZoneName'), '/', parameters('privateDnsZoneName'), '-link')]",
                             "location": "global",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                                "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
                             ],
                             "properties": {
                                 "registrationEnabled": false,
@@ -269,7 +275,7 @@
                             "name": "[variables('pvtendpointdnsgroupname')]",
                             "location": "[parameters('location')]",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
+                                "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]",
                                 "[parameters('privateEndpointName')]"
                             ],
                             "properties": {
@@ -277,7 +283,7 @@
                                     {
                                         "name": "config1",
                                         "properties": {
-                                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
                                         }
                                     }
                                 ]
@@ -314,6 +320,9 @@
                     },
                     "subnetName": {
                         "value": "[parameters('subnetName')]"
+                    },
+                    "privateDnsZoneName": {
+                        "value": "[parameters('privateDnsZoneName')]"
                     }
                 }
             }

--- a/iac/arm-templates/database-metrics.json
+++ b/iac/arm-templates/database-metrics.json
@@ -22,6 +22,13 @@
                 "description": "Resource Tags for project"
             }
         },
+        "systemTypeTag": {
+            "type": "string",
+            "defaultValue": "Metrics",
+            "metadata": {
+                "description": "Tag used to identify related resources for a subsystem"
+            }
+        },
         "secretName": {
             "type": "string",
             "metadata": {
@@ -52,6 +59,24 @@
             "defaultValue": "[subscription().subscriptionId]",
             "metadata": {
                 "description": "The name of the subscription that contains the keyvault."
+            }
+        },
+        "privateEndpointName": {
+            "type": "string",
+            "metadata": {
+                "description": "name of the private endpoint for the database server"
+            }
+        },
+        "vnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "name of the Virtual Network the private endpoint will use"
+            }
+        },
+        "subnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "name of the Virtual Network subnet delegated to the private endpoint"
             }
         }
     },
@@ -89,6 +114,22 @@
                             "metadata": {
                                 "description": "Server Name for Azure database for PostgreSQL"
                             }
+                        },
+                        "systemTypeTag": {
+                            "type": "string",
+                            "defaultValue": "Metrics",
+                            "metadata": {
+                                "description": "Tag used to identify related resources for a subsystem"
+                            }
+                        },
+                        "privateEndpointName": {
+                            "type": "string"
+                        },
+                        "vnetName": {
+                            "type": "string"
+                        },
+                        "subnetName": {
+                            "type": "string"
                         }
                     },
                     "variables": {
@@ -109,20 +150,26 @@
                                     }
                                 ]
                             }
-                        }
+                        },
+                        "systemTypeTag": {
+                            "SysType": "[parameters('systemTypeTag')]"
+                        },
+                        "privateDnsZoneName": "privatelink.postgres.database.azure.com",
+                        "pvtendpointdnsgroupname": "[concat(parameters('privateEndpointName'),'/dnsgroup')]"
                     },
                     "resources": [
+                        // postgres server
                         {
                             "type": "Microsoft.DBforPostgreSQL/servers",
                             "apiVersion": "2017-12-01-preview",
                             "name": "[parameters('serverName')]",
                             "location": "[parameters('location')]",
-                            "tags": "[parameters('resourceTags')]",
+                            "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
                             "sku": {
-                                "name": "B_Gen5_1",
-                                "tier": "Basic",
-                                "capacity": 1,
-                                "size": "5120",
+                                "name": "GP_Gen5_2",
+                                "tier": "GeneralPurpose",
+                                "capacity": 2,
+                                "size": 5120,
                                 "family": "Gen5"
                             },
                             "properties": {
@@ -140,6 +187,7 @@
                                 "infrastructureEncryption": "Disabled"
                             }
                         },
+                        // firewall rules
                         {
                             "type": "Microsoft.DBforPostgreSQL/servers/firewallRules",
                             "apiVersion": "2017-12-01",
@@ -157,6 +205,82 @@
                             "properties": {
                                 "startIpAddress": "[variables('firewallrules').batch.rules[copyIndex()].StartIpAddress]",
                                 "endIpAddress": "[variables('firewallrules').batch.rules[copyIndex()].EndIpAddress]"
+                            }
+                        },
+                        // privateEndpoint
+                        {
+                            "type": "Microsoft.Network/privateEndpoints",
+                            "apiVersion": "2020-06-01",
+                            "name": "[parameters('privateEndpointName')]",
+                            "location": "[parameters('location')]",
+                            "dependsOn": [
+                                "[parameters('serverName')]"
+                            ],
+                            "properties": {
+                                "subnet": {
+                                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]"
+                                },
+                                "privateLinkServiceConnections": [
+                                    {
+                                        "name": "[parameters('privateEndpointName')]",
+                                        "properties": {
+                                            "privateLinkServiceId": "[resourceId('Microsoft.DBforPostgreSQL/servers',parameters('serverName'))]",
+                                            "groupIds": [
+                                                "postgresqlServer"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        // privateDnsZone
+                        {
+                            "type": "Microsoft.Network/privateDnsZones",
+                            "apiVersion": "2020-01-01",
+                            "name": "[variables('privateDnsZoneName')]",
+                            "location": "global",
+                            "dependsOn": [
+                            ],
+                            "properties": ""
+                        },
+                        // link private DNS zone to virtual network
+                        {
+                            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+                            "apiVersion": "2020-01-01",
+                            "name": "[concat(variables('privateDnsZoneName'), '/', variables('privateDnsZoneName'), '-link')]",
+                            "location": "global",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                            ],
+                            "properties": {
+                                "registrationEnabled": false,
+                                "virtualNetwork": {
+                                    "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+                                }
+                            }
+                        },
+                        /***
+                        The dns group configures the private endpoint to the private DNS zone.
+                        In portal, see private endpoint -> DNS Configuration
+                        ***/
+                        {
+                            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                            "apiVersion": "2020-06-01",
+                            "name": "[variables('pvtendpointdnsgroupname')]",
+                            "location": "[parameters('location')]",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
+                                "[parameters('privateEndpointName')]"
+                            ],
+                            "properties": {
+                                "privateDnsZoneConfigs": [
+                                    {
+                                        "name": "config1",
+                                        "properties": {
+                                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                                        }
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -181,6 +305,15 @@
                     },
                     "serverName": {
                         "value": "[parameters('serverName')]"
+                    },
+                    "privateEndpointName": {
+                        "value": "[parameters('privateEndpointName')]"
+                    },
+                    "vnetName": {
+                        "value": "[parameters('vnetName')]"
+                    },
+                    "subnetName": {
+                        "value": "[parameters('subnetName')]"
                     }
                 }
             }

--- a/iac/arm-templates/key-vault.json
+++ b/iac/arm-templates/key-vault.json
@@ -13,17 +13,27 @@
         },
         "resourceTags": {
             "type": "object"
+        },
+        "systemTypeTag": {
+            "type": "string",
+            "defaultValue": "None",
+            "metadata": {
+                "description": "Tag used to identify related resources for a subsystem"
+            }
         }
     },
     "variables": {
-        "name": "[parameters('name')]"
+        "name": "[parameters('name')]",
+        "systemTypeTag": {
+            "SysType": "[parameters('systemTypeTag')]"
+        }
     },
     "resources": [
         {
             "apiVersion": "2018-02-14",
             "name": "[variables('name')]",
             "location": "[parameters('location')]",
-            "tags": "[parameters('resourceTags')]",
+            "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
             "type": "Microsoft.KeyVault/vaults",
             "properties": {
                 "enabledForDeployment": false,

--- a/iac/arm-templates/key-vault.json
+++ b/iac/arm-templates/key-vault.json
@@ -13,27 +13,17 @@
         },
         "resourceTags": {
             "type": "object"
-        },
-        "systemTypeTag": {
-            "type": "string",
-            "defaultValue": "None",
-            "metadata": {
-                "description": "Tag used to identify related resources for a subsystem"
-            }
         }
     },
     "variables": {
-        "name": "[parameters('name')]",
-        "systemTypeTag": {
-            "SysType": "[parameters('systemTypeTag')]"
-        }
+        "name": "[parameters('name')]"
     },
     "resources": [
         {
             "apiVersion": "2018-02-14",
             "name": "[variables('name')]",
             "location": "[parameters('location')]",
-            "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
+            "tags": "[parameters('resourceTags')]",
             "type": "Microsoft.KeyVault/vaults",
             "properties": {
                 "enabledForDeployment": false,

--- a/iac/arm-templates/participant-records.json
+++ b/iac/arm-templates/participant-records.json
@@ -41,6 +41,10 @@
         },
         "privateEndpointName": {
             "type": "string"
+        },
+        "privateDnsZoneName": {
+            "type": "string",
+            "defaultValue": "privatelink.postgres.database.azure.com"
         }
     },
     "variables": {
@@ -85,10 +89,12 @@
                         },
                         "privateEndpointName": {
                             "type": "string"
+                        },
+                        "privateDnsZoneName": {
+                            "type": "string"
                         }
                     },
                     "variables": {
-                        "privateDnsZoneName": "privatelink.postgres.database.azure.com",
                         "pvtendpointdnsgroupname": "[concat(parameters('privateEndpointName'),'/dnsgroup')]",
                         "firewallrules": {
                             "batch": {
@@ -190,7 +196,7 @@
                         {
                             "type": "Microsoft.Network/privateDnsZones",
                             "apiVersion": "2020-01-01",
-                            "name": "[variables('privateDnsZoneName')]",
+                            "name": "[parameters('privateDnsZoneName')]",
                             "location": "global",
                             "dependsOn": [
                             ],
@@ -200,10 +206,10 @@
                         {
                             "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
                             "apiVersion": "2020-01-01",
-                            "name": "[concat(variables('privateDnsZoneName'), '/', variables('privateDnsZoneName'), '-link')]",
+                            "name": "[concat(parameters('privateDnsZoneName'), '/', parameters('privateDnsZoneName'), '-link')]",
                             "location": "global",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                                "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
                             ],
                             "properties": {
                                 "registrationEnabled": false,
@@ -222,7 +228,7 @@
                             "name": "[variables('pvtendpointdnsgroupname')]",
                             "location": "[parameters('location')]",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
+                                "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]",
                                 "[parameters('privateEndpointName')]"
                             ],
                             "properties": {
@@ -230,7 +236,7 @@
                                     {
                                         "name": "config1",
                                         "properties": {
-                                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+                                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
                                         }
                                     }
                                 ]
@@ -267,6 +273,9 @@
                     },
                     "privateEndpointName": {
                         "value": "[parameters('privateEndpointName')]"
+                    },
+                    "privateDnsZoneName": {
+                        "value": "[parameters('privateDnsZoneName')]"
                     }
                 }
             }

--- a/iac/arm-templates/participant-records.json
+++ b/iac/arm-templates/participant-records.json
@@ -131,7 +131,7 @@
                                 "infrastructureEncryption": "Disabled",
                                 "publicNetworkAccess": "Enabled" // This gets disabled later in iac
                             },
-                            /* VNet Rules only work for GeneralPurpose and above tiers */
+                            /* VNet Private Endpoints only work for GeneralPurpose and above tiers */
                             "sku": {
                                 "name": "GP_Gen5_2",
                                 "tier": "GeneralPurpose",

--- a/iac/arm-templates/virtual-network.json
+++ b/iac/arm-templates/virtual-network.json
@@ -18,7 +18,13 @@
         "databaseSubnetName": {
             "type": "string",
             "metadata": {
-                "description": "The name of the subnet the database will use."
+                "description": "The name of the subnet the first database will use."
+            }
+        },
+        "database2SubnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the subnet the second database will use."
             }
         },
         "funcSubnetName": {
@@ -54,7 +60,7 @@
                             "type": "string",
                             "defaultValue": "10.0.0.0/24",
                             "metadata": {
-                                "description": "The address space for the subnet."
+                                "description": "The address space for the first database subnet."
                             }
                         },
                         "funcSubnetPrefix": {
@@ -62,6 +68,13 @@
                             "defaultValue": "10.0.1.0/24",
                             "metadata": {
                                 "description": "The address space for the function app subnet."
+                            }
+                        },
+                        "database2subnetPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.2.0/24",
+                            "metadata": {
+                                "description": "The address space for the second database subnet."
                             }
                         },
                         "vnetAddressPrefix": {
@@ -75,6 +88,9 @@
                             "type": "string"
                         },
                         "databaseSubnetName": {
+                            "type": "string"
+                        },
+                        "database2SubnetName": {
                             "type": "string"
                         },
                         "funcSubnetName": {
@@ -101,6 +117,13 @@
                                         "name": "[parameters('databaseSubnetName')]",
                                         "properties": {
                                             "addressPrefix": "[parameters('subnetPrefix')]",
+                                            "privateEndpointNetworkPolicies": "Disabled"
+                                        }
+                                    },
+                                    {
+                                        "name": "[parameters('database2SubnetName')]",
+                                        "properties": {
+                                            "addressPrefix": "[parameters('database2SubnetPrefix')]",
                                             "privateEndpointNetworkPolicies": "Disabled"
                                         }
                                     },
@@ -136,6 +159,9 @@
                     },
                     "databaseSubnetName": {
                         "value": "[parameters('databaseSubnetName')]"
+                    },
+                    "database2SubnetName": {
+                        "value": "[parameters('database2SubnetName')]"
                     },
                     "funcSubnetName": {
                         "value": "[parameters('funcSubnetName')]"

--- a/iac/arm-templates/virtual-network.json
+++ b/iac/arm-templates/virtual-network.json
@@ -15,19 +15,19 @@
         "vnetName": {
             "type": "string"
         },
-        "databaseSubnetName": {
+        "peParticipantsSubnetName": {
             "type": "string",
             "metadata": {
                 "description": "The name of the subnet the first database will use."
             }
         },
-        "database2SubnetName": {
+        "peCoreSubnetName": {
             "type": "string",
             "metadata": {
                 "description": "The name of the subnet the second database will use."
             }
         },
-        "funcSubnetName": {
+        "appServicePlanSubnetName": {
             "type": "string",
             "metadata": {
                 "description": "The name of the subnet etl apps will use."
@@ -56,21 +56,21 @@
                         "resourceTags": {
                             "type": "object"
                         },
-                        "subnetPrefix": {
+                        "peParticipantsSubnetPrefix": {
                             "type": "string",
                             "defaultValue": "10.0.0.0/24",
                             "metadata": {
                                 "description": "The address space for the first database subnet."
                             }
                         },
-                        "funcSubnetPrefix": {
+                        "appServicePlanSubnetPrefix": {
                             "type": "string",
                             "defaultValue": "10.0.1.0/24",
                             "metadata": {
                                 "description": "The address space for the function app subnet."
                             }
                         },
-                        "database2subnetPrefix": {
+                        "peCoreSubnetPrefix": {
                             "type": "string",
                             "defaultValue": "10.0.2.0/24",
                             "metadata": {
@@ -87,13 +87,13 @@
                         "vnetName": {
                             "type": "string"
                         },
-                        "databaseSubnetName": {
+                        "peParticipantsSubnetName": {
                             "type": "string"
                         },
-                        "database2SubnetName": {
+                        "peCoreSubnetName": {
                             "type": "string"
                         },
-                        "funcSubnetName": {
+                        "appServicePlanSubnetName": {
                             "type": "string"
                         }
                     },
@@ -114,23 +114,23 @@
                                 },
                                 "subnets": [
                                     {
-                                        "name": "[parameters('databaseSubnetName')]",
+                                        "name": "[parameters('peParticipantsSubnetName')]",
                                         "properties": {
-                                            "addressPrefix": "[parameters('subnetPrefix')]",
+                                            "addressPrefix": "[parameters('peParticipantsSubnetPrefix')]",
                                             "privateEndpointNetworkPolicies": "Disabled"
                                         }
                                     },
                                     {
-                                        "name": "[parameters('database2SubnetName')]",
+                                        "name": "[parameters('peCoreSubnetName')]",
                                         "properties": {
-                                            "addressPrefix": "[parameters('database2SubnetPrefix')]",
+                                            "addressPrefix": "[parameters('peCoreSubnetPrefix')]",
                                             "privateEndpointNetworkPolicies": "Disabled"
                                         }
                                     },
                                     {
-                                        "name": "[parameters('funcSubnetName')]",
+                                        "name": "[parameters('appServicePlanSubnetName')]",
                                         "properties": {
-                                            "addressPrefix": "[parameters('funcSubnetPrefix')]",
+                                            "addressPrefix": "[parameters('appServicePlanSubnetPrefix')]",
                                             "privateEndpointNetworkPolicies": "Disabled",
                                             "delegations": [
                                                 {
@@ -157,14 +157,14 @@
                     "vnetName": {
                         "value": "[parameters('vnetName')]"
                     },
-                    "databaseSubnetName": {
-                        "value": "[parameters('databaseSubnetName')]"
+                    "peParticipantsSubnetName": {
+                        "value": "[parameters('peParticipantsSubnetName')]"
                     },
-                    "database2SubnetName": {
-                        "value": "[parameters('database2SubnetName')]"
+                    "peCoreSubnetName": {
+                        "value": "[parameters('peCoreSubnetName')]"
                     },
-                    "funcSubnetName": {
-                        "value": "[parameters('funcSubnetName')]"
+                    "appServicePlanSubnetName": {
+                        "value": "[parameters('appServicePlanSubnetName')]"
                     }
                 }
             }

--- a/iac/configure-easy-auth.bash
+++ b/iac/configure-easy-auth.bash
@@ -10,7 +10,6 @@
 # usage: create-resources.bash <azure-env>
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 # App Service Authentication is done at the Azure tenant level
 TENANT_ID=$(az account show --query homeTenantId -o tsv)
@@ -246,6 +245,7 @@ main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   # Name of application roles authorized to call match APIs

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -85,6 +85,7 @@ main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   APIM_NAME=${PREFIX}-apim-duppartapi-${ENV}

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -16,19 +16,18 @@
 # usage: create-apim.bash <azure-env> <admin-email>
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 clean_defaults () {
   local group=$1
   local apim=$2
-  
+
   # Delete "echo API" example API
   az apim api delete \
     --api-id echo-api \
     -g ${group} \
     -n ${apim} \
     -y
-  
+
   # Delete default "Starter" and "Unlimited" products and their associated
   # product subscriptions
   az apim product delete \
@@ -37,7 +36,7 @@ clean_defaults () {
     -g ${group} \
     -n ${apim} \
     -y
-  
+
   az apim product delete \
     --product-id unlimited \
     --delete-subscriptions true \

--- a/iac/create-databases.bash
+++ b/iac/create-databases.bash
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 # Require PGHOST, PGUSER, PGPASSWORD and $ENV be set by the caller;
 # PGUSER and PGPASSWORD should correspond to the out-of-the-box,
@@ -145,6 +144,7 @@ EOF
 # https://info.enterprisedb.com/rs/069-ALB-339/images/Multitenancy%20Approaches%20Whitepaper.pdf
 main () {
   RESOURCE_GROUP=$1
+  source $(dirname "$0")/iac-common.bash
 
   echo "Baseline $TEMPLATE_DB before creating new databases from it"
   config_db $TEMPLATE_DB

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -40,8 +40,6 @@ set_constants () {
   METRICS_API_APP_ID=metricsapi
   API_APP_NAME=$PREFIX-func-$METRICS_API_APP_ID-$ENV
   API_APP_STORAGE_NAME=${PREFIX}st${METRICS_API_APP_ID}${ENV}
-  # System tag
-  METRICS_SYSTEM_TAG_VALUE=Metrics
 
   PRIVATE_DNS_ZONE=`private_dns_zone`
 }
@@ -65,8 +63,7 @@ main () {
       name=$VAULT_NAME \
       location=$LOCATION \
       objectId=$CURRENT_USER_OBJID \
-      resourceTags="$RESOURCE_TAGS" \
-      systemTypeTag=$METRICS_SYSTEM_TAG_VALUE
+      resourceTags="$RESOURCE_TAGS"
 
   # Set PG Secret in key vault
   # By default, Azure CLI will print the password set in Key Vault; instead
@@ -93,8 +90,7 @@ main () {
       subnetName=$DB_2_SUBNET_NAME \
       privateEndpointName=$CORE_DB_PRIVATE_ENDPOINT_NAME \
       privateDnsZoneName=$PRIVATE_DNS_ZONE \
-      resourceTags="$RESOURCE_TAGS" \
-      systemTypeTag=$METRICS_SYSTEM_TAG_VALUE
+      resourceTags="$RESOURCE_TAGS"
 
   ### Database stuff
   # Create database within db server (command is idempotent)
@@ -129,7 +125,7 @@ EOF
     --location $LOCATION \
     --resource-group $METRICS_RESOURCE_GROUP \
     --sku Standard_LRS \
-    --tags $METRICS_TAG Project=$PROJECT_TAG
+    --tags Project=$PROJECT_TAG
 
   # Create the function app in Azure
   echo "Creating function app $COLLECT_APP_NAME in Azure"
@@ -140,7 +136,7 @@ EOF
     --functions-version 3 \
     --name $COLLECT_APP_NAME \
     --storage-account $COLLECT_STORAGE_NAME \
-    --tags $METRICS_TAG Project=$PROJECT_TAG
+    --tags Project=$PROJECT_TAG
 
   # Integrate function app into Virtual Network
   echo "Integrating $COLLECT_APP_NAME into virtual network"
@@ -215,7 +211,7 @@ EOF
     --location $LOCATION \
     --resource-group $METRICS_RESOURCE_GROUP \
     --sku Standard_LRS \
-    --tags $METRICS_TAG Project=$PROJECT_TAG
+    --tags Project=$PROJECT_TAG
 
   # Create the function app in Azure
   echo "Creating function app $API_APP_NAME"
@@ -226,7 +222,7 @@ EOF
     --functions-version 3 \
     --name $API_APP_NAME \
     --storage-account $API_APP_STORAGE_NAME \
-    --tags $METRICS_TAG Project=$PROJECT_TAG
+    --tags Project=$PROJECT_TAG
 
   # Integrate function app into Virtual Network
   echo "Integrating $API_APP_NAME into virtual network"

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -42,6 +42,8 @@ set_constants () {
   API_APP_STORAGE_NAME=${PREFIX}st${METRICS_API_APP_ID}${ENV}
   # System tag
   METRICS_SYSTEM_TAG_VALUE=Metrics
+
+  PRIVATE_DNS_ZONE=`private_dns_zone`
 }
 
 main () {
@@ -90,6 +92,7 @@ main () {
       vnetName=$VNET_NAME \
       subnetName=$DB_2_SUBNET_NAME \
       privateEndpointName=$CORE_DB_PRIVATE_ENDPOINT_NAME \
+      privateDnsZoneName=$PRIVATE_DNS_ZONE \
       resourceTags="$RESOURCE_TAGS" \
       systemTypeTag=$METRICS_SYSTEM_TAG_VALUE
 

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -12,7 +12,6 @@
 # usage: create-metrics-resources.bash <azure-env>
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 set_constants () {
   DB_SERVER_NAME=$PREFIX-psql-core-$ENV
@@ -41,12 +40,15 @@ set_constants () {
   METRICS_API_APP_ID=metricsapi
   API_APP_NAME=$PREFIX-func-$METRICS_API_APP_ID-$ENV
   API_APP_STORAGE_NAME=${PREFIX}st${METRICS_API_APP_ID}${ENV}
+  # System tag
+  METRICS_SYSTEM_TAG_VALUE=Metrics
 }
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   set_constants
@@ -61,7 +63,8 @@ main () {
       name=$VAULT_NAME \
       location=$LOCATION \
       objectId=$CURRENT_USER_OBJID \
-      resourceTags="$RESOURCE_TAGS"
+      resourceTags="$RESOURCE_TAGS" \
+      systemTypeTag=$METRICS_SYSTEM_TAG_VALUE
 
   # Set PG Secret in key vault
   # By default, Azure CLI will print the password set in Key Vault; instead
@@ -84,7 +87,11 @@ main () {
       serverName=$DB_SERVER_NAME \
       secretName=$PG_SECRET_NAME \
       vaultName=$VAULT_NAME \
-      resourceTags="$RESOURCE_TAGS"
+      vnetName=$VNET_NAME \
+      subnetName=$DB_2_SUBNET_NAME \
+      privateEndpointName=$CORE_DB_PRIVATE_ENDPOINT_NAME \
+      resourceTags="$RESOURCE_TAGS" \
+      systemTypeTag=$METRICS_SYSTEM_TAG_VALUE
 
   ### Database stuff
   # Create database within db server (command is idempotent)
@@ -118,17 +125,27 @@ EOF
     --name $COLLECT_STORAGE_NAME \
     --location $LOCATION \
     --resource-group $METRICS_RESOURCE_GROUP \
-    --sku Standard_LRS
+    --sku Standard_LRS \
+    --tags $METRICS_TAG Project=$PROJECT_TAG
 
   # Create the function app in Azure
   echo "Creating function app $COLLECT_APP_NAME in Azure"
   az functionapp create \
     --resource-group $METRICS_RESOURCE_GROUP \
-    --consumption-plan-location $LOCATION \
+    --plan $APP_SERVICE_PLAN_FUNC_NAME \
     --runtime dotnet \
     --functions-version 3 \
     --name $COLLECT_APP_NAME \
-    --storage-account $COLLECT_STORAGE_NAME
+    --storage-account $COLLECT_STORAGE_NAME \
+    --tags $METRICS_TAG Project=$PROJECT_TAG
+
+  # Integrate function app into Virtual Network
+  echo "Integrating $COLLECT_APP_NAME into virtual network"
+  az functionapp vnet-integration add \
+    --name $COLLECT_APP_NAME \
+    --resource-group $METRICS_RESOURCE_GROUP \
+    --subnet $FUNC_SUBNET_NAME \
+    --vnet $VNET_NAME
 
   # Waiting before publishing the app, since publishing immediately after creation returns an   App Not Found error
   # Waiting was the best solution I could find. More info in these GH issues:
@@ -194,17 +211,27 @@ EOF
     --name $API_APP_STORAGE_NAME \
     --location $LOCATION \
     --resource-group $METRICS_RESOURCE_GROUP \
-    --sku Standard_LRS
+    --sku Standard_LRS \
+    --tags $METRICS_TAG Project=$PROJECT_TAG
 
   # Create the function app in Azure
-  echo "Creating function app metrics api"
+  echo "Creating function app $API_APP_NAME"
   az functionapp create \
     --resource-group $METRICS_RESOURCE_GROUP \
-    --consumption-plan-location $LOCATION \
+    --plan $APP_SERVICE_PLAN_FUNC_NAME \
     --runtime dotnet \
     --functions-version 3 \
     --name $API_APP_NAME \
-    --storage-account $API_APP_STORAGE_NAME
+    --storage-account $API_APP_STORAGE_NAME \
+    --tags $METRICS_TAG Project=$PROJECT_TAG
+
+  # Integrate function app into Virtual Network
+  echo "Integrating $API_APP_NAME into virtual network"
+  az functionapp vnet-integration add \
+    --name $API_APP_NAME \
+    --resource-group $METRICS_RESOURCE_GROUP \
+    --subnet $FUNC_SUBNET_NAME \
+    --vnet $VNET_NAME
 
   az functionapp config appsettings set \
       --resource-group $METRICS_RESOURCE_GROUP \
@@ -259,7 +286,7 @@ EOF
   metrics_api_uri=$(\
     az functionapp function show \
       -g $METRICS_RESOURCE_GROUP \
-      -n  $API_APP_NAME \
+      -n $API_APP_NAME \
       --function-name GetParticipantUploads \
       --query invokeUrlTemplate \
       --output tsv)
@@ -277,6 +304,12 @@ EOF
       servicePlan=$APP_SERVICE_PLAN \
       frontDoorId=$front_door_id \
       metricsApiUri=$metrics_api_uri
+
+  echo "Secure database connection"
+  ./remove-external-network.bash \
+    $azure_env \
+    $METRICS_RESOURCE_GROUP \
+    $DB_SERVER_NAME
 
   script_completed
 }

--- a/iac/create-resource-groups.bash
+++ b/iac/create-resource-groups.bash
@@ -9,12 +9,12 @@
 # usage: create-resource-groups.bash <azure-env>
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   # Any changes to the set of resource groups below should also

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -11,7 +11,6 @@
 # usage: create-resources.bash <azure-env>
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 set_constants () {
   # Name of Key Vault
@@ -29,12 +28,6 @@ set_constants () {
   # Name of PostgreSQL server
   PG_SERVER_NAME=$PREFIX-psql-participants-$ENV
 
-  # Names of participant records database Vnet and Subnet
-  VNET_NAME=vnet-core-$ENV
-  DB_SUBNET_NAME=snet-participants-$ENV # Subnet database private endpoint uses
-  FUNC_SUBNET_NAME=snet-apps1-$ENV # Subnet function apps uses
-  PRIVATE_ENDPOINT_NAME=pe-participants-$ENV
-
   # Base name of query tool app
   QUERY_TOOL_APP_NAME=$PREFIX-app-querytool-$ENV
   QUERY_TOOL_FRONTDOOR_NAME=$PREFIX-fd-querytool-$ENV
@@ -48,11 +41,6 @@ set_constants () {
 
   # App Service Authentication is done at the Azure tenant level
   TENANT_ID=$(az account show --query homeTenantId -o tsv)
-
-  # App service plan name for function apps
-  APP_SERVICE_PLAN_FUNC_NAME=plan-apps1-$ENV
-  APP_SERVICE_PLAN_FUNC_SKU=P1V2
-  APP_SERVICE_PLAN_FUNC_KIND=functionapp
 
   # Orchestrator Function app and its blob storage
   ORCHESTRATOR_FUNC_APP_NAME=$PREFIX-func-orchestrator-$ENV
@@ -96,6 +84,7 @@ main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   set_constants
@@ -115,6 +104,7 @@ main () {
         resourceTags="$RESOURCE_TAGS" \
         vnetName=$VNET_NAME \
         databaseSubnetName=$DB_SUBNET_NAME \
+        database2SubnetName=$DB_2_SUBNET_NAME \
         funcSubnetName=$FUNC_SUBNET_NAME
 
   # Many CLI commands use a URI to identify nested resources; pre-compute the URI's prefix

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -45,6 +45,8 @@ set_constants () {
   # Orchestrator Function app and its blob storage
   ORCHESTRATOR_FUNC_APP_NAME=$PREFIX-func-orchestrator-$ENV
   ORCHESTRATOR_FUNC_APP_STORAGE_NAME=${PREFIX}storchestrator${ENV}
+
+  PRIVATE_DNS_ZONE=`private_dns_zone`
 }
 
 # Generate the storage account connection string for the corresponding
@@ -103,9 +105,9 @@ main () {
         location=$LOCATION \
         resourceTags="$RESOURCE_TAGS" \
         vnetName=$VNET_NAME \
-        databaseSubnetName=$DB_SUBNET_NAME \
-        database2SubnetName=$DB_2_SUBNET_NAME \
-        funcSubnetName=$FUNC_SUBNET_NAME
+        peParticipantsSubnetName=$DB_SUBNET_NAME \
+        peCoreSubnetName=$DB_2_SUBNET_NAME \
+        appServicePlanSubnetName=$FUNC_SUBNET_NAME
 
   # Many CLI commands use a URI to identify nested resources; pre-compute the URI's prefix
   # for our default resource group
@@ -163,7 +165,8 @@ main () {
       resourceTags="$RESOURCE_TAGS" \
       vnetName=$VNET_NAME \
       subnetName=$DB_SUBNET_NAME \
-      privateEndpointName=$PRIVATE_ENDPOINT_NAME
+      privateEndpointName=$PRIVATE_ENDPOINT_NAME \
+      privateDnsZoneName=$PRIVATE_DNS_ZONE
 
 
   # The AD admin can't be specified in the PostgreSQL ARM template,

--- a/iac/create-service-principal.bash
+++ b/iac/create-service-principal.bash
@@ -16,12 +16,12 @@
 # usage: create-service-principal.bash <azure-env> <service-principal-name> [<output-format>]
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   # Required service principal name

--- a/iac/create-state-storage-service-principal.bash
+++ b/iac/create-state-storage-service-principal.bash
@@ -14,13 +14,13 @@
 # usage: create-service-principal.bash <azure-env> <storage-account-name>
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   storage_acct_name=$2
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   # Required service principal name

--- a/iac/delete-resources.bash
+++ b/iac/delete-resources.bash
@@ -6,7 +6,6 @@
 # usage: delete-resources.bash <azure-env>
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 purge () {
   local group=$1
@@ -24,6 +23,7 @@ main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   echo "This script will delete all resources hosted on $CLOUD_NAME in ${azure_env}."

--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -11,10 +11,10 @@ RESOURCE_GROUP=rg-core-$ENV
 MATCH_RESOURCE_GROUP=rg-match-$ENV
 
 # Resource group for metrics
-METRICS_RESOURCE_GROUP=rg-metrics-$ENV
+METRICS_RESOURCE_GROUP=$RESOURCE_GROUP
 
 # Prefix for resource identifiers
-PREFIX=fns
+PREFIX=tts
 
 # Either AzureCloud or AzureUSGovernment
 CLOUD_NAME=AzureCloud

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -10,6 +10,7 @@ ORCHESTRATOR_API_TAG="SysType=OrchestratorApi"
 DASHBOARD_APP_TAG="SysType=DashboardApp"
 QUERY_APP_TAG="SysType=QueryApp"
 DUP_PART_API_TAG="SysType=DupPartApi"
+METRICS_TAG="SysType=Metrics"
 
 # Identity object ID for the Azure environment account
 CURRENT_USER_OBJID=`az ad signed-in-user show --query objectId --output tsv`
@@ -19,6 +20,11 @@ SUBSCRIPTION_ID=`az account show --query id -o tsv`
 
 # Name of App Service Plan, used by both query tool and dashboard
 APP_SERVICE_PLAN=piipan-app-plan
+
+# App Service Plan used by function apps with VNet integration
+APP_SERVICE_PLAN_FUNC_NAME=plan-apps1-$ENV
+APP_SERVICE_PLAN_FUNC_SKU=P1V2
+APP_SERVICE_PLAN_FUNC_KIND=functionapp
 
 # Name of environment variable used to pass database connection strings
 # to app or function code
@@ -38,6 +44,14 @@ CLOUD_NAME_STR_KEY=CloudName
 
 # For connection strings, our established placeholder value
 PASSWORD_PLACEHOLDER='{password}'
+
+# Virtual Network and Subnets
+VNET_NAME=vnet-core-$ENV
+DB_SUBNET_NAME=snet-participants-$ENV # Subnet that participants database private endpoint uses
+DB_2_SUBNET_NAME=snet-core-$ENV # Subnet that core database private endpoint uses
+FUNC_SUBNET_NAME=snet-apps1-$ENV # Subnet function apps use
+PRIVATE_ENDPOINT_NAME=pe-participants-$ENV
+CORE_DB_PRIVATE_ENDPOINT_NAME=pe-core-$ENV
 ### END Constants
 
 ### Functions

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -10,7 +10,6 @@ ORCHESTRATOR_API_TAG="SysType=OrchestratorApi"
 DASHBOARD_APP_TAG="SysType=DashboardApp"
 QUERY_APP_TAG="SysType=QueryApp"
 DUP_PART_API_TAG="SysType=DupPartApi"
-METRICS_TAG="SysType=Metrics"
 
 # Identity object ID for the Azure environment account
 CURRENT_USER_OBJID=`az ad signed-in-user show --query objectId --output tsv`

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -159,4 +159,14 @@ state_event_grid_topic_name () {
 
   echo "evgt-${abbr}upload-${env}"
 }
+
+private_dns_zone () {
+  base=privatelink.postgres.database.azure.com
+
+  if [ "$CLOUD_NAME" = "AzureUSGovernment" ]; then
+    base=${base/.postgres.database.azure.com/.postgres.database.usgovcloudapi.net}
+  fi
+
+  echo $base
+}
 ### END Functions

--- a/iac/remove-external-network.bash
+++ b/iac/remove-external-network.bash
@@ -12,11 +12,11 @@
 # ./iac/remove-external-network.bash tts/dev rg-core-dev fns-db-participant-records-dev
 
 source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/iac-common.bash || exit
 
 main () {
   azure_env=$1
   source $(dirname "$0")/env/${azure_env}.bash
+  source $(dirname "$0")/iac-common.bash
   verify_cloud
 
   resource_group=$2

--- a/tools/assign-app-role.bash
+++ b/tools/assign-app-role.bash
@@ -12,12 +12,12 @@
 # usage: assign-app-role.bash <azure-env> <func-app-name> <role-name>
 
 source $(dirname "$0")/common.bash || exit
-source $(dirname "$0")/../iac/iac-common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/../iac/env/${azure_env}.bash
+  source $(dirname "$0")/../iac/iac-common.bash
   verify_cloud
 
   function=$2

--- a/tools/authorize-cli.bash
+++ b/tools/authorize-cli.bash
@@ -13,12 +13,12 @@
 # usage: assign-app-role.bash <azure-env> <app-uri>
 
 source $(dirname "$0")/common.bash || exit
-source $(dirname "$0")/../iac/iac-common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   source $(dirname "$0")/../iac/env/${azure_env}.bash
+  source $(dirname "$0")/../iac/iac-common.bash
   verify_cloud
 
   app_uri=$2


### PR DESCRIPTION
Closes #691 

- moves metrics resources into VNet resource group
- adds system type tag to identify Metrics resources
- upgrades metrics database to plan with VNet integration
- adds resources needed to integrate metrics db with VNet
- adds subnet to existing VNet for metrics database private link
- puts metrics function apps onto existing premium app service plan
- integrates metrics function apps with VNet
- locks down access to metrics db
- Also adds environment-related constants to iac-common