### PR TITLE
Add specs for recent benefits months in CSV import schema

### DIFF
--- a/ddl/per-state.sql
+++ b/ddl/per-state.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS participants(
 	upload_id integer REFERENCES uploads (id),
   	case_id text NOT NULL,
   	participant_id text,
-	benefits_end_date date
+	benefits_end_date date,
+    	recent_benefit_months date[]
 );
 
 COMMENT ON TABLE participants IS 'Program participant Personally Identifiable Information (PII)';
@@ -42,6 +43,7 @@ COMMENT ON COLUMN participants.exception IS 'Placeholder for value indicating sp
 COMMENT ON COLUMN participants.case_id IS 'Participant''s state-specific case identifier';
 COMMENT ON COLUMN participants.participant_id IS 'Participant''s state-specific identifier';
 COMMENT ON COLUMN participants.benefits_end_date IS 'Participant''s ending benefits date';
+COMMENT ON COLUMN participants.recent_benefit_months IS 'Participant''s recent benefit months';
 
 CREATE INDEX IF NOT EXISTS participants_ssn_idx ON participants (ssn, upload_id);
 

--- a/etl/docs/csv/example.csv
+++ b/etl/docs/csv/example.csv
@@ -1,11 +1,11 @@
-﻿last,first,middle,dob,ssn,exception,case id,participant id, benefits end month
-Farrington,Theodore,Carri,10/13/1931,000-12-3456,ReasonXYZ,caseid1,,5/2021
-Lynn,Wesley,Eura,8/01/1940,000-12-3457,,caseid2,,
-Cullen,S,,1/1/2015,000-12-3458,,caseid3,,
-Alger,Megan,Kamala,1/25/2020,000-12-3459,,caseid4,,
-Yu,,,11/2/1973,000-12-3460,,caseid5,,
-Wallen,Homer,Madonna,4/4/1913,000-12-3461,ReasonXYZ,caseid6,,
-Benner,Cristina,Wilton,07/22/1961,000-12-3462,,caseid7,,
-Whittaker,Troy,G,2/15/1985,000-12-3463,,caseid8,,
-Grier,Paulette,Tequila,12/24/1997,000-12-3464,,caseid9,,
-Suarez,Amelia,Shavonda,1/19/1950,000-12-3465,,caseid10,participantid1,
+﻿last,first,middle,dob,ssn,exception,case id,participant id, benefits end month, recent benefit months
+Farrington,Theodore,Carri,10/13/1931,000-12-3456,ReasonXYZ,caseid1,,2021-05, 2021-04 2021-03 2021-02
+Lynn,Wesley,Eura,8/01/1940,000-12-3457,,caseid2,,,
+Cullen,S,,1/1/2015,000-12-3458,,caseid3,,,
+Alger,Megan,Kamala,1/25/2020,000-12-3459,,caseid4,,,
+Yu,,,11/2/1973,000-12-3460,,caseid5,,,
+Wallen,Homer,Madonna,4/4/1913,000-12-3461,ReasonXYZ,caseid6,,,
+Benner,Cristina,Wilton,07/22/1961,000-12-3462,,caseid7,,,
+Whittaker,Troy,G,2/15/1985,000-12-3463,,caseid8,,,
+Grier,Paulette,Tequila,12/24/1997,000-12-3464,,caseid9,,,
+Suarez,Amelia,Shavonda,1/19/1950,000-12-3465,,caseid10,participantid1,,,

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -64,6 +64,12 @@
         "type": "yearmonth",
         "format": "%m/%Y",
         "description": "month and year when participant's benefits end"
+      },
+      {
+        "name": "recent benefit months",
+        "type": "string",
+        "format": "%m/%Y,%m/%Y,%m/%Y",
+        "description": "List of the last 3 months that participant received benefits, formatted as yearmonths separated by commas in a single column. Does not include current benefit month. Months do not need to be consecutive."
       }
     ]
   }

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -62,14 +62,13 @@
       {
         "name": "benefits end month",
         "type": "yearmonth",
-        "format": "%m/%Y",
         "description": "month and year when participant's benefits end"
       },
       {
         "name": "recent benefit months",
         "type": "string",
-        "format": "%m/%Y,%m/%Y,%m/%Y",
-        "description": "List of the last 3 months that participant received benefits, formatted as yearmonths separated by commas in a single column. Does not include current benefit month. Months do not need to be consecutive."
+        "format": "%Y-%m %Y-%m %Y-%m",
+        "description": "List of up to the last 3 months that participant received benefits, formatted as yearmonths separated by spaces. Does not include current benefit month. Months need to be consecutive. Fewer than 3 months can be entered for newer participants."
       }
     ]
   }

--- a/etl/src/Piipan.Etl/PiiRecord.cs
+++ b/etl/src/Piipan.Etl/PiiRecord.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 #nullable enable
 
@@ -24,5 +25,6 @@ namespace Piipan.Etl
         public string? ParticipantId { get; set; }
         public string? Exception { get; set; }
         public DateTime? BenefitsEndDate { get; set; }
