### PR TITLE
Remove `state_name` from DupPart API

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -66,7 +66,7 @@ Queries all state databases for any PII records that are an exact match to the l
       "last": "string",
       "ssn": "string",
       "dob": "2019-08-24",
-      "state_name": "string",
+      "state": "string",
       "state_abbr": "string",
       "exception": "string",
       "case_id": "string",
@@ -96,8 +96,8 @@ Status Code **200**
 |»» last|string|true|none|Last name|
 |»» ssn|string|true|none|Social Security number|
 |»» dob|string(date)|true|none|Date of birth|
-|»» state_name|string|false|none|Full state/territory name|
-|»» state_abbr|string|false|none|State/territory two-letter postal abbreviation|
+|»» state|string|false|none|State/territory two-letter postal abbreviation|
+|»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
 |»» exception|string|false|none|Placeholder for value indicating special processing instructions|
 |»» case_id|string|false|none|Participant's state-specific case identifier|
 |»» participant_id|string|false|none|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -85,12 +85,13 @@ paths:
                           type: string
                           format: date
                           description: Date of birth
-                        state_name:
-                          type: string
-                          description: Full state/territory name
-                        state_abbr:
+                        state:
                           type: string
                           description: State/territory two-letter postal abbreviation
+                        state_abbr:
+                          type: string
+                          description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
+                          deprecated: true
                         exception:
                           type: string
                           description: Placeholder for value indicating special processing instructions

--- a/iac/arm-templates/function-state-match.json
+++ b/iac/arm-templates/function-state-match.json
@@ -8,9 +8,6 @@
         "stateAbbr": {
             "type": "string"
         },
-        "stateName": {
-            "type": "string"
-        },
         "location": {
             "type": "string"
         },
@@ -140,10 +137,6 @@
                             "value": "[reference(resourceId('microsoft.insights/components', variables('functionAppName')), '2020-02-02-preview').InstrumentationKey]"
                         },
                         // Custom environment variables:
