### PR TITLE
Add Shellcheck of full repo to CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   azure-cli: circleci/azure-cli@1.1.0
+  shellcheck: circleci/shellcheck@2.2.3
 
 commands:
   run_pa11y:
@@ -38,6 +39,15 @@ commands:
           command: pa11y-ci
 
 jobs:
+  shellcheck:
+    docker:
+      - image: 'cimg/base:stable'
+    steps:
+      - checkout
+      - shellcheck/install
+      - run:
+          name: Run Shellcheck
+          command: find ./ -type f \( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' -o -name '*.bashrc' -o -name '*.bash_profile' -o -name '*.bash_login' -o -name '*.bash_logout' \) | xargs shellcheck -x
   test:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:3.1
@@ -155,10 +165,12 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
+      - shellcheck
       - test
       - build
       - deploy:
           requires:
+            - shellcheck
             - test
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - shellcheck/install
       - run:
           name: Run Shellcheck
-          command: find ./ -type f \( -name '*.sh' -o -name '*.bash' \) | xargs shellcheck -x
+          command: find ./ -type f \( -name '*.bash' \) | xargs shellcheck -x -e SC2207
   test:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - shellcheck/install
       - run:
           name: Run Shellcheck
-          command: find ./ -type f \( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' -o -name '*.bashrc' -o -name '*.bash_profile' -o -name '*.bash_login' -o -name '*.bash_logout' \) | xargs shellcheck -x
+          command: find ./ -type f \( -name '*.sh' -o -name '*.bash' \) | xargs shellcheck -x
   test:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:3.1

--- a/dashboard/build.bash
+++ b/dashboard/build.bash
@@ -4,8 +4,10 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 # See build-common.bash for usage details
 
-source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/../tools/build-common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+# shellcheck source=./tools/build-common.bash
+source "$(dirname "$0")"/../tools/build-common.bash || exit
 
 set_constants () {
   DASHBOARD_APP_NAME=$PREFIX-app-dashboard-$ENV # TODO: make this DRY
@@ -13,8 +15,8 @@ set_constants () {
 
 run_deploy () {
   azure_env=$1
-  source $(dirname "$0")/../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../iac/iac-common.bash
+  source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
+  source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
   set_constants
 
@@ -26,9 +28,9 @@ run_deploy () {
   popd
   az webapp deployment \
     source config-zip \
-    -g $RESOURCE_GROUP \
-    -n $DASHBOARD_APP_NAME \
+    -g "$RESOURCE_GROUP" \
+    -n "$DASHBOARD_APP_NAME" \
     --src ./artifacts/dashboard.zip
 }
 
-main $@
+main "$@"

--- a/ddl/apply-ddl.bash
+++ b/ddl/apply-ddl.bash
@@ -5,7 +5,8 @@
 #
 # usage: apply-ddl.bash
 
-source $(dirname "$0")/../iac/iac-common.bash || exit
+# shellcheck source=./iac/iac-common.bash
+source "$(dirname "$0")"/../iac/iac-common.bash || exit
 
 set -e
 
@@ -29,22 +30,22 @@ apply_ddl () {
   owner=$2
   admin=$3
 
-  psql $PSQL_OPTS -d $db \
-    -v owner=$owner \
-    -v admin=$admin \
-    -v superuser=$SUPERUSER \
+  psql "$PSQL_OPTS" -d "$db" \
+    -v owner="$owner" \
+    -v admin="$admin" \
+    -v superuser="$SUPERUSER" \
     -f ./per-state.sql
 }
 
 main () {
-  while IFS=, read -r abbr name ; do
-    db=`echo "$abbr" | tr '[:upper:]' '[:lower:]'`
+  while IFS=, read -r abbr ; do
+    db=$(echo "$abbr" | tr '[:upper:]' '[:lower:]')
     owner=$db
-    admin=`state_managed_id_name $db $ENV`
+    admin=$(state_managed_id_name "$db" "$ENV")
     admin=${admin//-/_}
 
     echo "Applying DDL to database $db..."
-    apply_ddl $db $owner $admin
+    apply_ddl "$db" "$owner" "$admin"
 
   done < ../iac/states.csv
 }

--- a/ddl/apply-ddl.bash
+++ b/ddl/apply-ddl.bash
@@ -23,14 +23,14 @@ set -u
 SUPERUSER=${PGUSER%@*}
 
 export PGOPTIONS='--client-min-messages=warning'
-PSQL_OPTS='-v ON_ERROR_STOP=1 -X -q'
+PSQL_OPTS=(-v ON_ERROR_STOP=1 -X -q)
 
 apply_ddl () {
   db=$1
   owner=$2
   admin=$3
 
-  psql "$PSQL_OPTS" -d "$db" \
+  psql "${PSQL_OPTS[@]}" -d "$db" \
     -v owner="$owner" \
     -v admin="$admin" \
     -v superuser="$SUPERUSER" \
@@ -38,7 +38,7 @@ apply_ddl () {
 }
 
 main () {
-  while IFS=, read -r abbr ; do
+  while IFS=, read -r abbr _; do
     db=$(echo "$abbr" | tr '[:upper:]' '[:lower:]')
     owner=$db
     admin=$(state_managed_id_name "$db" "$ENV")

--- a/docs/openapi/tools/generate-docs.bash
+++ b/docs/openapi/tools/generate-docs.bash
@@ -20,7 +20,7 @@ main () {
 
   for s in "${specs[@]}"
   do
-    pushd ./generated/${s}/
+    pushd ./generated/"${s}"/
     widdershins \
         --language_tabs 'shell:curl:request' \
         --omitBody \

--- a/docs/openapi/tools/generate-specs.bash
+++ b/docs/openapi/tools/generate-specs.bash
@@ -19,10 +19,10 @@ main () {
         generated_path="./generated/${s}/openapi.yaml"
 
         echo "Validating ${spec_path}"
-        swagger-cli validate $spec_path
+        swagger-cli validate "$spec_path"
 
         echo "Generating ${generated_path}"
-        swagger-cli bundle $spec_path -o $generated_path -t yaml
+        swagger-cli bundle "$spec_path" -o "$generated_path" -t yaml
     done
 }
 

--- a/etl/build.bash
+++ b/etl/build.bash
@@ -4,24 +4,27 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 # See build-common.bash for usage details
 
-source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/../tools/build-common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+# shellcheck source=./tools/build-common.bash
+source "$(dirname "$0")"/../tools/build-common.bash || exit
 
 run_deploy () {
   azure_env=$1
-  source $(dirname "$0")/../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../iac/iac-common.bash
+  source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
+  source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
 
-  etl_function_apps=($(get_resources $PER_STATE_ETL_TAG $RESOURCE_GROUP))
+  # shellcheck disable=SC2207
+  etl_function_apps=($(get_resources "$PER_STATE_ETL_TAG" "$RESOURCE_GROUP"))
 
   for app in "${etl_function_apps[@]}"
   do
-    echo "\nPublish ${app} to Azure Environment ${azure_env}"
+    echo "Publish ${app} to Azure Environment ${azure_env}"
     pushd ./src/Piipan.Etl
-      func azure functionapp publish $app --dotnet
+      func azure functionapp publish "$app" --dotnet
     popd
   done
 }
 
-main $@
+main "$@"

--- a/etl/build.bash
+++ b/etl/build.bash
@@ -15,7 +15,6 @@ run_deploy () {
   source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
 
-  # shellcheck disable=SC2207
   etl_function_apps=($(get_resources "$PER_STATE_ETL_TAG" "$RESOURCE_GROUP"))
 
   for app in "${etl_function_apps[@]}"

--- a/etl/tools/grant-blob.bash
+++ b/etl/tools/grant-blob.bash
@@ -9,29 +9,30 @@
 #
 # usage: grant-blob.bash <azure-env> <storage-account>
 
-source $(dirname "$0")/../../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../../tools/common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/../../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../../iac/iac-common.bash
+  source "$(dirname "$0")"/../../iac/env/"${azure_env}".bash
+  source "$(dirname "$0")"/../../iac/iac-common.bash
   verify_cloud
 
   storage_account=$2
 
   # The default Azure subscription
-  SUBSCRIPTION_ID=`az account show --query id -o tsv`
+  SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 
   # Many CLI commands use a URI to identify nested resources; pre-compute the URI's prefix
   # for our default resource group
   DEFAULT_PROVIDERS=/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers
 
-  assignee=`az ad signed-in-user show --query objectId -o tsv`
+  assignee=$(az ad signed-in-user show --query objectId -o tsv)
 
   az role assignment create \
     --role "Storage Blob Data Contributor" \
-    --assignee $assignee \
+    --assignee "$assignee" \
     --scope "${DEFAULT_PROVIDERS}/Microsoft.Storage/storageAccounts/${storage_account}"
 }
 

--- a/etl/tools/upload.bash
+++ b/etl/tools/upload.bash
@@ -10,23 +10,26 @@
 #
 # usage: upload.bash <azure-env> <path-to-file> <storage-account>
 
-source $(dirname "$0")/../../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../../tools/common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/../../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../../iac/iac-common.bash
+  source "$(dirname "$0")"/../../iac/env/"${azure_env}".bash
+  source "$(dirname "$0")"/../../iac/iac-common.bash
   verify_cloud
 
   file_path=$2
   storage_account=$3
 
+  name=$(basename "$file_path")
+
   az storage blob upload \
-    --account-name $storage_account \
+    --account-name "$storage_account" \
     --container-name upload \
-    --name `basename $file_path` \
-    --file $file_path \
+    --name "$name" \
+    --file "$file_path" \
     --auth-mode login
 }
 

--- a/iac/add-front-door-to-app.bash
+++ b/iac/add-front-door-to-app.bash
@@ -12,12 +12,13 @@
 # Usage:
 # ./iac/add-front-door-to-app.bash tts/dev rg-core-dev dashboard my-dashboard-123.azurewebsites.net
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 main () {
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   resource_group=$2
@@ -27,16 +28,16 @@ main () {
 
   suffix=$(front_door_host_suffix)
   az deployment group create \
-    --name $front_door_name \
-    --resource-group $resource_group \
+    --name "$front_door_name" \
+    --resource-group "$resource_group" \
     --template-file ./arm-templates/front-door-app-service.json \
     --parameters \
-      appAddress=$app_address \
-      frontDoorHostName=${front_door_name}${suffix} \
-      frontDoorName=$front_door_name \
-      resourceGroupName=$resource_group \
+      appAddress="$app_address" \
+      frontDoorHostName="${front_door_name}${suffix}" \
+      frontDoorName="$front_door_name" \
+      resourceGroupName="$resource_group" \
       resourceTags="$RESOURCE_TAGS" \
-      wafPolicyName=$waf_name
+      wafPolicyName="$waf_name"
 
   script_completed
 }

--- a/iac/configure-easy-auth.bash
+++ b/iac/configure-easy-auth.bash
@@ -259,11 +259,11 @@ main () {
   match_func_names=($(\
     get_resources "$PER_STATE_MATCH_API_TAG" "$RESOURCE_GROUP"))
 
-  orch_name=$(get_resources "$ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP")
+  orch_name=$(get_resources "$ORCHESTRATOR_API_TAG" "$MATCH_RESOURCE_GROUP")
 
-  query_tool_name=$(get_resources "$QUERY_APP_TAG $RESOURCE_GROUP")
+  query_tool_name=$(get_resources "$QUERY_APP_TAG" "$RESOURCE_GROUP")
 
-  dp_api_name=$(get_resources "$DUP_PART_API_TAG $MATCH_RESOURCE_GROUP")
+  dp_api_name=$(get_resources "$DUP_PART_API_TAG" "$MATCH_RESOURCE_GROUP")
 
   orch_identity=$(\
     az webapp identity show \

--- a/iac/configure-easy-auth.bash
+++ b/iac/configure-easy-auth.bash
@@ -9,7 +9,8 @@
 #
 # usage: create-resources.bash <azure-env>
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 # App Service Authentication is done at the Azure tenant level
 TENANT_ID=$(az account show --query homeTenantId -o tsv)
@@ -34,6 +35,7 @@ app_role_assignment () {
 app_role_manifest () {
   role=$1
 
+  # shellcheck disable=SC2089
   json="\
   [{
     \"allowedMemberTypes\": [
@@ -46,7 +48,7 @@ app_role_manifest () {
     \"origin\": \"Application\",
     \"value\": \"${role}\"
   }]"
-  echo $json
+  echo "$json"
 }
 
 # Create an Active Directory app registration with an application
@@ -58,8 +60,8 @@ create_aad_app_reg () {
 
   app_uri=$(\
     az functionapp show \
-    --resource-group $resource_group \
-    --name $app \
+    --resource-group "$resource_group" \
+    --name "$app" \
     --query defaultHostName \
     --output tsv)
   app_uri="https://${app_uri}"
@@ -68,32 +70,32 @@ create_aad_app_reg () {
   # an error if the app already exists and the app role is enabled
   exists=$(\
     az ad app list \
-    --display-name ${app} \
+    --display-name "${app}" \
     --filter "displayName eq '${app}'" \
     --query "[0].appRoles[?value == '${role}'].value" \
     --output tsv)
   if [ -z "$exists" ]; then
-    app_role=$(app_role_manifest $role)
+    app_role=$(app_role_manifest "$role")
     app_id=$(\
       az ad app create \
-        --display-name $app \
+        --display-name "$app" \
         --app-roles "${app_role}" \
         --available-to-other-tenants false \
-        --homepage $app_uri \
-        --identifier-uris $app_uri \
+        --homepage "$app_uri" \
+        --identifier-uris "$app_uri" \
         --reply-urls "${app_uri}/.auth/login/aad/callback" \
         --query objectId \
         --output tsv)
   else
     app_id=$(\
       az ad app list \
-        --display-name ${app} \
+        --display-name "${app}" \
         --filter "displayName eq '${app}'" \
         --query "[0].objectId" \
         --output tsv)
   fi
 
-  echo $app_id
+  echo "$app_id"
 }
 
 # Create a service principal associated with a given AAD
@@ -106,19 +108,19 @@ create_aad_app_sp () {
   # `az ad sp create` throws error if service principal exits
   sp=$(\
     az ad sp list \
-    --display-name $app \
+    --display-name "$app" \
     --filter "${filter}" \
     --query "[0].objectId" \
     --output tsv)
   if [ -z "$sp" ]; then
     sp=$(\
       az ad sp create \
-        --id $aad_app_id \
+        --id "$aad_app_id" \
         --query objectId \
         --output tsv)
   fi
 
-  echo $sp
+  echo "$sp"
 }
 
 # Assign an application role to a service principal (generally in
@@ -130,7 +132,7 @@ assign_app_role () {
   role=$3
   role_id=$(\
     az ad sp show \
-    --id $resource_id \
+    --id "$resource_id" \
     --query "appRoles[?value == '${role}'].id" \
     --output tsv)
 
@@ -146,8 +148,8 @@ assign_app_role () {
     --output tsv)
 
   if [ -z "$exists" ]; then
-    role_json=`app_role_assignment $principal_id $resource_id $role_id`
-    echo $role_json
+    role_json=$(app_role_assignment "$principal_id" "$resource_id" "$role_id")
+    echo "$role_json"
     az rest \
     --method POST \
     --uri "https://graph${domain}/v1.0/servicePrincipals/${resource_id}/appRoleAssignedTo" \
@@ -166,15 +168,15 @@ enable_easy_auth () {
 
   app_uri=$(\
     az functionapp show \
-    --resource-group $resource_group \
-    --name $app \
+    --resource-group "$resource_group" \
+    --name "$app" \
     --query defaultHostName \
     --output tsv)
   app_uri="https://${app_uri}"
 
   app_aad_client=$(\
     az ad app list \
-      --display-name ${app} \
+      --display-name "${app}" \
       --filter "displayName eq '${app}'" \
       --query "[0].objectId" \
       --output tsv)
@@ -182,24 +184,24 @@ enable_easy_auth () {
   sp_filter="displayName eq '${app}' and servicePrincipalType eq 'Application'"
   app_aad_sp=$(\
     az ad sp list \
-      --display-name $app \
+      --display-name "$app" \
       --filter "${sp_filter}" \
       --query "[0].objectId" \
       --output tsv)
 
   echo "Configuring Easy Auth settings for ${app}"
   az webapp auth update \
-    --resource-group $resource_group \
-    --name $app \
-    --aad-allowed-token-audiences $app_uri \
-    --aad-client-id $app_aad_client \
+    --resource-group "$resource_group" \
+    --name "$app" \
+    --aad-allowed-token-audiences "$app_uri" \
+    --aad-client-id "$app_aad_client" \
     --aad-token-issuer-url "https://sts.windows.net/${TENANT_ID}/" \
     --enabled true \
     --action LoginWithAzureActiveDirectory
 
   # Any client that attemps authentication must be assigned a role
   az ad sp update \
-    --id $app_aad_sp \
+    --id "$app_aad_sp" \
     --set "appRoleAssignmentRequired=true"
 }
 
@@ -225,29 +227,29 @@ configure_easy_auth_pair () {
   local client_identity=$4
 
   local func_app_reg_id
-  func_app_reg_id=$(create_aad_app_reg $func $role $group)
+  func_app_reg_id=$(create_aad_app_reg "$func" "$role" "$group")
 
   # Wait a bit to prevent "service principal being created must in the local tenant" error
   sleep 60
   local func_app_sp
-  func_app_sp=$(create_aad_app_sp $func $func_app_reg_id)
+  func_app_sp=$(create_aad_app_sp "$func" "$func_app_reg_id")
 
   # Activate App Service Authentication for the Function App API
   # Wait a bit so we can find the SP in AAD when we search for it
   sleep 60
-  enable_easy_auth $func $group
+  enable_easy_auth "$func" "$group"
 
   # Give the client component access to the Function App API
   # Wait a bit to prevent ResourceNotFoundError
   sleep 60
-  assign_app_role $func_app_sp $client_identity $role
+  assign_app_role "$func_app_sp" "$client_identity" "$role"
 }
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   # Name of application roles authorized to call match APIs
@@ -255,32 +257,32 @@ main () {
   ORCH_API_APP_ROLE='OrchestratorApi.Query'
 
   match_func_names=($(\
-    get_resources $PER_STATE_MATCH_API_TAG $RESOURCE_GROUP))
+    get_resources "$PER_STATE_MATCH_API_TAG" "$RESOURCE_GROUP"))
 
-  orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
+  orch_name=$(get_resources "$ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP")
 
-  query_tool_name=$(get_resources $QUERY_APP_TAG $RESOURCE_GROUP)
+  query_tool_name=$(get_resources "$QUERY_APP_TAG $RESOURCE_GROUP")
 
-  dp_api_name=$(get_resources $DUP_PART_API_TAG $MATCH_RESOURCE_GROUP)
+  dp_api_name=$(get_resources "$DUP_PART_API_TAG $MATCH_RESOURCE_GROUP")
 
   orch_identity=$(\
     az webapp identity show \
-      --name $orch_name \
-      --resource-group $MATCH_RESOURCE_GROUP \
+      --name "$orch_name" \
+      --resource-group "$MATCH_RESOURCE_GROUP" \
       --query principalId \
       --output tsv)
 
   query_tool_identity=$(\
     az webapp identity show \
-      --name $query_tool_name \
-      --resource-group $RESOURCE_GROUP \
+      --name "$query_tool_name" \
+      --resource-group "$RESOURCE_GROUP" \
       --query principalId \
       --output tsv)
 
   dp_api_identity=$(\
     az apim show \
-      --name $dp_api_name \
-      --resource-group $MATCH_RESOURCE_GROUP \
+      --name "$dp_api_name" \
+      --resource-group "$MATCH_RESOURCE_GROUP" \
       --query identity.principalId \
       --output tsv)
 
@@ -288,22 +290,22 @@ main () {
   do
     echo "Configure Easy Auth for PerStateMatchApi:${func} and OrchestratorApi"
     configure_easy_auth_pair \
-      $func $RESOURCE_GROUP \
-      $STATE_API_APP_ROLE \
-      $orch_identity
+      "$func" "$RESOURCE_GROUP" \
+      "$STATE_API_APP_ROLE" \
+      "$orch_identity"
   done
 
   echo "Configure Easy Auth for OrchestratorApi and QueryApp"
   configure_easy_auth_pair \
-    $orch_name $MATCH_RESOURCE_GROUP \
-    $ORCH_API_APP_ROLE \
-    $query_tool_identity
+    "$orch_name" "$MATCH_RESOURCE_GROUP" \
+    "$ORCH_API_APP_ROLE" \
+    "$query_tool_identity"
 
   echo "Configure Easy Auth for OrchestratorApi and DupPartApi"
   configure_easy_auth_pair \
-    $orch_name $MATCH_RESOURCE_GROUP \
-    $ORCH_API_APP_ROLE \
-    $dp_api_identity
+    "$orch_name" "$MATCH_RESOURCE_GROUP" \
+    "$ORCH_API_APP_ROLE" \
+    "$dp_api_identity"
 
   script_completed
 }

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -106,8 +106,9 @@ main () {
 
   upload_policy_path=$(dirname "$0")/apim-bulkupload-policy.xml
   upload_policy_xml=$(< "$upload_policy_path")
-  # shellcheck disable=SC2178
-  state_abbrs="$(get_state_abbrs)"
+
+  local state_abbrs
+  state_abbrs=$(get_state_abbrs)
 
   apim_identity=$(\
     az deployment group create \
@@ -125,7 +126,7 @@ main () {
         publisherName="$PUBLISHER_NAME" \
         orchestratorUrl="$orch_api_url" \
         dupPartPolicyXml="$duppart_policy_xml" \
-        uploadStates="${state_abbrs[*]}" \
+        uploadStates="$state_abbrs" \
         uploadPolicyXml="$upload_policy_xml" \
         location="$LOCATION" \
         resourceTags="$RESOURCE_TAGS")

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -15,7 +15,8 @@
 #
 # usage: create-apim.bash <azure-env> <admin-email>
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 clean_defaults () {
   local group=$1
@@ -24,8 +25,8 @@ clean_defaults () {
   # Delete "echo API" example API
   az apim api delete \
     --api-id echo-api \
-    -g ${group} \
-    -n ${apim} \
+    -g "${group}" \
+    -n "${apim}" \
     -y
 
   # Delete default "Starter" and "Unlimited" products and their associated
@@ -33,15 +34,15 @@ clean_defaults () {
   az apim product delete \
     --product-id starter \
     --delete-subscriptions true \
-    -g ${group} \
-    -n ${apim} \
+    -g "${group}" \
+    -n "${apim}" \
     -y
 
   az apim product delete \
     --product-id unlimited \
     --delete-subscriptions true \
-    -g ${group} \
-    -n ${apim} \
+    -g "${group}" \
+    -n "${apim}" \
     -y
 }
 
@@ -51,11 +52,11 @@ generate_policy () {
   local uri=$2
   local APP_URI_PLACEHOLDER="{applicationUri}"
   local xml
-  xml=$(< $path)
+  xml=$(< "$path")
 
   xml=${xml/$APP_URI_PLACEHOLDER/$uri}
 
-  echo $xml
+  echo "$xml"
 }
 
 grant_blob () {
@@ -65,14 +66,14 @@ grant_blob () {
 
   az role assignment create \
     --role "Storage Blob Data Contributor" \
-    --assignee $assignee \
+    --assignee "$assignee" \
     --scope "${DEFAULT_PROVIDERS}/Microsoft.Storage/storageAccounts/${storage_account}"
 }
 
 get_state_abbrs () {
   local state_abbrs=()
 
-  while IFS=, read -r abbr name ; do
+  while IFS=, read -r abbr _; do
     abbr=$(echo "$abbr" | tr '[:upper:]' '[:lower:]')
     state_abbrs+=("${abbr}")
   done < states.csv
@@ -83,60 +84,61 @@ get_state_abbrs () {
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   APIM_NAME=${PREFIX}-apim-duppartapi-${ENV}
   PUBLISHER_NAME='API Administrator'
   publisher_email=$2
 
-  orch_name=$(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP)
+  orch_name=$(get_resources "$ORCHESTRATOR_API_TAG" "$MATCH_RESOURCE_GROUP")
   orch_base_url=$(\
     az functionapp show \
-      -g $MATCH_RESOURCE_GROUP \
-      -n $orch_name \
+      -g "$MATCH_RESOURCE_GROUP" \
+      -n "$orch_name" \
       --query defaultHostName \
       --output tsv)
   orch_base_url="https://${orch_base_url}"
   orch_api_url="${orch_base_url}/api/v1"
 
-  duppart_policy_xml=$(generate_policy apim-duppart-policy.xml ${orch_base_url})
+  duppart_policy_xml=$(generate_policy apim-duppart-policy.xml "${orch_base_url}")
 
   upload_policy_path=$(dirname "$0")/apim-bulkupload-policy.xml
-  upload_policy_xml=$(< $upload_policy_path)
-  state_abbrs=$(get_state_abbrs)
+  upload_policy_xml=$(< "$upload_policy_path")
+  # shellcheck disable=SC2178
+  state_abbrs="$(get_state_abbrs)"
 
   apim_identity=$(\
     az deployment group create \
       --name apim-dev \
-      --resource-group $MATCH_RESOURCE_GROUP \
+      --resource-group "$MATCH_RESOURCE_GROUP" \
       --template-file ./arm-templates/apim.json \
       --query properties.outputs.identity.value.principalId \
       --output tsv \
       --parameters \
-        env=$ENV \
-        prefix=$PREFIX \
+        env="$ENV" \
+        prefix="$PREFIX" \
         cloudName="$CLOUD_NAME" \
-        apiName=$APIM_NAME \
-        publisherEmail=$publisher_email \
+        apiName="$APIM_NAME" \
+        publisherEmail="$publisher_email" \
         publisherName="$PUBLISHER_NAME" \
-        orchestratorUrl=$orch_api_url \
+        orchestratorUrl="$orch_api_url" \
         dupPartPolicyXml="$duppart_policy_xml" \
-        uploadStates="$state_abbrs" \
+        uploadStates="${state_abbrs[*]}" \
         uploadPolicyXml="$upload_policy_xml" \
-        location=$LOCATION \
+        location="$LOCATION" \
         resourceTags="$RESOURCE_TAGS")
 
-  upload_accounts=($(get_resources $PER_STATE_STORAGE_TAG $RESOURCE_GROUP))
+  upload_accounts=($(get_resources "$PER_STATE_STORAGE_TAG" "$RESOURCE_GROUP"))
   for account in "${upload_accounts[@]}"
   do
-    grant_blob $apim_identity $account
+    grant_blob "$apim_identity" "$account"
   done
 
   # Clear out default example resources
   # See: https://stackoverflow.com/a/64297708
-  clean_defaults $MATCH_RESOURCE_GROUP $APIM_NAME
+  clean_defaults "$MATCH_RESOURCE_GROUP" "$APIM_NAME"
 }
 
 main "$@"

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -11,7 +11,8 @@
 #
 # usage: create-metrics-resources.bash <azure-env>
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 set_constants () {
   DB_SERVER_NAME=$PREFIX-psql-core-$ENV
@@ -19,7 +20,7 @@ set_constants () {
   DB_NAME=metrics
   DB_TABLE_NAME=participant_uploads
   # Needed for both function apps
-  DB_CONN_STR=`pg_connection_string $DB_SERVER_NAME $DB_NAME $DB_ADMIN_NAME`
+  DB_CONN_STR=$(pg_connection_string "$DB_SERVER_NAME" "$DB_NAME" "$DB_ADMIN_NAME")
   # Name of Key Vault
   VAULT_NAME_KEY=KeyVaultName
   VAULT_NAME=$PREFIX-kv-metrics-$ENV
@@ -41,14 +42,15 @@ set_constants () {
   API_APP_NAME=$PREFIX-func-$METRICS_API_APP_ID-$ENV
   API_APP_STORAGE_NAME=${PREFIX}st${METRICS_API_APP_ID}${ENV}
 
-  PRIVATE_DNS_ZONE=`private_dns_zone`
+  PRIVATE_DNS_ZONE=$(private_dns_zone)
 }
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   set_constants
@@ -56,58 +58,60 @@ main () {
   # Create new Key Vault for this resource group
   echo "Creating Key Vault"
   az deployment group create \
-    --name $VAULT_NAME \
-    --resource-group $METRICS_RESOURCE_GROUP \
+    --name "$VAULT_NAME" \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
     --template-file ./arm-templates/key-vault.json \
     --parameters \
-      name=$VAULT_NAME \
-      location=$LOCATION \
-      objectId=$CURRENT_USER_OBJID \
+      name="$VAULT_NAME" \
+      location="$LOCATION" \
+      objectId="$CURRENT_USER_OBJID" \
       resourceTags="$RESOURCE_TAGS"
 
   # Set PG Secret in key vault
   # By default, Azure CLI will print the password set in Key Vault; instead
   # just extract and print the secret id from the JSON response.
   echo "Setting key in vault"
-  export PG_SECRET=`random_password`
+  PG_SECRET=$(random_password)
+  export PG_SECRET
   printenv PG_SECRET | tr -d '\n' | az keyvault secret set \
-    --vault-name $VAULT_NAME \
-    --name $PG_SECRET_NAME \
+    --vault-name "$VAULT_NAME" \
+    --name "$PG_SECRET_NAME" \
     --file /dev/stdin \
     --query id
 
   echo "Creating Metrics database server"
   az deployment group create \
     --name metrics \
-    --resource-group $METRICS_RESOURCE_GROUP \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
     --template-file ./arm-templates/database-metrics.json \
     --parameters \
       administratorLogin=$DB_ADMIN_NAME \
-      serverName=$DB_SERVER_NAME \
-      secretName=$PG_SECRET_NAME \
-      vaultName=$VAULT_NAME \
-      vnetName=$VNET_NAME \
-      subnetName=$DB_2_SUBNET_NAME \
-      privateEndpointName=$CORE_DB_PRIVATE_ENDPOINT_NAME \
-      privateDnsZoneName=$PRIVATE_DNS_ZONE \
+      serverName="$DB_SERVER_NAME" \
+      secretName="$PG_SECRET_NAME" \
+      vaultName="$VAULT_NAME" \
+      vnetName="$VNET_NAME" \
+      subnetName="$DB_2_SUBNET_NAME" \
+      privateEndpointName="$CORE_DB_PRIVATE_ENDPOINT_NAME" \
+      privateDnsZoneName="$PRIVATE_DNS_ZONE" \
       resourceTags="$RESOURCE_TAGS"
 
   ### Database stuff
   # Create database within db server (command is idempotent)
-  az postgres db create --name $DB_NAME --resource-group $METRICS_RESOURCE_GROUP --server-name $DB_SERVER_NAME
+  az postgres db create --name $DB_NAME --resource-group "$METRICS_RESOURCE_GROUP" --server-name "$DB_SERVER_NAME"
 
   ## Connect to the db server
   # For some reason PG threw an Invalid Username error when trying to set PGUSER here, so it's specified in the prompt instead.
   # export PGUSER=${DB_ADMIN_NAME}@${DB_SERVER_NAME}
-  export PGHOST=`az resource show \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --name $DB_SERVER_NAME \
+  PGHOST=$(az resource show \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --name "$DB_SERVER_NAME" \
     --resource-type "Microsoft.DbForPostgreSQL/servers" \
-    --query properties.fullyQualifiedDomainName -o tsv`
+    --query properties.fullyQualifiedDomainName -o tsv)
+  export PGHOST
   export PGPASSWORD=$PG_SECRET
 
   echo "Insert db table"
-  psql -U $DB_ADMIN_NAME@$DB_SERVER_NAME -p 5432 -d $DB_NAME -w -v ON_ERROR_STOP=1 -X -q - <<EOF
+  psql -U $DB_ADMIN_NAME@"$DB_SERVER_NAME" -p 5432 -d $DB_NAME -w -v ON_ERROR_STOP=1 -X -q - <<EOF
       CREATE TABLE IF NOT EXISTS $DB_TABLE_NAME (
           id serial PRIMARY KEY,
           state VARCHAR(50) NOT NULL,
@@ -121,30 +125,30 @@ EOF
   # Need a storage account to publish function app to:
   echo "Creating storage account for $COLLECT_APP_NAME"
   az storage account create \
-    --name $COLLECT_STORAGE_NAME \
-    --location $LOCATION \
-    --resource-group $METRICS_RESOURCE_GROUP \
+    --name "$COLLECT_STORAGE_NAME" \
+    --location "$LOCATION" \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
     --sku Standard_LRS \
     --tags Project=$PROJECT_TAG
 
   # Create the function app in Azure
   echo "Creating function app $COLLECT_APP_NAME in Azure"
   az functionapp create \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --plan $APP_SERVICE_PLAN_FUNC_NAME \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --plan "$APP_SERVICE_PLAN_FUNC_NAME" \
     --runtime dotnet \
     --functions-version 3 \
-    --name $COLLECT_APP_NAME \
-    --storage-account $COLLECT_STORAGE_NAME \
+    --name "$COLLECT_APP_NAME" \
+    --storage-account "$COLLECT_STORAGE_NAME" \
     --tags Project=$PROJECT_TAG
 
   # Integrate function app into Virtual Network
   echo "Integrating $COLLECT_APP_NAME into virtual network"
   az functionapp vnet-integration add \
-    --name $COLLECT_APP_NAME \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --subnet $FUNC_SUBNET_NAME \
-    --vnet $VNET_NAME
+    --name "$COLLECT_APP_NAME" \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --subnet "$FUNC_SUBNET_NAME" \
+    --vnet "$VNET_NAME"
 
   # Waiting before publishing the app, since publishing immediately after creation returns an   App Not Found error
   # Waiting was the best solution I could find. More info in these GH issues:
@@ -155,8 +159,8 @@ EOF
 
   echo "configure settings"
   az functionapp config appsettings set \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --name $COLLECT_APP_NAME \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --name "$COLLECT_APP_NAME" \
     --settings \
       $DB_CONN_STR_KEY="$DB_CONN_STR" \
       $VAULT_NAME_KEY="$VAULT_NAME" \
@@ -164,21 +168,21 @@ EOF
     --output none
 
   # Connect creds from function app to key vault so app can connect to db
-  principalId=`az functionapp identity assign \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --name $COLLECT_APP_NAME \
+  principalId=$(az functionapp identity assign \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --name "$COLLECT_APP_NAME" \
     --query principalId \
-    --output tsv`
+    --output tsv)
 
   az keyvault set-policy \
-    --name $VAULT_NAME \
-    --object-id $principalId \
+    --name "$VAULT_NAME" \
+    --object-id "$principalId" \
     --secret-permissions get list
 
   # publish the function app
   echo "Publishing function app $COLLECT_APP_NAME"
   pushd ../metrics/src/Piipan.Metrics/$COLLECT_APP_FILEPATH
-    func azure functionapp publish $COLLECT_APP_NAME --dotnet
+    func azure functionapp publish "$COLLECT_APP_NAME" --dotnet
   popd
 
   # Subscribe each dynamically created event blob topic to this function
@@ -187,15 +191,15 @@ EOF
 
   while IFS=, read -r abbr name ; do
       echo "Subscribing to ${name} blob events"
-      abbr=`echo "$abbr" | tr '[:upper:]' '[:lower:]'`
+      abbr=$(echo "$abbr" | tr '[:upper:]' '[:lower:]')
       sub_name=evgs-${abbr}metricsupload-${ENV}
-      topic_name=`state_event_grid_topic_name $abbr $ENV`
+      topic_name=$(state_event_grid_topic_name "$abbr" "$ENV")
 
       az eventgrid system-topic event-subscription create \
-          --name $sub_name \
-          --resource-group $SUBS_RESOURCE_GROUP \
-          --system-topic-name $topic_name \
-          --endpoint ${METRICS_PROVIDERS}/Microsoft.Web/sites/${COLLECT_APP_NAME}/functions/${COLLECT_FUNC} \
+          --name "$sub_name" \
+          --resource-group "$SUBS_RESOURCE_GROUP" \
+          --system-topic-name "$topic_name" \
+          --endpoint "${METRICS_PROVIDERS}/Microsoft.Web/sites/${COLLECT_APP_NAME}/functions/${COLLECT_FUNC}" \
           --endpoint-type azurefunction \
           --included-event-types Microsoft.Storage.BlobCreated \
           --subject-begins-with /blobServices/default/containers/upload/blobs/
@@ -207,34 +211,34 @@ EOF
   # Need a storage account to publish function app to:
   echo "Creating storage account for metrics api"
   az storage account create \
-    --name $API_APP_STORAGE_NAME \
-    --location $LOCATION \
-    --resource-group $METRICS_RESOURCE_GROUP \
+    --name "$API_APP_STORAGE_NAME" \
+    --location "$LOCATION" \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
     --sku Standard_LRS \
     --tags Project=$PROJECT_TAG
 
   # Create the function app in Azure
   echo "Creating function app $API_APP_NAME"
   az functionapp create \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --plan $APP_SERVICE_PLAN_FUNC_NAME \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --plan "$APP_SERVICE_PLAN_FUNC_NAME" \
     --runtime dotnet \
     --functions-version 3 \
-    --name $API_APP_NAME \
-    --storage-account $API_APP_STORAGE_NAME \
+    --name "$API_APP_NAME" \
+    --storage-account "$API_APP_STORAGE_NAME" \
     --tags Project=$PROJECT_TAG
 
   # Integrate function app into Virtual Network
   echo "Integrating $API_APP_NAME into virtual network"
   az functionapp vnet-integration add \
-    --name $API_APP_NAME \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --subnet $FUNC_SUBNET_NAME \
-    --vnet $VNET_NAME
+    --name "$API_APP_NAME" \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --subnet "$FUNC_SUBNET_NAME" \
+    --vnet "$VNET_NAME"
 
   az functionapp config appsettings set \
-      --resource-group $METRICS_RESOURCE_GROUP \
-      --name $API_APP_NAME \
+      --resource-group "$METRICS_RESOURCE_GROUP" \
+      --name "$API_APP_NAME" \
       --settings \
         $DB_CONN_STR_KEY="$DB_CONN_STR" \
         $VAULT_NAME_KEY="$VAULT_NAME" \
@@ -242,15 +246,15 @@ EOF
       --output none
 
   # Connect creds from function app to key vault so app can connect to db
-  principalId=`az functionapp identity assign \
-    --resource-group $METRICS_RESOURCE_GROUP \
-    --name $API_APP_NAME \
+  principalId=$(az functionapp identity assign \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --name "$API_APP_NAME" \
     --query principalId \
-    --output tsv`
+    --output tsv)
 
   az keyvault set-policy \
-    --name $VAULT_NAME \
-    --object-id $principalId \
+    --name "$VAULT_NAME" \
+    --object-id "$principalId" \
     --secret-permissions get list
 
   echo "Waiting to publish function app"
@@ -259,7 +263,7 @@ EOF
   # publish metrics function app
   echo "Publishing function app $API_APP_NAME"
   pushd ../metrics/src/Piipan.Metrics/$API_APP_FILEPATH
-    func azure functionapp publish $API_APP_NAME --dotnet
+    func azure functionapp publish "$API_APP_NAME" --dotnet
   popd
 
   ## Dashboard stuff
@@ -268,24 +272,24 @@ EOF
   suffix=$(web_app_host_suffix)
   dashboard_host=${DASHBOARD_APP_NAME}${suffix}
   ./add-front-door-to-app.bash \
-    $azure_env \
-    $RESOURCE_GROUP \
-    $DASHBOARD_FRONTDOOR_NAME \
-    $DASHBOARD_WAF_NAME \
-    $dashboard_host
+    "$azure_env" \
+    "$RESOURCE_GROUP" \
+    "$DASHBOARD_FRONTDOOR_NAME" \
+    "$DASHBOARD_WAF_NAME" \
+    "$dashboard_host"
 
   front_door_id=$(\
   az network front-door show \
-    --name $DASHBOARD_FRONTDOOR_NAME \
-    --resource-group $RESOURCE_GROUP \
+    --name "$DASHBOARD_FRONTDOOR_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
     --query frontdoorId \
     --output tsv)
   echo "Front Door iD: ${front_door_id}"
 
   metrics_api_uri=$(\
     az functionapp function show \
-      -g $METRICS_RESOURCE_GROUP \
-      -n $API_APP_NAME \
+      -g "$METRICS_RESOURCE_GROUP" \
+      -n "$API_APP_NAME" \
       --function-name GetParticipantUploads \
       --query invokeUrlTemplate \
       --output tsv)
@@ -293,22 +297,22 @@ EOF
   # Create App Service resources for dashboard app
   echo "Creating App Service resources for dashboard app"
   az deployment group create \
-    --name $DASHBOARD_APP_NAME \
-    --resource-group $RESOURCE_GROUP \
+    --name "$DASHBOARD_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
     --template-file ./arm-templates/dashboard-app.json \
     --parameters \
-      location=$LOCATION \
+      location="$LOCATION" \
       resourceTags="$RESOURCE_TAGS" \
-      appName=$DASHBOARD_APP_NAME \
-      servicePlan=$APP_SERVICE_PLAN \
-      frontDoorId=$front_door_id \
-      metricsApiUri=$metrics_api_uri
+      appName="$DASHBOARD_APP_NAME" \
+      servicePlan="$APP_SERVICE_PLAN" \
+      frontDoorId="$front_door_id" \
+      metricsApiUri="$metrics_api_uri"
 
   echo "Secure database connection"
   ./remove-external-network.bash \
-    $azure_env \
-    $METRICS_RESOURCE_GROUP \
-    $DB_SERVER_NAME
+    "$azure_env" \
+    "$METRICS_RESOURCE_GROUP" \
+    "$DB_SERVER_NAME"
 
   script_completed
 }

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -111,7 +111,7 @@ main () {
   export PGPASSWORD=$PG_SECRET
 
   echo "Insert db table"
-  psql -U $DB_ADMIN_NAME@"$DB_SERVER_NAME" -p 5432 -d $DB_NAME -w -v ON_ERROR_STOP=1 -X -q - <<EOF
+  psql -U "$DB_ADMIN_NAME@$DB_SERVER_NAME" -p 5432 -d "$DB_NAME" -w -v ON_ERROR_STOP=1 -X -q - <<EOF
       CREATE TABLE IF NOT EXISTS $DB_TABLE_NAME (
           id serial PRIMARY KEY,
           state VARCHAR(50) NOT NULL,

--- a/iac/create-resource-groups.bash
+++ b/iac/create-resource-groups.bash
@@ -8,24 +8,25 @@
 #
 # usage: create-resource-groups.bash <azure-env>
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   # Any changes to the set of resource groups below should also
   # be made to create-service-principal.bash
   echo "Creating $RESOURCE_GROUP group"
-  az group create --name $RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+  az group create --name "$RESOURCE_GROUP" -l "$LOCATION" --tags Project="$PROJECT_TAG"
   echo "Creating match APIs resource group"
-  az group create --name $MATCH_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+  az group create --name "$MATCH_RESOURCE_GROUP" -l "$LOCATION" --tags Project="$PROJECT_TAG"
   # Create Metrics resource group
   echo "Creating $METRICS_RESOURCE_GROUP group"
-  az group create --name $METRICS_RESOURCE_GROUP -l $LOCATION --tags Project=$PROJECT_TAG
+  az group create --name "$METRICS_RESOURCE_GROUP" -l "$LOCATION" --tags Project="$PROJECT_TAG"
 
   script_completed
 }

--- a/iac/create-service-principal.bash
+++ b/iac/create-service-principal.bash
@@ -15,13 +15,16 @@
 #
 # usage: create-service-principal.bash <azure-env> <service-principal-name> [<output-format>]
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   # Required service principal name
@@ -31,12 +34,12 @@ main () {
   output=${3:-json}
 
   # Array of groups to which the service principal will be scoped
-  RESOURCE_GROUPS=($RESOURCE_GROUP $METRICS_RESOURCE_GROUP $MATCH_RESOURCE_GROUP)
+  RESOURCE_GROUPS=("$RESOURCE_GROUP" "$METRICS_RESOURCE_GROUP" "$MATCH_RESOURCE_GROUP")
 
   # Create space-separated list of resource group IDs
   for g in "${RESOURCE_GROUPS[@]}"
   do
-    scope=`az group show -n $g --query id --output tsv`
+    scope=$(az group show -n "$g" --query id --output tsv)
     SCOPES="${SCOPES:+$SCOPES }$scope"
   done
 
@@ -45,11 +48,11 @@ main () {
   # it, creating new credentials and attempting to add the appropriate scopes.
   echo "Creating/resetting service principal $name"
   az ad sp create-for-rbac \
-    --name $name \
+    --name "$name" \
     --role Contributor \
-    --scopes $SCOPES \
+    --scopes "$SCOPES" \
     --only-show-errors \
-    --output $output
+    --output "$output"
 
   script_completed
 }

--- a/iac/create-state-storage-service-principal.bash
+++ b/iac/create-state-storage-service-principal.bash
@@ -13,14 +13,17 @@
 #
 # usage: create-service-principal.bash <azure-env> <storage-account-name>
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
   storage_acct_name=$2
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   # Required service principal name
@@ -30,16 +33,16 @@ main () {
   ROLE_ID=ba92f5b4-2d11-453d-a403-e96b0029c9fe
 
   # Get resource id of storage account
-  scope=`az resource show -g $RESOURCE_GROUP -n $storage_acct_name --resource-type "Microsoft.Storage/storageAccounts" --query id --output tsv`
+  scope=$(az resource show -g "$RESOURCE_GROUP" -n "$storage_acct_name" --resource-type "Microsoft.Storage/storageAccounts" --query id --output tsv)
 
   # If the service principal does not exist, the `create-for-rbac` command will
   # create it. If the service principal does exist, `create-for-rbac` will "patch"
   # it, creating new credentials.
   echo "Creating/resetting service principal $name"
   az ad sp create-for-rbac \
-    --name $name \
-    --role $ROLE_ID \
-    --scopes $scope
+    --name "$name" \
+    --role "$ROLE_ID" \
+    --scopes "$scope"
 
   script_completed
 }

--- a/iac/delete-resources.bash
+++ b/iac/delete-resources.bash
@@ -5,7 +5,8 @@
 #
 # usage: delete-resources.bash <azure-env>
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 purge () {
   local group=$1
@@ -13,8 +14,8 @@ purge () {
 
   # Disable info output by querying for non-existent property
   az deployment group create \
-    -g $group \
-    -f $(dirname "$0")/arm-templates/unique-string.json \
+    -g "$group" \
+    -f "$(dirname "$0")"/arm-templates/unique-string.json \
     --mode Complete \
     --query doesNotExist
 }
@@ -22,8 +23,10 @@ purge () {
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   echo "This script will delete all resources hosted on $CLOUD_NAME in ${azure_env}."
@@ -31,9 +34,9 @@ main () {
   read -p "Proceed with bulk delete? (Yes or No) " -r
   if [[ $REPLY =~ ^[yY]es$ ]]; then
 
-    purge $RESOURCE_GROUP
-    purge $MATCH_RESOURCE_GROUP
-    purge $METRICS_RESOURCE_GROUP
+    purge "$RESOURCE_GROUP"
+    purge "$MATCH_RESOURCE_GROUP"
+    purge "$METRICS_RESOURCE_GROUP"
 
   else
     exit 1

--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2034
+
 # Deployment environment for resource identifiers
 ENV=$(basename "${BASH_SOURCE%.*}")
 

--- a/iac/env/tts/test.bash
+++ b/iac/env/tts/test.bash
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2034
+
 # Deployment environment for resource identifiers
 ENV=$(basename "${BASH_SOURCE%.*}")
 

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2034
+
 ### Constants
 # It's helpful to tag all piipan-related resources
 PROJECT_TAG=piipan
@@ -13,10 +15,10 @@ QUERY_APP_TAG="SysType=QueryApp"
 DUP_PART_API_TAG="SysType=DupPartApi"
 
 # Identity object ID for the Azure environment account
-CURRENT_USER_OBJID=`az ad signed-in-user show --query objectId --output tsv`
+CURRENT_USER_OBJID=$(az ad signed-in-user show --query objectId --output tsv)
 
 # The default Azure subscription
-SUBSCRIPTION_ID=`az account show --query id -o tsv`
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 
 # Name of App Service Plan, used by both query tool and dashboard
 APP_SERVICE_PLAN=piipan-app-plan
@@ -69,13 +71,13 @@ pg_connection_string () {
   user=$3
   user=${user//-/_}
 
-  base=`az postgres show-connection-string \
-    --server-name $server \
-    --database-name $db \
-    --admin-user $user \
+  base=$(az postgres show-connection-string \
+    --server-name "$server" \
+    --database-name "$db" \
+    --admin-user "$user" \
     --admin-password "$PASSWORD_PLACEHOLDER" \
     --query connectionStrings.\"ado.net\" \
-    -o tsv`
+    -o tsv)
 
   # See:
   # https://github.com/Azure/azure-cli-extensions/issues/3143
@@ -108,17 +110,17 @@ get_resources () {
   local res
   res=$(\
     az resource list \
-      --tag $sys_type \
+      --tag "$sys_type" \
       --query "[? resourceGroup == '${group}' ].name" \
       -o tsv)
 
-  local as_array=($res)
+  local as_array=("$res")
   if [[ ${#as_array[@]} -eq 0 ]]; then
     echo "error: no resources found with $sys_type in $group" 1>&2
     return 1
   fi
 
-  echo $res
+  echo "$res"
 }
 
 # hard-coded switches between commerical and government Azure environments

--- a/iac/install-extensions.bash
+++ b/iac/install-extensions.bash
@@ -1,15 +1,16 @@
 #!/bin/bash
 #
 # Installs Azure CLI extensions required for create-resources.bash.
-# 
+#
 # usage: install-extensions.bash
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 # Array of extension names
 declare -a extensions=("db-up" "front-door")
 
-for name in ${extensions[@]}; do
+for name in "${extensions[@]}"; do
   echo "Installing '$name'..."
   az extension add --name "$name"
 done

--- a/iac/remove-external-network.bash
+++ b/iac/remove-external-network.bash
@@ -11,36 +11,37 @@
 # Usage:
 # ./iac/remove-external-network.bash tts/dev rg-core-dev fns-db-participant-records-dev
 
-source $(dirname "$0")/../tools/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
 
 main () {
   azure_env=$1
-  source $(dirname "$0")/env/${azure_env}.bash
-  source $(dirname "$0")/iac-common.bash
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  source "$(dirname "$0")"/iac-common.bash
   verify_cloud
 
   resource_group=$2
   server_name=$3
 
 	echo "Collect all firewall rules on database"
-	ids=`az postgres server firewall-rule list \
-		--resource-group $resource_group \
-		--server-name $server_name \
+	ids=$(az postgres server firewall-rule list \
+		--resource-group "$resource_group" \
+		--server-name "$server_name" \
 		--query "[].id" \
-		--output tsv`
+		--output tsv)
 
 	len=${#ids}
-	if [ $len -gt 1 ]; then
+	if [ "$len" -gt 1 ]; then
 		echo "Remove all firewall rules from database"
 		az postgres server firewall-rule delete \
 			--yes \
-			--ids $ids
+			--ids "$ids"
 	fi
 
 	echo "Deny public access to database"
 	az postgres server update \
-		--name $server_name \
-		--resource-group $resource_group \
+		--name "$server_name" \
+		--resource-group "$resource_group" \
 		--public-network-access Disabled
 
   script_completed

--- a/match/build.bash
+++ b/match/build.bash
@@ -4,34 +4,38 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 # See build-common.bash for usage details
 
-source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/../tools/build-common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+# shellcheck source=./tools/build-common.bash
+source "$(dirname "$0")"/../tools/build-common.bash || exit
 
 run_deploy () {
   azure_env=$1
-  source $(dirname "$0")/../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../iac/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
 
-  match_function_apps=($(get_resources $PER_STATE_MATCH_API_TAG $RESOURCE_GROUP))
+  match_function_apps=($(get_resources $PER_STATE_MATCH_API_TAG "$RESOURCE_GROUP"))
 
   for app in "${match_function_apps[@]}"
   do
-    echo "\nPublish ${app} to Azure Environment ${azure_env}"
+    echo "Publish ${app} to Azure Environment ${azure_env}"
     pushd ./src/Piipan.Match.State
-      func azure functionapp publish $app --dotnet
+      func azure functionapp publish "$app" --dotnet
     popd
   done
 
-  orch_function_apps=($(get_resources $ORCHESTRATOR_API_TAG $MATCH_RESOURCE_GROUP))
+  orch_function_apps=($(get_resources $ORCHESTRATOR_API_TAG "$MATCH_RESOURCE_GROUP"))
 
   for app in "${orch_function_apps[@]}"
   do
-    echo "\nPublish ${app} to Azure Environment ${azure_env}"
+    echo "Publish ${app} to Azure Environment ${azure_env}"
     pushd ./src/Piipan.Match.Orchestrator
-      func azure functionapp publish $app --dotnet
+      func azure functionapp publish "$app" --dotnet
     popd
   done
 }
 
-main $@
+main "$@"

--- a/match/tools/generate-specs.bash
+++ b/match/tools/generate-specs.bash
@@ -20,10 +20,10 @@ main () {
         generated_path="${base_path}/generated/openapi.yaml"
 
         echo "Validating ${spec_path}"
-        swagger-cli validate $spec_path
+        swagger-cli validate "$spec_path"
 
         echo "Generating ${generated_path}"
-        swagger-cli bundle $spec_path -o $generated_path -t yaml
+        swagger-cli bundle "$spec_path" -o "$generated_path" -t yaml
     done
 }
 

--- a/match/tools/test-lookup-api.bash
+++ b/match/tools/test-lookup-api.bash
@@ -14,8 +14,6 @@
 
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/../../tools/common.bash || exit
-# shellcheck source=./iac/iac-common.bash
-source "$(dirname "$0")"/../../iac/iac-common.bash || exit
 
 LOOKUP_API_FUNC_NAME="lookup_ids"
 
@@ -24,6 +22,8 @@ main () {
   azure_env=$1
   # shellcheck source=./iac/env/tts/dev.bash
   source "$(dirname "$0")"/../../iac/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/../../iac/iac-common.bash
   verify_cloud
 
   lookup_id=$2
@@ -52,8 +52,7 @@ main () {
       --function-name "$LOOKUP_API_FUNC_NAME" \
       --query invokeUrlTemplate \
       -o tsv)
-  # shellcheck disable=SC2001
-  endpoint_uri=$(echo "$endpoint_uri" | sed "s/{lookupid}/$lookup_id/")
+  endpoint_uri="${endpoint_uri//\{lookupid\}/$lookup_id}"
 
   echo "Submitting request to ${endpoint_uri}"
   curl \

--- a/match/tools/test-match-api.bash
+++ b/match/tools/test-match-api.bash
@@ -15,8 +15,6 @@
 
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/../../tools/common.bash || exit
-# shellcheck source=./iac/iac-common.bash
-source "$(dirname "$0")"/../../iac/iac-common.bash || exit
 
 QUERY_API_FUNC_NAME="query"
 JSON='{
@@ -34,6 +32,8 @@ main () {
   azure_env=$1
   # shellcheck source=./iac/env/tts/dev.bash
   source "$(dirname "$0")"/../../iac/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/../../iac/iac-common.bash
   verify_cloud
 
   name=$2

--- a/match/tools/test-match-api.bash
+++ b/match/tools/test-match-api.bash
@@ -13,8 +13,10 @@
 #
 # usage: test-lookup-api.bash <azure-env> <function-name>
 
-source $(dirname "$0")/../../tools/common.bash || exit
-source $(dirname "$0")/../../iac/iac-common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../../tools/common.bash || exit
+# shellcheck source=./iac/iac-common.bash
+source "$(dirname "$0")"/../../iac/iac-common.bash || exit
 
 QUERY_API_FUNC_NAME="query"
 JSON='{
@@ -30,15 +32,16 @@ JSON='{
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/../../iac/env/${azure_env}.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/../../iac/env/"${azure_env}".bash
   verify_cloud
 
   name=$2
 
   resource_uri=$(\
     az functionapp show \
-      -g $MATCH_RESOURCE_GROUP \
-      -n $name \
+      -g "$MATCH_RESOURCE_GROUP" \
+      -n "$name" \
       --query defaultHostName \
       -o tsv)
   resource_uri="https://${resource_uri}"
@@ -46,16 +49,16 @@ main () {
   echo "Retrieving access token from ${resource_uri}"
   token=$(\
     az account get-access-token \
-      --resource ${resource_uri} \
+      --resource "${resource_uri}" \
       --query accessToken \
       -o tsv
   )
 
   endpoint_uri=$(\
     az functionapp function show \
-      -g $MATCH_RESOURCE_GROUP \
-      -n $name \
-      --function-name $QUERY_API_FUNC_NAME \
+      -g "$MATCH_RESOURCE_GROUP" \
+      -n "$name" \
+      --function-name "$QUERY_API_FUNC_NAME" \
       --query invokeUrlTemplate \
       -o tsv)
 
@@ -67,7 +70,7 @@ main () {
     --data-raw "$JSON" \
     --include
 
-  echo "\n"
+  printf "\n"
 
   script_completed
 

--- a/metrics/build.bash
+++ b/metrics/build.bash
@@ -6,8 +6,8 @@
 
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/../tools/common.bash || exit
-# shellcheck source=./iac/iac-common.bash
-source "$(dirname "$0")"/../iac/iac-common.bash || exit
+# shellcheck source=./tools/build-common.bash
+source "$(dirname "$0")"/../tools/build-common.bash || exit
 
 set_constants () {
    # TODO: make more DRY
@@ -23,8 +23,8 @@ run_deploy () {
   source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
   # shellcheck source=./iac/iac-common.bash
   source "$(dirname "$0")"/../iac/iac-common.bash
-  verify_cloud
 
+  verify_cloud
   set_constants
 
   echo "Publish ${COLLECT_APP_NAME} to Azure Environment ${azure_env}"

--- a/metrics/build.bash
+++ b/metrics/build.bash
@@ -4,8 +4,10 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 # See build-common.bash for usage details
 
-source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/../tools/build-common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+# shellcheck source=./iac/iac-common.bash
+source "$(dirname "$0")"/../iac/iac-common.bash || exit
 
 set_constants () {
    # TODO: make more DRY
@@ -17,21 +19,23 @@ set_constants () {
 
 run_deploy () {
   azure_env=$1
-  source $(dirname "$0")/../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../iac/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
 
   set_constants
 
-  echo "\nPublish ${COLLECT_APP_NAME} to Azure Environment ${azure_env}"
+  echo "Publish ${COLLECT_APP_NAME} to Azure Environment ${azure_env}"
   pushd ./src/Piipan.Metrics/Piipan.Metrics.Collect
-    func azure functionapp publish $COLLECT_APP_NAME --dotnet
+    func azure functionapp publish "$COLLECT_APP_NAME" --dotnet
   popd
 
-  echo "\nPublish ${API_APP_NAME} to Azure Environment ${azure_env}"
+  echo "Publish ${API_APP_NAME} to Azure Environment ${azure_env}"
   pushd ./src/Piipan.Metrics/Piipan.Metrics.Api
-    func azure functionapp publish $API_APP_NAME --dotnet
+    func azure functionapp publish "$API_APP_NAME" --dotnet
   popd
 }
 
-main $@
+main "$@"

--- a/query-tool/build.bash
+++ b/query-tool/build.bash
@@ -4,8 +4,10 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 # See build-common.bash for usage details
 
-source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/../tools/build-common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+# shellcheck source=./iac/iac-common.bash
+source "$(dirname "$0")"/../iac/iac-common.bash || exit
 
 set_constants () {
   QUERY_TOOL_APP_NAME=$PREFIX-app-querytool-$ENV # TODO: make this DRY
@@ -13,8 +15,10 @@ set_constants () {
 
 run_deploy () {
   azure_env=$1
-  source $(dirname "$0")/../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../iac/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
   set_constants
   echo "Publishing project"
@@ -25,9 +29,9 @@ run_deploy () {
   popd
   az webapp deployment \
     source config-zip \
-    -g $RESOURCE_GROUP \
-    -n $QUERY_TOOL_APP_NAME \
+    -g "$RESOURCE_GROUP" \
+    -n "$QUERY_TOOL_APP_NAME" \
     --src ./artifacts/dashboard.zip
 }
 
-main $@
+main "$@"

--- a/query-tool/build.bash
+++ b/query-tool/build.bash
@@ -6,8 +6,8 @@
 
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/../tools/common.bash || exit
-# shellcheck source=./iac/iac-common.bash
-source "$(dirname "$0")"/../iac/iac-common.bash || exit
+# shellcheck source=./tools/build-common.bash
+source "$(dirname "$0")"/../tools/build-common.bash || exit
 
 set_constants () {
   QUERY_TOOL_APP_NAME=$PREFIX-app-querytool-$ENV # TODO: make this DRY

--- a/shared/build.bash
+++ b/shared/build.bash
@@ -4,11 +4,13 @@
 # Relies on a solutions file (sln) in the subsystem root directory
 # See build-common.bash for usage details
 
-source $(dirname "$0")/../tools/common.bash || exit
-source $(dirname "$0")/../tools/build-common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+# shellcheck source=./iac/iac-common.bash
+source "$(dirname "$0")"/../iac/iac-common.bash || exit
 
 run_deploy () {
   echo "N/A"
 }
 
-main $@
+main "$@"

--- a/shared/build.bash
+++ b/shared/build.bash
@@ -6,8 +6,8 @@
 
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/../tools/common.bash || exit
-# shellcheck source=./iac/iac-common.bash
-source "$(dirname "$0")"/../iac/iac-common.bash || exit
+# shellcheck source=./tools/build-common.bash
+source "$(dirname "$0")"/../tools/build-common.bash || exit
 
 run_deploy () {
   echo "N/A"

--- a/tools/assign-app-role.bash
+++ b/tools/assign-app-role.bash
@@ -11,13 +11,16 @@
 #
 # usage: assign-app-role.bash <azure-env> <func-app-name> <role-name>
 
-source $(dirname "$0")/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../iac/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
 
   function=$2
@@ -26,21 +29,21 @@ main () {
   # Get function's application object
   application=$(\
     az ad app list \
-      --display-name ${function} \
+      --display-name "${function}" \
       --query "[0].appId" \
       --output tsv)
 
   # Get application role ID from application object
   role_id=$(\
     az ad app show \
-      --id ${application} \
+      --id "${application}" \
       --query "appRoles[?value == '${role}'].id" \
       --output tsv)
 
   # Get application object's service principal
   service_principal=$(\
     az ad sp list \
-      --display-name ${function} \
+      --display-name "${function}" \
       --filter "appId eq '${application}'" \
       --query [0].objectId \
       --output tsv)

--- a/tools/authorize-cli.bash
+++ b/tools/authorize-cli.bash
@@ -21,7 +21,7 @@ main () {
   # shellcheck source=./iac/env/tts/dev.bash
   source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
   # shellcheck source=./iac/iac-common.bash
-  source "$(dirname "$0")"/../iac/iac-common.bash || exit
+  source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
 
   app_uri=$2

--- a/tools/authorize-cli.bash
+++ b/tools/authorize-cli.bash
@@ -30,17 +30,17 @@ main () {
   # - https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-rest-api-use?view=azs-2008#example
   # - https://github.com/Azure/azure-cli/blob/24e0b9ef8716e16b9e38c9bb123a734a6cf550eb/src/azure-cli-core/azure/cli/core/_profile.py#L65
   CLI_ID="04b07795-8ddb-461a-bbee-02f9e1bf7b46"
-
   object_id=$(\
     az ad app show \
       --id "$app_uri" \
       --query objectId \
       -o tsv)
+  # shellcheck disable=SC2016
   permission_id=$(\
     az rest \
       -m GET \
       -u "https://graph.microsoft.com/v1.0/applications/${object_id}" \
-      --query "api.oauth2PermissionScopes[?value == $(user_impersonation)].id" \
+      --query 'api.oauth2PermissionScopes[?value == `user_impersonation`].id' \
       -o tsv)
   json="{
     \"api\": {

--- a/tools/authorize-cli.bash
+++ b/tools/authorize-cli.bash
@@ -12,13 +12,16 @@
 #
 # usage: assign-app-role.bash <azure-env> <app-uri>
 
-source $(dirname "$0")/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/common.bash || exit
 
 main () {
   # Load agency/subscription/deployment-specific settings
   azure_env=$1
-  source $(dirname "$0")/../iac/env/${azure_env}.bash
-  source $(dirname "$0")/../iac/iac-common.bash
+  # shellcheck source=./iac/env/tts/dev.bash
+  source "$(dirname "$0")"/../iac/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/../iac/iac-common.bash || exit
   verify_cloud
 
   app_uri=$2
@@ -30,14 +33,14 @@ main () {
 
   object_id=$(\
     az ad app show \
-      --id $app_uri \
+      --id "$app_uri" \
       --query objectId \
       -o tsv)
   permission_id=$(\
     az rest \
       -m GET \
       -u "https://graph.microsoft.com/v1.0/applications/${object_id}" \
-      --query 'api.oauth2PermissionScopes[?value == `user_impersonation`].id' \
+      --query "api.oauth2PermissionScopes[?value == $(user_impersonation)].id" \
       -o tsv)
   json="{
     \"api\": {

--- a/tools/build-common.bash
+++ b/tools/build-common.bash
@@ -80,6 +80,10 @@ main () {
         c )
           ci_mode='true'
           ;;
+        * )
+          echo "usage: test [-c]"
+          exit 1
+          ;;
       esac
     done
     shift $((OPTIND -1))
@@ -100,7 +104,7 @@ main () {
       echo "Example: ./build.bash deploy -e tts/dev"
       exit 1
     else
-      run_deploy $azure_env
+      run_deploy "$azure_env"
     fi
   fi
 

--- a/tools/common.bash
+++ b/tools/common.bash
@@ -9,7 +9,7 @@ set -e
 set -u
 
 # Conform more closely to POSIX standard, specifically so command substitutions
-# inherit the value of the -e option. The more targeted inherit_errexit option 
+# inherit the value of the -e option. The more targeted inherit_errexit option
 # would be preferred, but it is not available in bash 3.2, which ships with macOS.
 set -o posix
 
@@ -19,7 +19,7 @@ set -o pipefail
 # Inherit trap on ERR in shell functions, command substitutions, etc.
 set -o errtrace
 
-_script=$(basename $0)
+_script=$(basename "$0")
 
 _err_report () {
   # If the error occurred in a while/done loop or in a function, the trap can

--- a/tools/unit-test-all.bash
+++ b/tools/unit-test-all.bash
@@ -9,7 +9,8 @@
 # ./unit-test-all.bash
 # ./unit-test-all.bash -c
 
-source $(dirname "$0")/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/common.bash || exit
 
 
 main () {
@@ -17,7 +18,13 @@ main () {
 
   while getopts ':c' arg; do
     case "${arg}" in
-      c) ci_mode='true' ;;
+      c )
+        ci_mode='true'
+        ;;
+      * )
+        echo "usage: [-c]"
+        exit 1
+        ;;
     esac
   done
 
@@ -25,8 +32,8 @@ main () {
 
   for s in "${subsystems[@]}"
   do
-    pushd ../$s/
-      echo "\nTesting ${s}"
+    pushd ../"$s"/
+      echo "Testing ${s}"
       if [ "$ci_mode" = "true" ]; then
         ./build.bash test -c
       else
@@ -38,4 +45,4 @@ main () {
   script_completed
 }
 
-main $@
+main "$@"

--- a/tools/update-packages.bash
+++ b/tools/update-packages.bash
@@ -6,11 +6,12 @@
 #
 # usage: update-packages.bash <path> [--highest-major]
 
-source $(dirname "$0")/common.bash || exit
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/common.bash || exit
 
 restore () {
   options=${1:- }
-  dotnet restore $options > /dev/null
+  dotnet restore "$options" > /dev/null
 }
 
 update () {
@@ -21,14 +22,14 @@ update () {
 
   # Don't want grep to result in error code for whole pipeline if no
   # new packages found; see https://unix.stackexchange.com/a/581991
-  list=$(dotnet list package --outdated $options | tr -s ' ' | { grep '>' || test $? = 1; } | cut -f 3,6 -d ' ')
-  while IFS=, read line; do
+  list=$(dotnet list package --outdated "$options" | tr -s ' ' | { grep '>' || test $? = 1; } | cut -f 3,6 -d ' ')
+  while IFS=, read -r line; do
     trimmed=$(echo "$line" | tr -d '[:space:]')
     if [ "$trimmed" != "" ]; then
-      package=$(echo $line | cut -f1 -d ' ')
-      version=$(echo $line | cut -f2 -d ' ')
+      package=$(echo "$line" | cut -f1 -d ' ')
+      version=$(echo "$line" | cut -f2 -d ' ')
 
-      dotnet add package --version $version $package
+      dotnet add package --version "$version" "$package"
     fi
   done <<< "$list"
 }
@@ -51,8 +52,8 @@ main () {
 
   for op in "${operations[@]}"
   do
-    while IFS=, read csproj; do
-      dn=$(dirname $csproj)
+    while IFS=, read -r csproj; do
+      dn=$(dirname "$csproj")
 
       pushd "$dn" > /dev/null
         $op


### PR DESCRIPTION
closes #156

I tried out running [shellcheck](https://github.com/koalaman/shellcheck) in our repo and adding it as a Circle CI job. 

Running shellcheck on the entire repo produces >100 warnings—mostly linting and shellcheck configuration. These are simple fixes but they'll take some time, maybe a day or two. Considering how heavily we on rely bash scripting, I think this is worth doing. But before I start fixing all the files, I wanted to show an example of what shellcheck catches (`dashboard/build.bash`) to see if we're ok with moving forward.

Some things I discovered:
- In order for shellcheck to source files correctly from scripts, you must specify sourced files in your scripts (`# shellcheck source=./tools/common.bash`) along with running shellcheck with the `-x` option.
- By default, shellcheck [does not have a recursive option](https://github.com/koalaman/shellcheck/wiki/Recursiveness). The command added to `.circleci/config.yml` is the recommended recursive approach.
- At first I tried adding CircleCi's built-in orb job, but quickly realized that a more custom job would be needed, since our scripts are in different directory levels throughout the repo. 