### PR TITLE
Add example requests and responses for DupPart API

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -40,21 +40,23 @@ Queries all state databases for any PII records that are an exact match to the l
 
 > Body parameter
 
+> A request with values for all fields
+
 ```json
 {
   "query": {
     "first": "string",
     "middle": "string",
     "last": "string",
-    "ssn": "string",
-    "dob": "2019-08-24"
+    "ssn": "000-00-0000",
+    "dob": "1970-01-01"
   }
 }
 ```
 
 > Example responses
 
-> 200 Response
+> A query returning a single match
 
 ```json
 {
@@ -64,13 +66,56 @@ Queries all state databases for any PII records that are an exact match to the l
       "first": "string",
       "middle": "string",
       "last": "string",
-      "ssn": "string",
-      "dob": "2019-08-24",
-      "state": "string",
-      "state_abbr": "string",
+      "ssn": "000-00-0000",
+      "dob": "1970-01-01",
+      "state": "ea",
+      "state_abbr": "ea",
       "exception": "string",
       "case_id": "string",
       "participant_id": "string"
+    }
+  ]
+}
+```
+
+> A query returning no matches
+
+```json
+{
+  "lookup_id": null,
+  "matches": []
+}
+```
+
+> A query returning multiple matches
+
+```json
+{
+  "lookup_id": "string",
+  "matches": [
+    {
+      "first": "string",
+      "middle": "string",
+      "last": "string",
+      "ssn": "000-00-0000",
+      "dob": "1970-01-01",
+      "state": "eb",
+      "state_abbr": "eb",
+      "exception": "string",
+      "case_id": "string",
+      "participant_id": "string"
+    },
+    {
+      "first": null,
+      "middle": null,
+      "last": "string",
+      "ssn": "000-00-0000",
+      "dob": "1970-01-01",
+      "state": "ec",
+      "state_abbr": "ec",
+      "exception": null,
+      "case_id": "string",
+      "participant_id": null
     }
   ]
 }
@@ -131,7 +176,7 @@ User can provide a Lookup ID and receive the match data associated with it
 
 > Example responses
 
-> 200 Response
+> A response showing a query with values for all fields
 
 ```json
 {
@@ -139,8 +184,21 @@ User can provide a Lookup ID and receive the match data associated with it
     "first": "string",
     "middle": "string",
     "last": "string",
-    "ssn": "string",
-    "dob": "2019-08-24"
+    "ssn": "000-00-0000",
+    "dob": "1970-01-01"
+  }
+}
+```
+
+> A response showing a query with values for only required fields
+
+```json
+{
+  "data": {
+    "first": "string",
+    "last": "string",
+    "ssn": "000-00-0000",
+    "dob": "1970-01-01"
   }
 }
 ```

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -47,6 +47,24 @@ paths:
                       type: string
                       format: date
                       description: PII record's date of birth
+            examples:
+              All fields:
+                description: A request with values for all fields
+                value:
+                  query:
+                    first: string
+                    middle: string
+                    last: string
+                    ssn: 000-00-0000
+                    dob: '1970-01-01'
+              Only requried fields:
+                description: A request with values only for required fields
+                value:
+                  query:
+                    first: string
+                    last: string
+                    ssn: 000-00-0000
+                    dob: '1970-01-01'
       responses:
         '200':
           description: 'Matching PII records, if any exist'
@@ -101,6 +119,52 @@ paths:
                         participant_id:
                           type: string
                           description: Participant's state-specific identifier. Must not be social security number or any personal identifiable information.
+              examples:
+                Single:
+                  description: A query returning a single match
+                  value:
+                    lookup_id: string
+                    matches:
+                      - first: string
+                        middle: string
+                        last: string
+                        ssn: 000-00-0000
+                        dob: '1970-01-01'
+                        state: ea
+                        state_abbr: ea
+                        exception: string
+                        case_id: string
+                        participant_id: string
+                None:
+                  description: A query returning no matches
+                  value:
+                    lookup_id: null
+                    matches: []
+                Multiple:
+                  description: A query returning multiple matches
+                  value:
+                    lookup_id: string
+                    matches:
+                      - first: string
+                        middle: string
+                        last: string
+                        ssn: 000-00-0000
+                        dob: '1970-01-01'
+                        state: eb
+                        state_abbr: eb
+                        exception: string
+                        case_id: string
+                        participant_id: string
+                      - first: null
+                        middle: null
+                        last: string
+                        ssn: 000-00-0000
+                        dob: '1970-01-01'
+                        state: ec
+                        state_abbr: ec
+                        exception: null
+                        case_id: string
+                        participant_id: null
         '400':
           description: Bad request. Missing one of the required properties in the request body.
   '/lookup_ids/{id}':
@@ -122,6 +186,24 @@ paths:
                 properties:
                   data:
                     $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/query'
+              examples:
+                All:
+                  description: A response showing a query with values for all fields
+                  value:
+                    data:
+                      first: string
+                      middle: string
+                      last: string
+                      ssn: 000-00-0000
+                      dob: '1970-01-01'
+                Required:
+                  description: A response showing a query with values for only required fields
+                  value:
+                    data:
+                      first: string
+                      last: string
+                      ssn: 000-00-0000
+                      dob: '1970-01-01'
         '400':
           description: Bad request
         '404':

--- a/match/docs/openapi/lookup/id.yaml
+++ b/match/docs/openapi/lookup/id.yaml
@@ -11,6 +11,8 @@ get:
         application/json:
           schema:
             $ref: '../schemas/lookup.yaml#/LookupIdResponse'
+          examples:
+            $ref: '../schemas/lookup.yaml#/LookupIdResponseExamples'
     '400':
       description: "Bad request"
     '404':

--- a/match/docs/openapi/orchestrator/query.yaml
+++ b/match/docs/openapi/orchestrator/query.yaml
@@ -13,5 +13,7 @@ post:
         application/json:
           schema:
             $ref: '../schemas/match-query.yaml#/MatchQueryResponse'
+          examples:
+            $ref: '../schemas/match-query.yaml#/MatchQueryResponseExamples'
     '400':
       description: "Bad request. Missing one of the required properties in the request body."

--- a/match/docs/openapi/schemas/lookup.yaml
+++ b/match/docs/openapi/schemas/lookup.yaml
@@ -6,3 +6,22 @@ LookupIdResponse:
   properties:
     data:
       $ref: 'match-query.yaml#/MatchQuery'
+
+LookupIdResponseExamples:
+  All:
+    description: "A response showing a query with values for all fields"
+    value:
+      data:
+        first: "string"
+        middle: "string"
+        last: "string"
+        ssn: "000-00-0000"
+        dob: "1970-01-01"
+  Required:
+    description: "A response showing a query with values for only required fields"
+    value:
+      data:
+        first: "string"
+        last: "string"
+        ssn: "000-00-0000"
+        dob: "1970-01-01"

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -10,6 +10,8 @@ MatchQueryRequest:
         properties:
           query:
             $ref: '#/MatchQuery'
+      examples:
+        $ref: '#/MatchQueryRequestExamples'
 MatchQuery:
   type: object
   required:
@@ -35,6 +37,24 @@ MatchQuery:
       type: string
       format: "date"
       description: "PII record's date of birth"
+MatchQueryRequestExamples:
+  "All fields":
+    description: "A request with values for all fields"
+    value:
+      query:
+        first: "string"
+        middle: "string"
+        last: "string"
+        ssn: "000-00-0000"
+        dob: "1970-01-01"
+  "Only requried fields":
+    description: "A request with values only for required fields"
+    value:
+      query:
+        first: "string"
+        last: "string"
+        ssn: "000-00-0000"
+        dob: "1970-01-01"
 
 #/components/schemas/MatchQueryResponse
 MatchQueryResponse:
@@ -48,3 +68,23 @@ MatchQueryResponse:
       type: array
       items:
         $ref: './pii-record.yaml#/PiiRecord'
+
+MatchQueryResponseExamples:
+  Single:
+    description: "A query returning a single match"
+    value:
+      lookup_id: "string"
+      matches:
+        - $ref: './pii-record.yaml#/PiiRecordExamples/All'
+  None:
+    description: "A query returning no matches"
+    value:
+      lookup_id: null
+      matches: []
+  Multiple:
+    description: "A query returning multiple matches"
+    value:
+      lookup_id: "string"
+      matches:
+        - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
+        - $ref: './pii-record.yaml#/PiiRecordExamples/Required'

--- a/match/docs/openapi/schemas/pii-record.yaml
+++ b/match/docs/openapi/schemas/pii-record.yaml
@@ -39,3 +39,38 @@ PiiRecord:
     participant_id:
       type: string
       description: "Participant's state-specific identifier. Must not be social security number or any personal identifiable information."
+
+PiiRecordExamples:
+  All:
+    first: "string"
+    middle: "string"
+    last: "string"
+    ssn: "000-00-0000"
+    dob: "1970-01-01"
+    state: "ea"
+    state_abbr: "ea"
+    exception: "string"
+    case_id: "string"
+    participant_id: "string"
+  AllEB:
+    first: "string"
+    middle: "string"
+    last: "string"
+    ssn: "000-00-0000"
+    dob: "1970-01-01"
+    state: "eb"
+    state_abbr: "eb"
+    exception: "string"
+    case_id: "string"
+    participant_id: "string"
+  Required:
+    first: null
+    middle: null
+    last: "string"
+    ssn: "000-00-0000"
+    dob: "1970-01-01"
+    state: "ec"
+    state_abbr: "ec"
+    exception: null
+    case_id: "string"
+    participant_id: null


### PR DESCRIPTION
- Regenerated documentation
- Tried to keep examples as close as possible to their associated models to minimize the chance they fall out of date
- Widdershins does not currently support multiple request examples for markdown, only displays first example

The primary change here is adding examples to the API documentation used by states: https://github.com/18F/piipan/blob/413b021c906658a44732348e1a358a1bc457ff71/docs/openapi/generated/duplicate-participation-api/openapi.md

Closes #899, but will need to be kept up to date with scheduled API updates (included #911).