-                        {
-                            "name": "StateName",
-                            "value": "[parameters('stateName')]"
-                        },
                         {
                             "name": "AzureServicesAuthConnectionString",
                             "value": "[parameters('azAuthConnectionString')]"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -425,7 +425,6 @@ main () {
           location="$LOCATION" \
           azAuthConnectionString="$az_serv_str" \
           stateAbbr="$abbr" \
-          stateName="$name" \
           functionAppName="$func_app_name" \
           storageAccountName="$storage_acct_name" \
           managedIdentityName="$identity" \

--- a/match/docs/openapi/schemas/pii-record.yaml
+++ b/match/docs/openapi/schemas/pii-record.yaml
@@ -23,12 +23,13 @@ PiiRecord:
       type: string
       format: "date"
       description: "Date of birth"
-    state_name:
-      type: string
-      description: "Full state/territory name"
-    state_abbr:
+    state:
       type: string
       description: "State/territory two-letter postal abbreviation"
+    state_abbr:
+      type: string
+      description: "State/territory two-letter postal abbreviation. Deprecated, superseded by `state`."
+      deprecated: true
     exception:
       type: string
       description: "Placeholder for value indicating special processing instructions"

--- a/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
@@ -40,9 +40,10 @@ namespace Piipan.Match.Orchestrator
         [JsonProperty("exception")]
         public string Exception { get; set; }
 
-        [JsonProperty("state_name")]
-        public string StateName { get; set; }
+        [JsonProperty("state")]
+        public string State { get; set; }
 
+        // Deprecated, duplicates value of `State`
         [JsonProperty("state_abbr")]
         public string StateAbbr { get; set; }
 

--- a/match/src/Piipan.Match.State/MatchResponse.cs
+++ b/match/src/Piipan.Match.State/MatchResponse.cs
@@ -20,8 +20,7 @@ namespace Piipan.Match.State
     {
         public PiiRecord()
         {
-            StateName = Environment.GetEnvironmentVariable("StateName");
-            StateAbbr = Environment.GetEnvironmentVariable("StateAbbr");
+            State = Environment.GetEnvironmentVariable("StateAbbr");
         }
 
         [JsonProperty("last")]
@@ -44,12 +43,19 @@ namespace Piipan.Match.State
         public string Exception { get; set; }
 
         // Read-only
-        [JsonProperty("state_name")]
-        public string StateName { get; }
+        [JsonProperty("state")]
+        public string State { get; }
 
         // Read-only
+        // Deprecated
         [JsonProperty("state_abbr")]
-        public string StateAbbr { get; }
+        public string StateAbbr
+        {
+            get
+            {
+                return State;
+            }
+        }
 
         [JsonProperty("case_id")]
         public string CaseId { get; set; }

--- a/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
@@ -174,10 +174,11 @@ namespace Piipan.Match.Orchestrator.Tests
             Assert.Contains("\"first\": \"First\"", record.ToJson());
             Assert.Contains("\"middle\": null", record.ToJson());
             Assert.Contains("\"exception\": null", record.ToJson());
-            Assert.Contains("\"state_name\": null", record.ToJson());
-            Assert.Contains("\"state_abbr\": null", record.ToJson());
+            Assert.Contains("\"state\": null", record.ToJson());
             Assert.Contains("\"case_id\": \"foo\"", record.ToJson());
 
+            // Deprecated
+            Assert.Contains("\"state_abbr\": null", record.ToJson());
         }
 
         // Malformed data results in BadRequest

--- a/match/tests/Piipan.Match.State.IntegrationTests/ApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.State.IntegrationTests/ApiIntegrationTests.cs
@@ -79,8 +79,10 @@ namespace Piipan.Match.State.IntegrationTests
             Assert.Equal(record.Exception, resultRecord.Matches[0].Exception);
             Assert.Equal(record.CaseId, resultRecord.Matches[0].CaseId);
             Assert.Equal(record.ParticipantId, resultRecord.Matches[0].ParticipantId);
+            Assert.Equal("ea", resultRecord.Matches[0].State);
+
+            // Deprecated
             Assert.Equal("ea", resultRecord.Matches[0].StateAbbr);
-            Assert.Equal("Echo Alpha", resultRecord.Matches[0].StateName);
         }
 
         [Fact]

--- a/match/tests/Piipan.Match.State.Tests/ApiModelTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiModelTests.cs
@@ -9,7 +9,6 @@ namespace Piipan.Match.State.Tests
     {
         void SetEnvironment()
         {
-            Environment.SetEnvironmentVariable("StateName", "Echo Alpha");
             Environment.SetEnvironmentVariable("StateAbbr", "ea");
         }
 
@@ -36,8 +35,10 @@ namespace Piipan.Match.State.Tests
             var record = FullRecord();
 
             // Assert
+            Assert.Equal("ea", record.State);
+
+            // Deprecated
             Assert.Equal("ea", record.StateAbbr);
-            Assert.Equal("Echo Alpha", record.StateName);
         }
 
         [Fact]
@@ -46,7 +47,7 @@ namespace Piipan.Match.State.Tests
             // Arrange
             SetEnvironment();
             var record = FullRecord();
-            var expected = "{\n  \"last\": \"Last\",\n  \"first\": \"First\",\n  \"middle\": \"Middle\",\n  \"ssn\": \"000-00-0000\",\n  \"dob\": \"1970-01-01\",\n  \"exception\": \"Exception\",\n  \"state_name\": \"Echo Alpha\",\n  \"state_abbr\": \"ea\",\n  \"case_id\": \"CaseIdExample\",\n  \"participant_id\": \"ParticipantIdExample\"\n}";
+            var expected = "{\n  \"last\": \"Last\",\n  \"first\": \"First\",\n  \"middle\": \"Middle\",\n  \"ssn\": \"000-00-0000\",\n  \"dob\": \"1970-01-01\",\n  \"exception\": \"Exception\",\n  \"state\": \"ea\",\n  \"state_abbr\": \"ea\",\n  \"case_id\": \"CaseIdExample\",\n  \"participant_id\": \"ParticipantIdExample\"\n}";
 
             // Assert
             Assert.Equal(expected, record.ToJson());
@@ -63,7 +64,7 @@ namespace Piipan.Match.State.Tests
                 Matches = new List<PiiRecord>()
             };
             var expected = "{\n  \"matches\": [\n    {" +
-                    "\n      \"last\": \"Last\",\n      \"first\": \"First\",\n      \"middle\": \"Middle\",\n      \"ssn\": \"000-00-0000\",\n      \"dob\": \"1970-01-01\",\n      \"exception\": \"Exception\",\n      \"state_name\": \"Echo Alpha\",\n      \"state_abbr\": \"ea\",\n" +
+                    "\n      \"last\": \"Last\",\n      \"first\": \"First\",\n      \"middle\": \"Middle\",\n      \"ssn\": \"000-00-0000\",\n      \"dob\": \"1970-01-01\",\n      \"exception\": \"Exception\",\n      \"state\": \"ea\",\n      \"state_abbr\": \"ea\",\n" +
                     "      \"case_id\": \"CaseIdExample\",\n      \"participant_id\": \"ParticipantIdExample\"" +
                     "\n    }\n  ]\n}";
 

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -14,7 +14,6 @@ namespace Piipan.Match.State.Tests
     {
         void SetEnvironment()
         {
-            Environment.SetEnvironmentVariable("StateName", "Echo Alpha");
             Environment.SetEnvironmentVariable("StateAbbr", "ea");
         }
 

--- a/match/tests/docker-compose.yml
+++ b/match/tests/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - statedb
     environment:
       DatabaseConnectionString: "Server=statedb;Database=ea;Port=5432;User Id=postgres;Password=securepass;"
-      StateName: "Echo Alpha"
       StateAbbr: ea
   statedb:
     image: postgres:11-alpine


### PR DESCRIPTION
- Removes `state_name` entirely from state match, orch match, openapi docs, and IaC
- Renames `state_abbr` to `state`, preserving `state_abbr` as a deprecated property

Closes #895.