### PR TITLE
Create one script to run all unit tests; use in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,6 @@ commands:
 
 jobs:
   test:
-    environment:
-      MSBUILD_PROPS: "-p:ContinuousIntegrationBuild=true"
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:3.1
       - image: postgres:11-alpine
@@ -56,17 +54,9 @@ jobs:
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
       - run:
-          working_directory: dashboard/tests/Piipan.Dashboard.Tests
-          name: Test Dashboard
-          command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - run:
-          working_directory: etl/tests/Piipan.Etl.Tests
-          name: Test Etl
-          command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - run:
-          working_directory: match/tests/Piipan.Match.State.Tests
-          name: Test State Match
-          command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          working_directory: tools
+          name: Run All Unit Tests
+          command: ./unit-test-all.bash -c
       - run:
           working_directory: match/tests/Piipan.Match.State.IntegrationTests
           name: Test State Match integration
@@ -74,22 +64,6 @@ jobs:
             DatabaseConnectionString: "Server=localhost;Database=ea;Port=5432;User Id=postgres;Password=securepass;"
             StateName: "Echo Alpha"
             StateAbbr: ea
-          command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - run:
-          working_directory: query-tool/tests/Piipan.QueryTool.Tests
-          name: Test Query Tool
-          command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - run:
-          working_directory: match/tests/Piipan.Match.Orchestrator.Tests
-          name: Test Orchestrator Match
-          command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - run:
-          working_directory: metrics/tests/Piipan.Metrics.Tests
-          name: Test Metrics
-          command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - run:
-          working_directory: shared/tests/Piipan.Shared.Tests
-          name: Test Shared
           command: dotnet test $MSBUILD_PROPS --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
       - run:
           name: Upload Code Climate coverage report

--- a/shared/shared.sln
+++ b/shared/shared.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{93135BDE-0152-4513-A6CD-00256F12F847}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piipan.Shared.Tests", "tests\Piipan.Shared.Tests\Piipan.Shared.Tests.csproj", "{69F7763A-9006-4165-947A-A35FC5B18C20}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8195D85F-83AE-4F7F-B826-F49E316B8C58}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piipan.Shared", "src\Piipan.Shared\Piipan.Shared.csproj", "{2FD5540A-039E-4FCA-AE07-413A6079D0D3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Debug|x64.Build.0 = Debug|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Debug|x86.Build.0 = Debug|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Release|x64.ActiveCfg = Release|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Release|x64.Build.0 = Release|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Release|x86.ActiveCfg = Release|Any CPU
+		{69F7763A-9006-4165-947A-A35FC5B18C20}.Release|x86.Build.0 = Release|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Debug|x64.Build.0 = Debug|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Debug|x86.Build.0 = Debug|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Release|x64.ActiveCfg = Release|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Release|x64.Build.0 = Release|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Release|x86.ActiveCfg = Release|Any CPU
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{69F7763A-9006-4165-947A-A35FC5B18C20} = {93135BDE-0152-4513-A6CD-00256F12F847}
+		{2FD5540A-039E-4FCA-AE07-413A6079D0D3} = {8195D85F-83AE-4F7F-B826-F49E316B8C58}
+	EndGlobalSection
+EndGlobal

--- a/tools/unit-test-all.bash
+++ b/tools/unit-test-all.bash
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Unit test all subsystems in repo
+#
+# Optional Flags:
+# -c Run tests in continuous integration mode
+#
+# usage: ./unit-test-all.bash
+
+source $(dirname "$0")/common.bash || exit
+
+ci='false'
+
+while getopts ':c' arg; do
+	case "${arg}" in
+		c) ci='true' ;;
+	esac
+done
+
+subsystems=(dashboard etl match metrics query-tool shared)
+
+for s in "${subsystems[@]}"
+do
+	pushd ../$s/
+		echo "\nTesting ${s}"
+		if [ "$ci" = "true" ]; then
+			dotnet test -p:ContinuousIntegrationBuild=true \
+				--collect:"XPlat Code Coverage" \
+				-- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+		else
+			dotnet test
+		fi
+	popd
+done
+
+script_completed


### PR DESCRIPTION
Part of #529 and #509 

This is a sketch for testing all subsystems at once—wanted to see if I'm on the right track. I was planning on 1 script for each task (build/test/deploy) that does the task for all subsystems at once. But I could also see a scenario where one script does all tasks for one subsystem at a time. 

Integrating a script like this into Circle config helped me figure out what would be required for CI usage, although I realize that's a little out of scope here. 

#### Misc
- Wasn't sure how to elegantly pass flags while also using a `main` function. 
- Also not sure what the deal is with my indentation in `unit-test-all.bash` on Github (shows up as correctly as 2 spaces in my VSCode)