### PR TITLE
Cloud-aware blob storage resource IDs in APIM

### DIFF
--- a/iac/apim-bulkupload-policy.xml
+++ b/iac/apim-bulkupload-policy.xml
@@ -3,7 +3,7 @@
 <policies>
     <inbound>
         <base />
-        <authentication-managed-identity resource="https://{storageAccountName}.blob.core.windows.net" />
+        <authentication-managed-identity resource="{storageResourceId}" />
 
         <!--
             Required blob storage API headers

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -275,7 +275,7 @@
                 "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('uploadApiNames')[copyIndex()])]"
             ],
             "properties": {
-                "value": "[replace(parameters('uploadPolicyXml'), '{storageAccountName}', variables('uploadAccountNames')[copyIndex()])]",
+                "value": "[replace(parameters('uploadPolicyXml'), '{storageResourceId}', concat('https://', variables('uploadAccountNames')[copyIndex()], variables('uploadUriBase')))]",
                 "format": "xml"
             },
             "copy": {


### PR DESCRIPTION
Storage resource IDs are different in Azure Commercial vs Azure Government.

Updates resource ID in per-state upload API policies so APIM can successfully retrieve managed identity authentication tokens.

Closes #769