### PR TITLE
Example of a build.bash script for dashboard subsystem

### DIFF
--- a/dashboard/build.bash
+++ b/dashboard/build.bash
@@ -4,15 +4,16 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 #
 # Arguments:
-# build                   Build project binaries
-# test                    Run tests
-# deploy [-e <azure_env>] Deploy to specified Azure Environment (e.g. tts/dev)
+# [none]                Build project binaries
+# test                  Run tests
+# deploy -e <azure_env> Deploy to specified Azure Environment (e.g. tts/dev)
 #
-# Description
-# When deploying, an optional environment flag [-e] can be passed. Defaults to tts/dev.
+# Description:
+# When passed no arguments, script runs in build mode.
+# When deploying, an environment flag [-e] must be passed.
 #
 # Usage:
-# ./build.bash build
+# ./build.bash
 # ./build.bash test
 # ./build.bash deploy
 # ./build.bash deploy -e tts/test

--- a/dashboard/build.bash
+++ b/dashboard/build.bash
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Builds dashboard project
+#
+# Optional Flags:
+# -t        Run tests only
+# -d [env]  Build and deploy to specified Azure Environment (e.g. tts/dev)
+#
+# Usage:
+# ./build.bash
+# ./build.bash -t
+# ./build.bash -d tts/dev
+#
+# Note: -t and -d flags are exclusive. When used together, it will only run in test mode.
+
+source $(dirname "$0")/../tools/common.bash || exit
+
+# set modes
+test_mode="false"
+azure_env=""
+
+while getopts ":td:" arg; do
+	case "${arg}" in
+		t) test_mode="true" ;;
+    d) azure_env=$OPTARG ;;
+	esac
+done
+# end set modes
+
+set_constants () {
+  DASHBOARD_APP_NAME=$PREFIX-app-dashboard-$ENV # TODO: make this DRY
+}
+
+main () {
+  test_mode=$1
+  azure_env=$2
+  source $(dirname "$0")/../iac/env/${azure_env}.bash
+  source $(dirname "$0")/../iac/iac-common.bash
+  verify_cloud
+
+  set_constants
+
+  # run build
+  dotnet build
+
+  if [ "$test_mode" = "true" ]; then
+    echo "Running tests"
+    dotnet test
+  else
+    echo "Publishing project"
+    dotnet publish -o ./artifacts
+    if [ "$azure_env" != "" ]; then
+      echo "Deploying to Azure Environment ${azure_env}"
+      pushd ./artifacts
+        zip -r dashboard.zip .
+      popd
+      az webapp deployment \
+        source config-zip \
+        -g $RESOURCE_GROUP \
+        -n $DASHBOARD_APP_NAME \
+        --src ./artifacts/dashboard.zip
+    fi
+  fi
+
+  script_completed
+}
+
+main $test_mode $azure_env

--- a/docs/iac.md
+++ b/docs/iac.md
@@ -68,6 +68,7 @@ The following environment variables are pre-configured by the Infrastructure-as-
 
 | Value | Description |
 |---|---|
+| PerStateEtl | one of _N_ function apps for per-state bulk ETL process |
 | PerStateStorage | one of _N_ storage accounts for per-state bulk PII uploads |
 | PerStateMatchApi | one of _N_ API Function Apps for Per-state matching |
 | OrchestratorApi | the single Function App for the Orchestrator API |

--- a/etl/build.bash
+++ b/etl/build.bash
@@ -4,15 +4,16 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 #
 # Arguments:
-# build                   Build project binaries
-# test                    Run tests
-# deploy [-e <azure_env>] Deploy to specified Azure Environment (e.g. tts/dev)
+# [none]                Build project binaries
+# test                  Run tests
+# deploy -e <azure_env> Deploy to specified Azure Environment (e.g. tts/dev)
 #
-# Description
-# When deploying, an optional environment flag [-e] can be passed. Defaults to tts/dev.
+# Description:
+# When passed no arguments, script runs in build mode.
+# When deploying, an environment flag [-e] must be passed.
 #
 # Usage:
-# ./build.bash build
+# ./build.bash
 # ./build.bash test
 # ./build.bash deploy
 # ./build.bash deploy -e tts/test

--- a/etl/build.bash
+++ b/etl/build.bash
@@ -20,28 +20,21 @@
 source $(dirname "$0")/../tools/common.bash || exit
 source $(dirname "$0")/../tools/build-common.bash || exit
 
