### PR TITLE
Start integration tests for metrics API; Make Metrics constants DRY

### DIFF
--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -54,6 +54,13 @@ DB_2_SUBNET_NAME=snet-core-$ENV # Subnet that core database private endpoint use
 FUNC_SUBNET_NAME=snet-apps1-$ENV # Subnet function apps use
 PRIVATE_ENDPOINT_NAME=pe-participants-$ENV
 CORE_DB_PRIVATE_ENDPOINT_NAME=pe-core-$ENV
+
+# Metrics Resources
+METRICS_COLLECT_APP_ID=metricscol
+METRICS_COLLECT_APP_NAME=${PREFIX}-func-${METRICS_COLLECT_APP_ID}-${ENV}
+METRICS_API_APP_ID=metricsapi
+METRICS_API_APP_NAME=$PREFIX-func-$METRICS_API_APP_ID-$ENV
+METRICS_API_FUNCTION_NAME=GetParticipantUploads
 ### END Constants
 
 ### Functions

--- a/metrics/build.bash
+++ b/metrics/build.bash
@@ -9,14 +9,6 @@ source "$(dirname "$0")"/../tools/common.bash || exit
 # shellcheck source=./tools/build-common.bash
 source "$(dirname "$0")"/../tools/build-common.bash || exit
 
-set_constants () {
-   # TODO: make more DRY
-  COLLECT_APP_ID=metricscol
-  COLLECT_APP_NAME=${PREFIX}-func-${COLLECT_APP_ID}-${ENV}
-  METRICS_API_APP_ID=metricsapi
-  API_APP_NAME=$PREFIX-func-$METRICS_API_APP_ID-$ENV
-}
-
 run_deploy () {
   azure_env=$1
   # shellcheck source=./iac/env/tts/dev.bash
@@ -25,16 +17,15 @@ run_deploy () {
   source "$(dirname "$0")"/../iac/iac-common.bash
 
   verify_cloud
-  set_constants
 
-  echo "Publish ${COLLECT_APP_NAME} to Azure Environment ${azure_env}"
+  echo "Publish ${METRICS_COLLECT_APP_NAME} to Azure Environment ${azure_env}"
   pushd ./src/Piipan.Metrics/Piipan.Metrics.Collect
-    func azure functionapp publish "$COLLECT_APP_NAME" --dotnet
+    func azure functionapp publish "$METRICS_COLLECT_APP_NAME" --dotnet
   popd
 
-  echo "Publish ${API_APP_NAME} to Azure Environment ${azure_env}"
+  echo "Publish ${METRICS_API_APP_NAME} to Azure Environment ${azure_env}"
   pushd ./src/Piipan.Metrics/Piipan.Metrics.Api
-    func azure functionapp publish "$API_APP_NAME" --dotnet
+    func azure functionapp publish "$METRICS_API_APP_NAME" --dotnet
   popd
 }
 


### PR DESCRIPTION
Partially addresses #864 

Since Metrics names are now being used in a lot of places, I hoisted them up to iac-common. This has implications for iac scripts. 