### PR TITLE
fix: function app tag typo

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -315,7 +315,7 @@ main () {
     az functionapp create \
       --resource-group "$RESOURCE_GROUP" \
       --plan "$APP_SERVICE_PLAN_FUNC_NAME" \
-      --tags Project="$PROJECT_TAG $PER_STATE_ETL_TAG" \
+      --tags Project="$PROJECT_TAG" "$PER_STATE_ETL_TAG" \
       --runtime dotnet \
       --functions-version 3 \
       --os-type Windows \


### PR DESCRIPTION
fixes piipan and subsystem tags from being merged on etl function apps. 