### PR TITLE
Fix optional argument handling in update-packages

### DIFF
--- a/tools/update-packages.bash
+++ b/tools/update-packages.bash
@@ -10,7 +10,7 @@
 source "$(dirname "$0")"/common.bash || exit
 
 restore () {
-  options=${1:- }
+  options=${1:-}
   dotnet restore "$options" > /dev/null
 }
 


### PR DESCRIPTION
`$options` was being set to a space in if no argument was passed. With the update to use double quotes to prevent globbing/splitting (#815), the space was then being passed to `dotnet restore` causing a "project not found" error.