-set_constants () {
-  DASHBOARD_APP_NAME=$PREFIX-app-dashboard-$ENV # TODO: make this DRY
-}
-
 run_deploy () {
   azure_env=$1
   source $(dirname "$0")/../iac/env/${azure_env}.bash
   source $(dirname "$0")/../iac/iac-common.bash
   verify_cloud
-  set_constants
 
-  echo "Publishing project"
-  dotnet publish -o ./artifacts
-  echo "Deploying to Azure Environment ${azure_env}"
-  pushd ./artifacts
-    zip -r dashboard.zip .
-  popd
-  az webapp deployment \
-    source config-zip \
-    -g $RESOURCE_GROUP \
-    -n $DASHBOARD_APP_NAME \
-    --src ./artifacts/dashboard.zip
+  etl_function_apps=($(get_resources $PER_STATE_ETL_TAG $RESOURCE_GROUP))
+
+  for app in "${etl_function_apps[@]}"
+  do
+    echo "\nPublish ${app} to Azure Environment ${azure_env}"
+    pushd ./src/Piipan.Etl
+      func azure functionapp publish $app --dotnet
+    popd
+  done
 }
 
 main $@

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -302,7 +302,7 @@ main () {
     az functionapp create \
       --resource-group $RESOURCE_GROUP \
       --plan $APP_SERVICE_PLAN_FUNC_NAME \
-      --tags Project=$PROJECT_TAG \
+      --tags Project=$PROJECT_TAG $PER_STATE_ETL_TAG \
       --runtime dotnet \
       --functions-version 3 \
       --os-type Windows \

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -4,6 +4,7 @@ PROJECT_TAG=piipan
 RESOURCE_TAGS="{ \"Project\": \"${PROJECT_TAG}\" }"
 
 # Tag filters for system types; descriptions are in iac.md
+PER_STATE_ETL_TAG="SysType=PerStateEtl"
 PER_STATE_STORAGE_TAG="SysType=PerStateStorage"
 PER_STATE_MATCH_API_TAG="SysType=PerStateMatchApi"
 ORCHESTRATOR_API_TAG="SysType=OrchestratorApi"

--- a/match/build.bash
+++ b/match/build.bash
@@ -4,15 +4,16 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 #
 # Arguments:
-# build                   Build project binaries
-# test                    Run tests
-# deploy [-e <azure_env>] Deploy to specified Azure Environment (e.g. tts/dev)
+# [none]                Build project binaries
+# test                  Run tests
+# deploy -e <azure_env> Deploy to specified Azure Environment (e.g. tts/dev)
 #
-# Description
-# When deploying, an optional environment flag [-e] can be passed. Defaults to tts/dev.
+# Description:
+# When passed no arguments, script runs in build mode.
+# When deploying, an environment flag [-e] must be passed.
 #
 # Usage:
-# ./build.bash build
+# ./build.bash
 # ./build.bash test
 # ./build.bash deploy
 # ./build.bash deploy -e tts/test

--- a/metrics/build.bash
+++ b/metrics/build.bash
@@ -4,15 +4,16 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 #
 # Arguments:
-# build                   Build project binaries
-# test                    Run tests
-# deploy [-e <azure_env>] Deploy to specified Azure Environment (e.g. tts/dev)
+# [none]                Build project binaries
+# test                  Run tests
+# deploy -e <azure_env> Deploy to specified Azure Environment (e.g. tts/dev)
 #
-# Description
-# When deploying, an optional environment flag [-e] can be passed. Defaults to tts/dev.
+# Description:
+# When passed no arguments, script runs in build mode.
+# When deploying, an environment flag [-e] must be passed.
 #
 # Usage:
-# ./build.bash build
+# ./build.bash
 # ./build.bash test
 # ./build.bash deploy
 # ./build.bash deploy -e tts/test

--- a/metrics/build.bash
+++ b/metrics/build.bash
@@ -21,7 +21,11 @@ source $(dirname "$0")/../tools/common.bash || exit
 source $(dirname "$0")/../tools/build-common.bash || exit
 
 set_constants () {
-  DASHBOARD_APP_NAME=$PREFIX-app-dashboard-$ENV # TODO: make this DRY
+   # TODO: make more DRY
+  COLLECT_APP_ID=metricscol
+  COLLECT_APP_NAME=${PREFIX}-func-${COLLECT_APP_ID}-${ENV}
+  METRICS_API_APP_ID=metricsapi
+  API_APP_NAME=$PREFIX-func-$METRICS_API_APP_ID-$ENV
 }
 
 run_deploy () {
@@ -29,19 +33,18 @@ run_deploy () {
   source $(dirname "$0")/../iac/env/${azure_env}.bash
   source $(dirname "$0")/../iac/iac-common.bash
   verify_cloud
+
   set_constants
 
-  echo "Publishing project"
-  dotnet publish -o ./artifacts
-  echo "Deploying to Azure Environment ${azure_env}"
-  pushd ./artifacts
-    zip -r dashboard.zip .
+  echo "\nPublish ${COLLECT_APP_NAME} to Azure Environment ${azure_env}"
+  pushd ./src/Piipan.Metrics/Piipan.Metrics.Collect
+    func azure functionapp publish $COLLECT_APP_NAME --dotnet
   popd
-  az webapp deployment \
-    source config-zip \
-    -g $RESOURCE_GROUP \
-    -n $DASHBOARD_APP_NAME \
-    --src ./artifacts/dashboard.zip
+
+  echo "\nPublish ${API_APP_NAME} to Azure Environment ${azure_env}"
+  pushd ./src/Piipan.Metrics/Piipan.Metrics.Api
+    func azure functionapp publish $API_APP_NAME --dotnet
+  popd
 }
 
 main $@

--- a/query-tool/build.bash
+++ b/query-tool/build.bash
@@ -4,15 +4,16 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 #
 # Arguments:
-# build                   Build project binaries
-# test                    Run tests
-# deploy [-e <azure_env>] Deploy to specified Azure Environment (e.g. tts/dev)
+# [none]                Build project binaries
+# test                  Run tests
+# deploy -e <azure_env> Deploy to specified Azure Environment (e.g. tts/dev)
 #
-# Description
-# When deploying, an optional environment flag [-e] can be passed. Defaults to tts/dev.
+# Description:
+# When passed no arguments, script runs in build mode.
+# When deploying, an environment flag [-e] must be passed.
 #
 # Usage:
-# ./build.bash build
+# ./build.bash
 # ./build.bash test
 # ./build.bash deploy
 # ./build.bash deploy -e tts/test

--- a/query-tool/build.bash
+++ b/query-tool/build.bash
@@ -21,7 +21,7 @@ source $(dirname "$0")/../tools/common.bash || exit
 source $(dirname "$0")/../tools/build-common.bash || exit
 
 set_constants () {
-  DASHBOARD_APP_NAME=$PREFIX-app-dashboard-$ENV # TODO: make this DRY
+  QUERY_TOOL_APP_NAME=$PREFIX-app-querytool-$ENV # TODO: make this DRY
 }
 
 run_deploy () {
@@ -30,7 +30,6 @@ run_deploy () {
   source $(dirname "$0")/../iac/iac-common.bash
   verify_cloud
   set_constants
-
   echo "Publishing project"
   dotnet publish -o ./artifacts
   echo "Deploying to Azure Environment ${azure_env}"
@@ -40,7 +39,7 @@ run_deploy () {
   az webapp deployment \
     source config-zip \
     -g $RESOURCE_GROUP \
-    -n $DASHBOARD_APP_NAME \
+    -n $QUERY_TOOL_APP_NAME \
     --src ./artifacts/dashboard.zip
 }
 

--- a/tools/build-common.bash
+++ b/tools/build-common.bash
@@ -22,8 +22,8 @@ run_tests () {
 # The Main runner for build scripts
 # switches between build modes (build, test, deploy)
 main () {
-  mode=$1
-  azure_env="tts/dev"
+  mode=${1:-build} # set default mode to "build"
+  azure_env=""
 
   case "$mode" in
     deploy)
@@ -50,7 +50,15 @@ main () {
 
   if [ "$mode" = "build" ];   then run_build; fi
   if [ "$mode" = "test" ];    then run_tests; fi
-  if [ "$mode" = "deploy" ];  then run_deploy $azure_env; fi
+  if [[ "$mode" = "deploy" ]]; then
+    if [[ "$azure_env" = "" ]]; then
+      echo "You must specify an azure environment using the -e flag"
+      echo "Example: ./build.bash deploy -e tts/dev"
+      exit 1
+    else
+      run_deploy $azure_env
+    fi
+  fi
 
   script_completed
 }

--- a/tools/build-common.bash
+++ b/tools/build-common.bash
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Supporting functionality for subsystem build scripts.
+# Purpose of build scripts is to have platform-agnostic scripts
+# that can be used for local development, CI, and IAC.
+# Each subsystem has a top-level build.bash file that may
+# use and/or override any of these functions.
+# Build scripts rely on a solutions file (sln) in subsystem root.
+
+# runs the build process
+run_build () {
+  echo "Running build"
+  dotnet build
+}
+
+# runs all tests
+run_tests () {
+  echo "Running tests"
+  dotnet test
+}
+
+# The Main runner for build scripts
+# switches between build modes (build, test, deploy)
+main () {
+  mode=$1
+  azure_env="tts/dev"
+
+  case "$mode" in
+    deploy)
+      shift # Remove `deploy` from the argument list
+
+    while getopts ":e:" opt; do
+      case ${opt} in
+        e )
+          azure_env=$OPTARG
+          ;;
+        \? )
+          echo "Invalid Option: -$OPTARG" 1>&2
+          exit 1
+          ;;
+        : )
+          echo "Invalid Option: -$OPTARG requires an argument" 1>&2
+          exit 1
+          ;;
+      esac
+    done
+    shift $((OPTIND -1))
+    ;;
+  esac
+
+  if [ "$mode" = "build" ];   then run_build; fi
+  if [ "$mode" = "test" ];    then run_tests; fi
+  if [ "$mode" = "deploy" ];  then run_deploy $azure_env; fi
+
+  script_completed
+}


### PR DESCRIPTION
Partially addresses #529

- options to run in test-only mode or deployment mode
- deployment mode passes an Azure environment argument