### PR TITLE
Add benefits end date to participants database and bulk upload

### DIFF
--- a/ddl/per-state.sql
+++ b/ddl/per-state.sql
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS participants(
 	exception text,
 	upload_id integer REFERENCES uploads (id),
   	case_id text NOT NULL,
-  	participant_id text
+  	participant_id text,
+	benefits_end_date date
 );
 
 COMMENT ON TABLE participants IS 'Program participant Personally Identifiable Information (PII)';
@@ -40,6 +41,7 @@ COMMENT ON COLUMN participants.ssn IS 'Participant''s Social Security Number';
 COMMENT ON COLUMN participants.exception IS 'Placeholder for value indicating special processing instructions';
 COMMENT ON COLUMN participants.case_id IS 'Participant''s state-specific case identifier';
 COMMENT ON COLUMN participants.participant_id IS 'Participant''s state-specific identifier';
+COMMENT ON COLUMN participants.benefits_end_date IS 'Participant''s ending benefits date';
 
 CREATE INDEX IF NOT EXISTS participants_ssn_idx ON participants (ssn, upload_id);
 

--- a/etl/docs/csv/example.csv
+++ b/etl/docs/csv/example.csv
@@ -1,11 +1,11 @@
-﻿last,first,middle,dob,ssn,exception,case id,participant id
-Farrington,Theodore,Carri,10/13/1931,000-12-3456,ReasonXYZ,caseid1,
-Lynn,Wesley,Eura,8/01/1940,000-12-3457,,caseid2,
-Cullen,S,,1/1/2015,000-12-3458,,caseid3,
-Alger,Megan,Kamala,1/25/2020,000-12-3459,,caseid4,
-Yu,,,11/2/1973,000-12-3460,,caseid5,
-Wallen,Homer,Madonna,4/4/1913,000-12-3461,ReasonXYZ,caseid6,
-Benner,Cristina,Wilton,07/22/1961,000-12-3462,,caseid7,
-Whittaker,Troy,G,2/15/1985,000-12-3463,,caseid8,
-Grier,Paulette,Tequila,12/24/1997,000-12-3464,,caseid9,
-Suarez,Amelia,Shavonda,1/19/1950,000-12-3465,,caseid10,participantid1
+﻿last,first,middle,dob,ssn,exception,case id,participant id, benefits end month
+Farrington,Theodore,Carri,10/13/1931,000-12-3456,ReasonXYZ,caseid1,,5/2021
+Lynn,Wesley,Eura,8/01/1940,000-12-3457,,caseid2,,
+Cullen,S,,1/1/2015,000-12-3458,,caseid3,,
+Alger,Megan,Kamala,1/25/2020,000-12-3459,,caseid4,,
+Yu,,,11/2/1973,000-12-3460,,caseid5,,
+Wallen,Homer,Madonna,4/4/1913,000-12-3461,ReasonXYZ,caseid6,,
+Benner,Cristina,Wilton,07/22/1961,000-12-3462,,caseid7,,
+Whittaker,Troy,G,2/15/1985,000-12-3463,,caseid8,,
+Grier,Paulette,Tequila,12/24/1997,000-12-3464,,caseid9,,
+Suarez,Amelia,Shavonda,1/19/1950,000-12-3465,,caseid10,participantid1,

--- a/etl/docs/csv/example.csv
+++ b/etl/docs/csv/example.csv
@@ -1,5 +1,5 @@
 ﻿last,first,middle,dob,ssn,exception,case id,participant id, benefits end month
-Farrington,Theodore,Carri,10/13/1931,000-12-3456,ReasonXYZ,caseid1,,5/2021
+Farrington,Theodore,Carri,10/13/1931,000-12-3456,ReasonXYZ,caseid1,,2021-05
 Lynn,Wesley,Eura,8/01/1940,000-12-3457,,caseid2,,
 Cullen,S,,1/1/2015,000-12-3458,,caseid3,,
 Alger,Megan,Kamala,1/25/2020,000-12-3459,,caseid4,,

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -62,7 +62,6 @@
       {
         "name": "benefits end month",
         "type": "yearmonth",
-        "format": "%m/%Y",
         "description": "month and year when participant's benefits end"
       }
     ]

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -22,7 +22,7 @@
       {
         "name": "dob",
         "type": "date",
-        "format": "%m/%d/%Y", 
+        "format": "%m/%d/%Y",
         "description": "Participant's date of birth",
         "constraints": {
             "required": true
@@ -58,6 +58,12 @@
         "name": "participant id",
         "type": "string",
         "description": "Participant's state-specific identifier. Must not be social security number or any personal identifiable information."
+      },
+      {
+        "name": "benefits end month",
+        "type": "yearmonth",
+        "format": "%m/%Y",
+        "description": "month and year when participant's benefits end"
       }
     ]
   }

