### PR TITLE
Update Query Tool to use new state API field

### DIFF
--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -21,7 +21,7 @@
                     <td>@record.FirstName @record.MiddleName @record.LastName</td>
                     <td>@Html.DisplayFor(m => record.DateOfBirth)</td>
                     <td>@record.SocialSecurityNum</td>
-                    <td>@record.StateName</td>
+                    <td>@record.State</td>
                     <td>@record.CaseId</td>
                     <td>@record.ParticipantId</td>
                 </tr>

--- a/query-tool/src/Piipan.QueryTool/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool/PiiRecord.cs
@@ -40,13 +40,9 @@ namespace Piipan.QueryTool
         [JsonPropertyName("ssn")]
         public string SocialSecurityNum { get; set; }
 
-        [Display(Name = "StateName")]
-        [JsonPropertyName("state_name")]
-        public string StateName { get; set; }
-
-        [Display(Name = "StateAbbr")]
-        [JsonPropertyName("state_abbr")]
-        public string StateAbbr { get; set; }
+        [Display(Name = "State")]
+        [JsonPropertyName("state")]
+        public string State { get; set; }
 
         [Display(Name = "CaseId")]
         [JsonPropertyName("case_id")]

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -74,8 +74,8 @@ namespace Piipan.QueryTool.Tests
                     ""last"": ""Farrington"",
                     ""ssn"": ""000-00-0000"",
                     ""dob"": ""2021-01-01"",
-                    ""state_abbr"": ""ea"",
-                    ""state_name"": ""Echo Alpha""
+                    ""state"": ""ea"",
+                    ""state_abbr"": ""ea""
                 }]
             }";
             var requestPii = new PiiRecord

--- a/query-tool/tests/Piipan.QueryTool.Tests/OrchestratorApiRequestTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/OrchestratorApiRequestTest.cs
@@ -24,8 +24,8 @@ namespace Piipan.QueryTool.Tests
                         ""last"": ""Farrington"",
                         ""ssn"": ""000-00-0000"",
                         ""dob"": ""2021-01-01"",
-                        ""state_abbr"": ""ea"",
-                        ""state_name"": ""Echo Alpha""
+                        ""state"": ""ea"",
+                        ""state_abbr"": ""ea""
                     }
                 ]
             }";
@@ -60,8 +60,7 @@ namespace Piipan.QueryTool.Tests
             Assert.Equal("Farrington", result.matches[0].LastName);
             Assert.Equal("000-00-0000", result.matches[0].SocialSecurityNum);
             Assert.Equal(new DateTime(2021, 1, 1), result.matches[0].DateOfBirth);
-            Assert.Equal("ea", result.matches[0].StateAbbr);
-            Assert.Equal("Echo Alpha", result.matches[0].StateName);
+            Assert.Equal("ea", result.matches[0].State);
         }
 
         [Fact]


### PR DESCRIPTION
- Remove state_name field from models and templates
- Use state field in templates
- Update tests

Follow on work from #954.
Closes #953.