### PR TITLE
Dynamically generate APIM hostname

### DIFF
--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -8,6 +8,9 @@
         "prefix": {
             "type": "String"
         },
+        "cloudName": {
+            "type": "String"
+        },
         "apiName": {
             "type": "String"
         },
@@ -32,9 +35,6 @@
         "uploadStates": {
             "type": "String"
         },
-        "uploadBaseDomain": {
-            "type": "String"
-        },
         "uploadPolicyXml": {
             "type": "String"
         }
@@ -43,6 +43,8 @@
         "systemTypeTag": {
             "SysType": "DupPartApi"
         },
+        "apimUriBase": "[if(equals(parameters('cloudName'), 'AzureUSGovernment'), '.azure-api.us', '.azure-api.net')]",
+        "uploadUriBase": "[if(equals(parameters('cloudName'), 'AzureUSGovernment'), '.blob.core.usgovcloudapi.net/', '.blob.core.windows.net/')]",
         "matchDisplayName": "Duplicate participation API",
         "matchSetName": "match",
         "uploadDisplayName": "Bulk upload API",
@@ -82,7 +84,7 @@
                 "hostnameConfigurations": [
                     {
                         "type": "Proxy",
-                        "hostName": "[concat(parameters('apiName'), '.azure-api.net')]",
+                        "hostName": "[concat(parameters('apiName'), variables('apimUriBase'))]",
                         "defaultSslBinding": true
                     }
                 ],
@@ -257,7 +259,7 @@
                 "path": "[concat(variables('uploadSetName'), '/', variables('uploadStatesList')[copyIndex()])]",
                 "apiVersion": "v1",
                 "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('uploadApiNames')[copyIndex()])]",
-                "serviceUrl": "[concat('https://', variables('uploadAccountNames')[copyIndex()], parameters('uploadBaseDomain'))]"
+                "serviceUrl": "[concat('https://', variables('uploadAccountNames')[copyIndex()], variables('uploadUriBase'))]"
             },
             "copy": {
                 "name": "per-state-upload-apis",

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -45,17 +45,6 @@ clean_defaults () {
     -y
 }
 
-storage_account_domain () {
-  local base=".blob.core.windows.net/"
-
-  # https://docs.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure
-  if [ "$CLOUD_NAME" = "AzureUSGovernment" ]; then
-    base=".blob.core.usgovcloudapi.net/"
-  fi
-
-  echo $base
-}
-
 generate_policy () {
   local path
   path=$(dirname "$0")/$1
@@ -114,7 +103,6 @@ main () {
 
   duppart_policy_xml=$(generate_policy apim-duppart-policy.xml ${orch_base_url})
 
-  upload_domain=$(storage_account_domain)
   upload_policy_path=$(dirname "$0")/apim-bulkupload-policy.xml
   upload_policy_xml=$(< $upload_policy_path)
   state_abbrs=$(get_state_abbrs)
@@ -129,13 +117,13 @@ main () {
       --parameters \
         env=$ENV \
         prefix=$PREFIX \
+        cloudName="$CLOUD_NAME" \
         apiName=$APIM_NAME \
         publisherEmail=$publisher_email \
         publisherName="$PUBLISHER_NAME" \
         orchestratorUrl=$orch_api_url \
         dupPartPolicyXml="$duppart_policy_xml" \
         uploadStates="$state_abbrs" \
-        uploadBaseDomain="$upload_domain" \
         uploadPolicyXml="$upload_policy_xml" \
         location=$LOCATION \
         resourceTags="$RESOURCE_TAGS")


### PR DESCRIPTION
- Pass `CLOUD_NAME` env variable to ARM template
- Conditionally determine appropriate URI base
- Adapt upload hostname generation to same approach

Fixes issue when attempting to deploy APIM ARM template to Government Cloud using a `azure-api.net` hostname.