+        public string? RecentBenefitMonths { get; set; }
     }
 }

--- a/etl/src/Piipan.Etl/PiiRecordMap.cs
+++ b/etl/src/Piipan.Etl/PiiRecordMap.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using CsvHelper.Configuration;
 
@@ -43,6 +46,28 @@ namespace Piipan.Etl
 
             Map(m => m.BenefitsEndDate).Name("benefits end month")
                 .TypeConverterOption.NullValues(string.Empty);
+
+            Map(m => m.RecentBenefitMonths).Name("recent benefit months")
+                .Validate(field => {
+                  if (String.IsNullOrEmpty(field.Field)) return true;
+
+                  string[] formats={"yyyy-MM", "yyyy-M"};
+                  string[] dates = field.Field.Split(' ');
+                  foreach (string date in dates)
+                  {
+                    DateTime dateValue;
+                    var result = DateTime.TryParseExact(
+                      date,
+                      formats,
+                      new CultureInfo("en-US"),
+                      DateTimeStyles.None,
+                      out dateValue);
+                    if (!result) return false;
+                  }
+                  return true;
+                })
+                .TypeConverterOption.NullValues(string.Empty);
+
         }
     }
 }

--- a/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
+++ b/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
@@ -17,7 +17,7 @@ namespace Piipan.Etl.Tests
             var writer = new StreamWriter(stream);
             if (includeHeader)
             {
-                writer.WriteLine("last,first,middle,dob,ssn,exception,case id,participant id, benefits end month");
+                writer.WriteLine("last,first,middle,dob,ssn,exception,case id,participant id, benefits end month, recent benefit months");
             }
             foreach (var record in records)
             {
@@ -52,7 +52,8 @@ namespace Piipan.Etl.Tests
                 Exception = "Exception",
                 CaseId = "CaseId",
                 ParticipantId = "ParticipantId",
-                BenefitsEndDate = new DateTime(1970, 1, 1)
+                BenefitsEndDate = new DateTime(1970, 1, 1),
+                RecentBenefitMonths = "2021-05 2021-04"
             };
         }
 
@@ -68,7 +69,8 @@ namespace Piipan.Etl.Tests
                 Exception = null,
                 CaseId = "CaseId",
                 ParticipantId = null,
-                BenefitsEndDate = null
+                BenefitsEndDate = null,
+                RecentBenefitMonths = null
             };
         }
 
@@ -97,7 +99,7 @@ namespace Piipan.Etl.Tests
         {
             var logger = Mock.Of<ILogger>();
             var stream = CsvFixture(new string[] {
-                "Last,First,Middle,01/01/1970,000-00-0000,Exception,CaseId,ParticipantId,01/1970"
+                "Last,First,Middle,01/01/1970,000-00-0000,Exception,CaseId,ParticipantId,01/1970,2021-05 2021-04"
             });
 
             var records = BulkUpload.Read(stream, logger);
@@ -112,6 +114,7 @@ namespace Piipan.Etl.Tests
                 Assert.Equal("CaseId", record.CaseId);
                 Assert.Equal("ParticipantId", record.ParticipantId);
                 Assert.Equal(new DateTime(1970, 1, 1), record.BenefitsEndDate);
+                Assert.Equal("2021-05 2021-04", record.RecentBenefitMonths);
             }
         }
 
@@ -229,6 +232,17 @@ namespace Piipan.Etl.Tests
           Assert.Equal(29, BulkUpload.LastDayOfMonth(februaryLeapYear).Day);
           var februaryNonLeapYear = new DateTime(2001,2,1);
           Assert.Equal(28, BulkUpload.LastDayOfMonth(februaryNonLeapYear).Day);
+        }
+
+        [Fact]
+        public void FormatDatesAsPgArray()
+        {
+          var emptyString = string.Empty;
+          Assert.Equal("{}", BulkUpload.FormatDatesAsPgArray(emptyString));
+          var singleDate = "2021-05";
+          Assert.Equal("{2021-05-01}", BulkUpload.FormatDatesAsPgArray(singleDate));
+          var multiDates = "2021-05 2021-04";
+          Assert.Equal("{2021-05-01,2021-04-01}", BulkUpload.FormatDatesAsPgArray(multiDates));
         }
     }
 }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -304,7 +304,7 @@ main () {
     az functionapp create \
       --resource-group "$RESOURCE_GROUP" \
       --plan "$APP_SERVICE_PLAN_FUNC_NAME" \
-      --tags Project="$PROJECT_TAG $PER_STATE_ETL_TAG" \
+      --tags Project="$PROJECT_TAG" "$PER_STATE_ETL_TAG" \
       --runtime dotnet \
       --functions-version 3 \
       --os-type Windows \


### PR DESCRIPTION
partially addresses #861 

I'd like to get consensus on these specs for the CSV import, since it'll inform how the data is parsed and stored. 

This new CSV column would look like this:
| recent benefit months |
|---|
| 2/2021,3/2021,4/2021 |
| 1/2021,3/2021,4/2021 |
| 1/2021,2/2021,3/2021 |

Does this look alright?

