### PR TITLE
Update bulk upload API naming and endpoints

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -4,23 +4,23 @@
 - [Swagger/OpenAPI CLI](https://github.com/APIDevTools/swagger-cli)
 - [Swagger Markdown tool](https://www.npmjs.com/package/swagger-markdown)
 
-This is the OpenAPI specification for our state-facing API. This spec mirrors what's found in our Azure API Management (APIM) instance as the "Duplication Participation" API.
+These are the OpenAPI specifications for our state-facing APIs. The specs mirror what's found in our Azure API Management (APIM) instance as the "Duplication Participation" API.
 
-The goal of this spec is to generate documentation that states will use to integrate with our system.
+The goal of the specs is to generate documentation that states will use to integrate with our system.
 
 ## Directory Structure
 
-Within the top-level `openapi` directory, there's an OpenAPI spec representing the Duplicate Participation API. Since this API is essentially a compilation of our various subsystem API's, this spec is composed of paths from various subsystem OpenAPI specs. The subsystem specs are managed in their own subdirectories as the single source of truth, and merely referenced here.
+Within the top-level `openapi` directory, there is an OpenAPI spec representing each individual API. Since the APIs are essentially a compilation of our various subsystem APIs, the specs are composed of paths from various subsystem OpenAPI specs. The subsystem specs are managed in their own subdirectories as the single source of truth, and merely referenced here.
 
 The top-level directory also has a tools directory for automatic documentation generation.
 
-Generating documentation will alter the contents of the `generated` directory.
+Generating documentation will alter the contents of the `generated` directory. Generated documentation is checked into source control and should be re-generated whenever the specs are edited.
 
 ## Generating Documentation
 
-from piipan project root, `cd docs/openapi` then run:
+From piipan project root, `cd docs/openapi` then run:
 ```
 ./tools/generate-docs.bash
 ```
 
-This creates a markdown file within the `generated` directory that's used for external documentation.
+This creates markdown files within the `generated` directory that are used for external documentation.

--- a/docs/openapi/bulk-api.yaml
+++ b/docs/openapi/bulk-api.yaml
@@ -1,19 +1,19 @@
 openapi: 3.0.0
 info:
-  title: Bulk upload API
+  title: "Bulk API"
   version: 1.0.0
-  description: API for uploading bulk participant data
+  description: "The API for performing bulk uploads"
 tags:
   - name: "Upload"
 servers:
   - url: /bulk/{stateAbbr}/v1
     variables:
       stateAbbr:
-        default: ea
+        default: none
         description: Lowercase two-letter postal code abbreviation
 paths:
   '/upload/{filename}':
-    $ref: './upload.yaml'
+    $ref: '../../etl/docs/openapi/upload.yaml'
 security:
   - ApiKeyAuth: []
 components:

--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -2,12 +2,10 @@ openapi: 3.0.0
 info:
   title: "Duplicate Participation API"
   version: 1.0.0
-  description: "The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur"
+  description: "The API for the Duplicate Participation system where matching and lookups will occur"
 servers:
   - url: "/v1"
 paths:
-  '/{state}/upload/{filename}':
-    $ref: '../../etl/docs/openapi/upload.yaml'
   /query:
     $ref: '../../match/docs/openapi/orchestrator/query.yaml'
   /lookup_ids/{id}:

--- a/docs/openapi/generated/bulk-api/openapi.md
+++ b/docs/openapi/generated/bulk-api/openapi.md
@@ -1,0 +1,67 @@
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="bulk-api">Bulk API v1.0.0</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+The API for performing bulk uploads
+
+Base URLs:
+
+* <a href="/bulk/{stateAbbr}/v1">/bulk/{stateAbbr}/v1</a>
+
+    * **stateAbbr** - Lowercase two-letter postal code abbreviation Default: none
+
+# Authentication
+
+* API Key (ApiKeyAuth)
+    - Parameter Name: **Ocp-Apim-Subscription-Key**, in: header. 
+
+<h1 id="bulk-api-upload">Upload</h1>
+
+## Upload a File
+
+<a id="opIdUpload a File"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X PUT /bulk/{stateAbbr}/v1/upload/{filename} \
+  -H 'Content-Type: text/plain' \
+  -H 'Content-Length: 0' \
+  -H 'Ocp-Apim-Subscription-Key: API_KEY'
+
+```
+
+`PUT /upload/{filename}`
+
+*Upload a CSV file of bulk participant data*
+
+> Body parameter
+
+```
+string
+
+```
+
+<h3 id="upload-a-file-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|filename|path|string|true|Name of file being uploaded|
+|Content-Length|header|integer|true|none|
+
+<h3 id="upload-a-file-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|File uploaded|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Access denied|None|
+|411|[Length Required](https://tools.ietf.org/html/rfc7231#section-6.5.10)|Content-Length not provided|None|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+ApiKeyAuth
+</aside>
+

--- a/docs/openapi/generated/bulk-api/openapi.yaml
+++ b/docs/openapi/generated/bulk-api/openapi.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.0
+info:
+  title: Bulk API
+  version: 1.0.0
+  description: The API for performing bulk uploads
+tags:
+  - name: Upload
+servers:
+  - url: '/bulk/{stateAbbr}/v1'
+    variables:
+      stateAbbr:
+        default: none
+        description: Lowercase two-letter postal code abbreviation
+paths:
+  '/upload/{filename}':
+    put:
+      operationId: Upload a File
+      summary: Upload a CSV file of bulk participant data
+      tags:
+        - Upload
+      parameters:
+        - name: filename
+          in: path
+          description: Name of file being uploaded
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Content-Length
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '201':
+          description: File uploaded
+        '401':
+          description: Access denied
+        '411':
+          description: Content-Length not provided
+security:
+  - ApiKeyAuth: []
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Ocp-Apim-Subscription-Key

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -4,7 +4,7 @@
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
-The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur
+The API for the Duplicate Participation system where matching and lookups will occur
 
 Base URLs:
 
@@ -14,55 +14,6 @@ Base URLs:
 
 * API Key (ApiKeyAuth)
     - Parameter Name: **Ocp-Apim-Subscription-Key**, in: header. 
-
-<h1 id="duplicate-participation-api-upload">Upload</h1>
-
-## Upload a File
-
-<a id="opIdUpload a File"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X PUT /v1/{state}/upload/{filename} \
-  -H 'Content-Type: text/plain' \
-  -H 'Content-Length: 0' \
-  -H 'Ocp-Apim-Subscription-Key: API_KEY'
-
-```
-
-`PUT /{state}/upload/{filename}`
-
-*Upload a CSV file of bulk participant data*
-
-> Body parameter
-
-```
-string
-
-```
-
-<h3 id="upload-a-file-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|state|path|string|true|state abbreviation|
-|filename|path|string|true|Name of file being uploaded|
-|Content-Length|header|integer|true|none|
-
-<h3 id="upload-a-file-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|File uploaded|None|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Access denied|None|
-|411|[Length Required](https://tools.ietf.org/html/rfc7231#section-6.5.10)|Content-Length not provided|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-ApiKeyAuth
-</aside>
 
 <h1 id="duplicate-participation-api-match">Match</h1>
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -2,47 +2,10 @@ openapi: 3.0.0
 info:
   title: Duplicate Participation API
   version: 1.0.0
-  description: 'The API for the Duplicate Participation system where bulk upload, matching, and lookups will occur'
+  description: The API for the Duplicate Participation system where matching and lookups will occur
 servers:
   - url: /v1
 paths:
-  '/{state}/upload/{filename}':
-    put:
-      operationId: Upload a File
-      summary: Upload a CSV file of bulk participant data
-      tags:
-        - Upload
-      parameters:
-        - name: state
-          in: path
-          description: state abbreviation
-          required: true
-          schema:
-            type: string
-        - name: filename
-          in: path
-          description: Name of file being uploaded
-          required: true
-          schema:
-            type: string
-        - in: header
-          name: Content-Length
-          schema:
-            type: integer
-          required: true
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              type: string
-              format: binary
-      responses:
-        '201':
-          description: File uploaded
-        '401':
-          description: Access denied
-        '411':
-          description: Content-Length not provided
   /query:
     post:
       operationId: Query for Matches

--- a/docs/openapi/tools/generate-docs.bash
+++ b/docs/openapi/tools/generate-docs.bash
@@ -14,16 +14,22 @@ set -e
 set -u
 
 main () {
-    ./tools/generate-specs.bash
-    pushd ./generated/duplicate-participation-api/
-        widdershins \
-            --language_tabs 'shell:curl:request' \
-            --omitBody \
-            --omitHeader \
-            --shallowSchemas \
-            openapi.yaml \
-            -o openapi.md
+  specs=(bulk-api duplicate-participation-api)
+
+  ./tools/generate-specs.bash
+
+  for s in "${specs[@]}"
+  do
+    pushd ./generated/${s}/
+    widdershins \
+        --language_tabs 'shell:curl:request' \
+        --omitBody \
+        --omitHeader \
+        --shallowSchemas \
+        openapi.yaml \
+        -o openapi.md
     popd
+  done
 }
 
 main

--- a/docs/openapi/tools/generate-specs.bash
+++ b/docs/openapi/tools/generate-specs.bash
@@ -11,7 +11,7 @@ set -e
 set -u
 
 main () {
-    specs=(duplicate-participation-api)
+    specs=(bulk-api duplicate-participation-api)
 
     for s in "${specs[@]}"
     do

--- a/docs/quick-start-guide-states.md
+++ b/docs/quick-start-guide-states.md
@@ -10,7 +10,7 @@ A high-level view of the system architecture can be found [here](../README.md).
 
 APIs are in Alpha stage and under active development. We plan on having APIs ready for state testing by the end of April 2021.
 
-## API Overview
+## APIs Overview
 
 In order to participate, states will need to:
 
@@ -18,15 +18,15 @@ In order to participate, states will need to:
 1. Conduct matches against the system
 1. Take appropriate action on those matches
 
-These three elements translate to three main areas of the API that states will integrate into their existing eligibility systems and workflows:
+These three elements translate to three main API calls that states will integrate into their existing eligibility systems and workflows:
 
-1. States will upload participant data through a scheduled [CSV upload](./openapi/generated/duplicate-participation-api/openapi.md#upload) (CSV formatting instructions can be found [here](https://github.com/18F/piipan/blob/main/etl/docs/bulk-import.md))
-2. States will conduct matches through [Active Matching](./openapi/generated/duplicate-participation-api/openapi.md#match)
-3. States will be able to take action by referencing previous matches through [a Lookup ID](./openapi/generated/duplicate-participation-api/openapi.md#Lookup)
+1. States will upload participant data through a scheduled [CSV upload](./openapi/generated/bulk-api/openapi.md#bulk-api-upload) (CSV formatting instructions can be found [here](https://github.com/18F/piipan/blob/main/etl/docs/bulk-import.md))
+2. States will conduct matches through [Active Matching](./openapi/generated/duplicate-participation-api/openapi.md#duplicate-participation-api-match)
+3. States will be able to take action by referencing previous matches through [a Lookup ID](./openapi/generated/duplicate-participation-api/openapi.md#duplicate-participation-api-lookup)
 
 ### Environments
 
-Seperate endpoints and credentials will be provided for each environment.
+Separate endpoints and credentials will be provided for each environment.
 
 | Environment | Purpose |
 |---|---|
@@ -36,17 +36,28 @@ Seperate endpoints and credentials will be provided for each environment.
 
 ### Endpoints Overview
 
+Endpoints are separated into two logical APIs:
+
+#### Bulk upload API
+
+[Detailed documentation](./openapi/generated/bulk-api/openapi.md)
+
 | Endpoint | Description | Request Type |
 |---|---|---|
-| `/<state-abbreviation>/upload/:filename` | uploads bulk participant data to the system | POST |
+| `/upload/:filename` | uploads bulk participant data to the system | PUT |
+
+#### Duplicate participation API
+
+[Detailed documentation](./openapi/generated/duplicate-participation-api/openapi.md)
+
+| Endpoint | Description | Request Type |
+|---|---|---|
 | `/query` | query for active matches | POST |
 | `/lookup_ids/:id` | Returns PII for a Lookup ID | GET |
 
-Detailed documentation for each endpoint can be found [here](./openapi/generated/duplicate-participation-api/openapi.md).
-
 ## Authentication
 
-States will be issued API keys that are placed into request headers to authenticate a web service call. The bulk upload API requires a separate API key from the query and lookup APIs.
+States will be issued API keys that are placed into request headers to authenticate a web service call. The bulk upload API requires a separate API key from the duplicate participation API.
 
 Example using cURL:
 
@@ -59,5 +70,3 @@ curl --request PUT '<uri>' --header 'Ocp-Apim-Subscription-Key: <api-key>'
 Got any feedback for us? We track API issues through [Github Issues](https://github.com/18F/piipan/issues).
 
 We also have a Microsoft Teams channel for daily communication with state agency engineers.
-
-

--- a/etl/docs/openapi/upload.yaml
+++ b/etl/docs/openapi/upload.yaml
@@ -4,12 +4,6 @@ put:
   tags:
     - "Upload"
   parameters:
-    - name: state
-      in: path
-      description: state abbreviation
-      required: true
-      schema:
-        type: string
     - name: filename
       in: path
       description: Name of file being uploaded

--- a/iac/apim-bulkupload-policy.xml
+++ b/iac/apim-bulkupload-policy.xml
@@ -3,7 +3,7 @@
 <policies>
     <inbound>
         <base />
-        <authentication-managed-identity resource="{applicationUri}" />
+        <authentication-managed-identity resource="https://{storageAccountName}.blob.core.windows.net" />
 
         <!--
             Required blob storage API headers

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -2,6 +2,12 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "env": {
+            "type": "String"
+        },
+        "prefix": {
+            "type": "String"
+        },
         "apiName": {
             "type": "String"
         },
@@ -23,7 +29,7 @@
         "dupPartPolicyXml": {
             "type": "String"
         },
-        "uploadAccounts": {
+        "uploadStates": {
             "type": "String"
         },
         "uploadBaseDomain": {
@@ -40,13 +46,21 @@
         "matchDisplayName": "Duplicate participation API",
         "matchSetName": "match",
         "uploadDisplayName": "Bulk upload API",
-        "uploadSetName": "bulk-upload",
-        "uploadAccountsList": "[split(parameters('uploadAccounts'), ' ')]",
-        "copy": [{
-            "name": "uploadApiNames",
-            "count": "[length(variables('uploadAccountsList'))]",
-            "input": "[concat(variables('uploadSetName'), '-', variables('uploadAccountsList')[copyIndex('uploadApiNames')])]"
-        }]
+        "uploadSetName": "bulk",
+        "uploadStatesList": "[split(toLower(parameters('uploadStates')), ' ')]",
+        "copy": [
+            {
+                "name": "uploadApiNames",
+                "count": "[length(variables('uploadStatesList'))]",
+                "input": "[concat(variables('uploadSetName'), '-', variables('uploadStatesList')[copyIndex('uploadApiNames')])]"
+            },
+            // Generate storage account names based on naming convention: {prefix}st{state-abbr}upload{env}
+            {
+                "name": "uploadAccountNames",
+                "count": "[length(variables('uploadStatesList'))]",
+                "input": "[concat(parameters('prefix'), 'st', variables('uploadStatesList')[copyIndex('uploadAccountNames')], 'upload', parameters('env'))]"
+            }
+        ]
     },
     "resources": [
         {
@@ -218,12 +232,12 @@
                 "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]"
             ],
             "properties": {
-                "displayName": "[concat(variables('uploadAccountsList')[copyIndex()], ' ', variables('uploadDisplayName'))]",
+                "displayName": "[concat(toUpper(variables('uploadStatesList')[copyIndex()]), ' ', variables('uploadDisplayName'))]",
                 "versioningScheme": "Segment"
             },
             "copy": {
                 "name": "per-state-upload-api-vs",
-                "count": "[length(variables('uploadAccountsList'))]"
+                "count": "[length(variables('uploadStatesList'))]"
             }
         },
         {
@@ -235,19 +249,19 @@
                 "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('uploadApiNames')[copyIndex()])]"
             ],
             "properties": {
-                "displayName": "[concat(variables('uploadAccountsList')[copyIndex()], ' ', variables('uploadDisplayName'))]",
+                "displayName": "[concat(toUpper(variables('uploadStatesList')[copyIndex()]), ' ', variables('uploadDisplayName'))]",
                 "subscriptionRequired": true,
                 "protocols": [
                     "https"
                 ],
-                "path": "[variables('uploadAccountsList')[copyIndex()]]",
+                "path": "[concat(variables('uploadSetName'), '/', variables('uploadStatesList')[copyIndex()])]",
                 "apiVersion": "v1",
                 "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('uploadApiNames')[copyIndex()])]",
-                "serviceUrl": "[concat('https://', variables('uploadAccountsList')[copyIndex()], parameters('uploadBaseDomain'))]"
+                "serviceUrl": "[concat('https://', variables('uploadAccountNames')[copyIndex()], parameters('uploadBaseDomain'))]"
             },
             "copy": {
                 "name": "per-state-upload-apis",
-                "count": "[length(variables('uploadAccountsList'))]"
+                "count": "[length(variables('uploadStatesList'))]"
             }
         },
         {
@@ -259,12 +273,12 @@
                 "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('uploadApiNames')[copyIndex()])]"
             ],
             "properties": {
-                "value": "[parameters('uploadPolicyXml')]",
+                "value": "[replace(parameters('uploadPolicyXml'), '{storageAccountName}', variables('uploadAccountNames')[copyIndex()])]",
                 "format": "xml"
             },
             "copy": {
                 "name": "per-state-upload-policies",
-                "count": "[length(variables('uploadAccountsList'))]"
+                "count": "[length(variables('uploadStatesList'))]"
             }
         },
         {
@@ -292,7 +306,7 @@
             },
             "copy": {
                 "name": "per-state-upload-ops",
-                "count": "[length(variables('uploadAccountsList'))]"
+                "count": "[length(variables('uploadStatesList'))]"
             }
         }
     ],

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -81,6 +81,17 @@ grant_blob () {
     --scope "${DEFAULT_PROVIDERS}/Microsoft.Storage/storageAccounts/${storage_account}"
 }
 
+get_state_abbrs () {
+  local state_abbrs=()
+
+  while IFS=, read -r abbr name ; do
+    abbr=$(echo "$abbr" | tr '[:upper:]' '[:lower:]')
+    state_abbrs+=("${abbr}")
+  done < states.csv
+
+  echo "${state_abbrs[*]}"
+}
+
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
@@ -92,8 +103,6 @@ main () {
   publisher_email=$2
 
   orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
-  upload_accounts=($(get_resources $PER_STATE_STORAGE_TAG $RESOURCE_GROUP))
-
   orch_base_url=$(\
     az functionapp show \
       -g $MATCH_RESOURCE_GROUP \
@@ -104,9 +113,11 @@ main () {
   orch_api_url="${orch_base_url}/api/v1"
 
   duppart_policy_xml=$(generate_policy apim-duppart-policy.xml ${orch_base_url})
-  upload_policy_xml=$(generate_policy apim-bulkupload-policy.xml https://storage.azure.com/)
 
   upload_domain=$(storage_account_domain)
+  upload_policy_path=$(dirname "$0")/apim-bulkupload-policy.xml
+  upload_policy_xml=$(< $upload_policy_path)
+  state_abbrs=$(get_state_abbrs)
 
   apim_identity=$(\
     az deployment group create \
@@ -116,17 +127,20 @@ main () {
       --query properties.outputs.identity.value.principalId \
       --output tsv \
       --parameters \
+        env=$ENV \
+        prefix=$PREFIX \
         apiName=$APIM_NAME \
         publisherEmail=$publisher_email \
         publisherName="$PUBLISHER_NAME" \
         orchestratorUrl=$orch_api_url \
         dupPartPolicyXml="$duppart_policy_xml" \
-        uploadAccounts="${upload_accounts[*]}" \
+        uploadStates="$state_abbrs" \
         uploadBaseDomain="$upload_domain" \
         uploadPolicyXml="$upload_policy_xml" \
         location=$LOCATION \
         resourceTags="$RESOURCE_TAGS")
 
+  upload_accounts=($(get_resources $PER_STATE_STORAGE_TAG $RESOURCE_GROUP))
   for account in "${upload_accounts[@]}"
   do
     grant_blob $apim_identity $account


### PR DESCRIPTION
- Use state abbreviations for upload endpoints
- Dynamically generate storage account names in ARM template
- Update documentation to reflect two APIs

This starts implementing some of the API naming conventions we discussed. After this update, per-state upload endpoints will be in the following format:
```
/bulk/ea/v1/upload/filename.csv
```

This update does not change the endpoints for the `/query` or `/lookup_ids` methods.

I'm tentatively referring to the two APIs as "bulk" (or just "bulk upload" for now) and "duplicate participation" in the documentation.

The updated IaC has been run against the duppart APIM resource in `-dev` and can be viewed in the Portal.

Closes #728, related to #762.