### PR TITLE
Create Event Hub resources for streaming logs

### DIFF
--- a/iac/arm-templates/event-hub-monitoring.json
+++ b/iac/arm-templates/event-hub-monitoring.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "env": {
+            "type": "String"
+        },
+        "prefix": {
+            "type": "String"
+        },
+        "resourceTags": {
+            "type": "object"
+        },
+        "location": {
+            "type": "String"
+        }
+    },
+    "variables": {
+        "basename": "monitoring",
+        "namespace": "[concat(parameters('prefix'), '-evh-', variables('basename'), '-', parameters('env'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.EventHub/namespaces",
+            "apiVersion": "2021-01-01-preview",
+            "name": "[variables('namespace')]",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
+            "sku": {
+                "name": "Standard",
+                "tier": "Standard",
+                "capacity": 1
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/eventhubs",
+            "apiVersion": "2017-04-01",
+            "name": "[concat(variables('namespace'), '/logs')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces', variables('namespace'))]"
+            ],
+            "properties": {
+                "messageRetentionInDays": 1,
+                "partitionCount": 1,
+                "status": "Active"
+            }
+        }
+    ]
+}

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -121,6 +121,17 @@ main () {
       objectId="$CURRENT_USER_OBJID" \
       resourceTags="$RESOURCE_TAGS"
 
+  # Create an Event Hub namespace and hub where resource logs will be streamed
+  az deployment group create \
+    --name monitoring \
+    --resource-group "$RESOURCE_GROUP" \
+    --template-file  ./arm-templates/event-hub-monitoring.json \
+    --parameters \
+      resourceTags="$RESOURCE_TAGS" \
+      location="$LOCATION" \
+      env="$ENV" \
+      prefix="$PREFIX"
+
   # For each participating state, create a separate storage account.
   # Each account has a blob storage container named `upload`.
   while IFS=, read -r abbr name ; do


### PR DESCRIPTION
- Creates an Event Hub namespace following our naming conventions: `{prefix}-evh-monitoring-{env}`
- Creates an event hub resource named `logs` intended as a single location for all resource logs for a given environment

Note: Event hubs have two SKUs, "Basic" and "Standard". I've chosen Standard, which gives us certain flexibility like the ability to "capture" logs in a storage account for debugging purposes.

First step for #729, to be followed by pointing resource logs to the event hub.