--- a/etl/src/Piipan.Etl/BulkUpload.cs
+++ b/etl/src/Piipan.Etl/BulkUpload.cs
@@ -64,6 +64,11 @@ namespace Piipan.Etl
             }
         }
 
+        public static DateTime LastDayOfMonth(DateTime dateTime)
+        {
+            return new DateTime(dateTime.Year, dateTime.Month, DateTime.DaysInMonth(dateTime.Year, dateTime.Month));
+        }
+
         internal static IEnumerable<PiiRecord> Read(Stream input, ILogger log)
         {
             var reader = new StreamReader(input);
@@ -143,11 +148,17 @@ namespace Piipan.Etl
 
                 foreach (var record in records)
                 {
+                    if (record.BenefitsEndDate.HasValue)
+                    {
+                      DateTime benefitsEndDate = record.BenefitsEndDate.Value;
+                      record.BenefitsEndDate = LastDayOfMonth(benefitsEndDate);
+                    }
+
                     using (var cmd = factory.CreateCommand())
                     {
                         cmd.Connection = conn;
-                        cmd.CommandText = "INSERT INTO participants (last, first, middle, dob, ssn, exception, upload_id, case_id, participant_id) " +
-                            "VALUES (@last, @first, @middle, @dob, @ssn, @exception, @upload_id, @case_id, @participant_id)";
+                        cmd.CommandText = "INSERT INTO participants (last, first, middle, dob, ssn, exception, upload_id, case_id, participant_id, benefits_end_date) " +
+                            "VALUES (@last, @first, @middle, @dob, @ssn, @exception, @upload_id, @case_id, @participant_id, @benefits_end_date)";
 
                         AddWithValue(cmd, DbType.String, "last", record.Last);
                         AddWithValue(cmd, DbType.String, "first", (object)record.First ?? DBNull.Value);
@@ -158,6 +169,7 @@ namespace Piipan.Etl
                         AddWithValue(cmd, DbType.Int64, "upload_id", lastval);
                         AddWithValue(cmd, DbType.String, "case_id", record.CaseId);
                         AddWithValue(cmd, DbType.String, "participant_id", (object)record.ParticipantId ?? DBNull.Value);
+                        AddWithValue(cmd, DbType.DateTime, "benefits_end_date", (object)record.BenefitsEndDate ?? DBNull.Value);
 
                         cmd.ExecuteNonQuery();
                     }

--- a/etl/src/Piipan.Etl/PiiRecord.cs
+++ b/etl/src/Piipan.Etl/PiiRecord.cs
@@ -23,5 +23,6 @@ namespace Piipan.Etl
         public string CaseId { get; set; } = null!;
         public string? ParticipantId { get; set; }
         public string? Exception { get; set; }
+        public DateTime? BenefitsEndDate { get; set; }
     }
 }

--- a/etl/src/Piipan.Etl/PiiRecordMap.cs
+++ b/etl/src/Piipan.Etl/PiiRecordMap.cs
@@ -40,6 +40,9 @@ namespace Piipan.Etl
 
             Map(m => m.ParticipantId).Name("participant id")
                 .TypeConverterOption.NullValues(string.Empty);
+
+            Map(m => m.BenefitsEndDate).Name("benefits end month")
+                .TypeConverterOption.NullValues(string.Empty);
         }
     }
 }

--- a/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
+++ b/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
@@ -17,7 +17,8 @@ namespace Piipan.Etl.Tests
             var writer = new StreamWriter(stream);
             if (includeHeader)
             {
-                writer.WriteLine("last,first,middle,dob,ssn,exception,case id,participant id, benefits end month");
+                writer.WriteLine("last,first,middle,dob,ssn,exception,case id,participant id,benefits end month");
+
             }
             foreach (var record in records)
             {

--- a/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
+++ b/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
@@ -17,7 +17,7 @@ namespace Piipan.Etl.Tests
             var writer = new StreamWriter(stream);
             if (includeHeader)
             {
-                writer.WriteLine("last,first,middle,dob,ssn,exception,case id,participant id");
+                writer.WriteLine("last,first,middle,dob,ssn,exception,case id,participant id, benefits end month");
             }
             foreach (var record in records)
             {
@@ -51,7 +51,8 @@ namespace Piipan.Etl.Tests
                 Ssn = "000-00-0000",
                 Exception = "Exception",
                 CaseId = "CaseId",
-                ParticipantId = "ParticipantId"
+                ParticipantId = "ParticipantId",
+                BenefitsEndDate = new DateTime(1970, 1, 1)
             };
         }
 
