### PR TITLE
Stream Front Door logs to Event Hub

### DIFF
--- a/iac/add-front-door-to-app.bash
+++ b/iac/add-front-door-to-app.bash
@@ -37,7 +37,9 @@ main () {
       frontDoorName="$front_door_name" \
       resourceGroupName="$resource_group" \
       resourceTags="$RESOURCE_TAGS" \
-      wafPolicyName="$waf_name"
+      wafPolicyName="$waf_name" \
+      prefix="$PREFIX" \
+      env="$ENV"
 
   script_completed
 }

--- a/iac/arm-templates/front-door-app-service.json
+++ b/iac/arm-templates/front-door-app-service.json
@@ -48,11 +48,24 @@
             "metadata": {
                 "description": "Describes if it is in detection mode or prevention mode at policy level."
             }
+        },
+        "prefix": {
+            "type": "string",
+            "metadata": {
+                "description": "Environment-specific resource naming prefix"
+            }
+        },
+        "env": {
+            "type": "string",
+            "metadata": {
+                "description": "Development environment indicator"
+            }
         }
     },
     "variables": {
         "location": "global", /* front-door location must be global */
-        "wafLocation": "global" /* waf location must be global */
+        "wafLocation": "global" /* waf location must be global */,
+        "eventhubName": "[concat(parameters('prefix'), '-evh-monitoring-', parameters('env'))]"
     },
     "resources": [
         {
@@ -227,6 +240,30 @@
                     "enforceCertificateNameCheck": "Enabled",
                     "sendRecvTimeoutSeconds": 30
                 }
+            }
+        },
+        {
+            /* https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/resource-manager-diagnostic-settings */
+            "apiVersion": "2017-05-01-preview",
+            "type": "Microsoft.Network/frontdoors/providers/diagnosticSettings",
+            "name": "[concat(parameters('frontDoorName'), '/Microsoft.Insights/stream-logs-to-event-hub')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/frontdoors', parameters('frontDoorName'))]"
+            ],
+            "properties": {
+                "eventHubAuthorizationRuleId": "[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', variables('eventhubName'), '/authorizationrules/RootManageSharedAccessKey')]",
+                "eventHubName": "logs",
+                "logs": [
+                    /* Category names from `az monitor diagnostic settings categories list` */
+                    {
+                        "category": "FrontdoorAccessLog",
+                        "enabled": true
+                    },
+                    {
+                        "category": "FrontdoorWebApplicationFirewallLog",
+                        "enabled": true
+                    }
+                ]
             }
         }
     ]


### PR DESCRIPTION
- Logs are streamed via "diagnostic settings" added via ARM template
- Added prefix and env parameters to front door ARM template so event hub resource name can be constructed

This work establishes a precedent of naming the [diagnostic setting](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/diagnostic-settings?tabs=CMD) `stream-logs-to-event-hub`. My current plan is for remaining resources which need their logs streamed to event hub to get a diagnostic setting with the same name.