@@ -66,6 +67,8 @@ namespace Piipan.Etl.Tests
                 Ssn = "000-00-0000",
                 Exception = null,
                 CaseId = "CaseId",
+                ParticipantId = null,
+                BenefitsEndDate = null
             };
         }
 
@@ -94,7 +97,7 @@ namespace Piipan.Etl.Tests
         {
             var logger = Mock.Of<ILogger>();
             var stream = CsvFixture(new string[] {
-                "Last,First,Middle,01/01/1970,000-00-0000,Exception,CaseId,ParticipantId"
+                "Last,First,Middle,01/01/1970,000-00-0000,Exception,CaseId,ParticipantId,01/1970"
             });
 
             var records = BulkUpload.Read(stream, logger);
@@ -108,6 +111,7 @@ namespace Piipan.Etl.Tests
                 Assert.Equal("Exception", record.Exception);
                 Assert.Equal("CaseId", record.CaseId);
                 Assert.Equal("ParticipantId", record.ParticipantId);
+                Assert.Equal(new DateTime(1970, 1, 1), record.BenefitsEndDate);
             }
         }
 
@@ -116,7 +120,7 @@ namespace Piipan.Etl.Tests
         {
             var logger = Mock.Of<ILogger>();
             var stream = CsvFixture(new string[] {
-                "Last,,,01/01/1970,000-00-0000,,CaseId,,"
+                "Last,,,01/01/1970,000-00-0000,,CaseId,,,"
             });
 
             var records = BulkUpload.Read(stream, logger);
@@ -126,6 +130,7 @@ namespace Piipan.Etl.Tests
                 Assert.Null(record.Middle);
                 Assert.Null(record.Exception);
                 Assert.Null(record.ParticipantId);
+                Assert.Null(record.BenefitsEndDate);
             }
         }
 
@@ -210,6 +215,20 @@ namespace Piipan.Etl.Tests
             {
                 await BulkUpload.Run(gridEvent, BadBlob(), logger.Object);
             });
+        }
+
+        [Fact]
+        public void LastDayOfMonth()
+        {
+
+          var monthWith31Days = new DateTime(1970,1,1);
+          Assert.Equal(31, BulkUpload.LastDayOfMonth(monthWith31Days).Day);
+          var monthWith30Days = new DateTime(1970,4,1);
+          Assert.Equal(30, BulkUpload.LastDayOfMonth(monthWith30Days).Day);
+          var februaryLeapYear = new DateTime(2000,2,1);
+          Assert.Equal(29, BulkUpload.LastDayOfMonth(februaryLeapYear).Day);
+          var februaryNonLeapYear = new DateTime(2001,2,1);
+          Assert.Equal(28, BulkUpload.LastDayOfMonth(februaryNonLeapYear).Day);
         }
     }
 }


### PR DESCRIPTION
Closes #860 
Since this changes the database schema, I'll drop participants database server and re-run iac on tts/dev before merging this. 

## Notes
Per [this discussion](https://github.com/18F/piipan/issues/860), I made the following choices:
- Database column name and C# object property are named `benefits_end_date` since it's technically a postgresql `date` column and a `DateTime` C# object. 
- However in the bulk upload csv, the field is named "benefits end month" since we're assuming the month is all states will be tracking. The import schema has a data type of [yearmonth](https://specs.frictionlessdata.io/table-schema/#types-and-formats) that seemed most appropriate. 
- Our system takes on the responsibility of determining the final day of benefits based on the provided month. I'm not sure when exactly this transfer from month-only to last-day-of-month should happen, but I think it should happen before it's recorded in the database. 
- ~I didn't convert the new csv field to ISO 8601 (per [this discussion](https://gsa-tts.slack.com/archives/C018P1ZJPEC/p1621541101091800?thread_ts=1621537600.087600&cid=C018P1ZJPEC)). figured we'd change all date fields at once. But if we want to do it here I can.~ See discussion below