### PR TITLE
Stream PSQL logs to event hub

### DIFF
--- a/iac/arm-templates/database-metrics.json
+++ b/iac/arm-templates/database-metrics.json
@@ -75,6 +75,9 @@
         "privateDnsZoneName": {
             "type": "string",
             "defaultValue": "privatelink.postgres.database.azure.com"
+        },
+        "eventHubName": {
+            "type": "string"
         }
     },
     "resources": [
@@ -122,6 +125,9 @@
                             "type": "string"
                         },
                         "privateDnsZoneName": {
+                            "type": "string"
+                        },
+                        "eventHubName": {
                             "type": "string"
                         }
                     },
@@ -272,6 +278,25 @@
                                     }
                                 ]
                             }
+                        },
+                        {
+                            /* https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/resource-manager-diagnostic-settings */
+                            "apiVersion": "2017-05-01-preview",
+                            "type": "Microsoft.DBforPostgreSQL/servers/providers/diagnosticSettings",
+                            "name": "[concat(parameters('serverName'), '/Microsoft.Insights/stream-logs-to-event-hub')]",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.DBforPostgreSQL/servers', parameters('serverName'))]"
+                            ],
+                            "properties": {
+                                "eventHubAuthorizationRuleId": "[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', parameters('eventHubName'), '/authorizationrules/RootManageSharedAccessKey')]",
+                                "eventHubName": "logs",
+                                "logs": [
+                                    {
+                                        "category": "PostgreSQLLogs",
+                                        "enabled": true
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },
@@ -307,6 +332,9 @@
                     },
                     "privateDnsZoneName": {
                         "value": "[parameters('privateDnsZoneName')]"
+                    },
+                    "eventHubName": {
+                        "value": "[parameters('eventHubName')]"
                     }
                 }
             }

--- a/iac/arm-templates/participant-records.json
+++ b/iac/arm-templates/participant-records.json
@@ -45,6 +45,9 @@
         "privateDnsZoneName": {
             "type": "string",
             "defaultValue": "privatelink.postgres.database.azure.com"
+        },
+        "eventHubName": {
+            "type": "string"
         }
     },
     "variables": {
@@ -91,6 +94,9 @@
                             "type": "string"
                         },
                         "privateDnsZoneName": {
+                            "type": "string"
+                        },
+                        "eventHubName": {
                             "type": "string"
                         }
                     },
@@ -241,6 +247,31 @@
                                     }
                                 ]
                             }
+                        },
+                        /*"type": "Microsoft.DBforPostgreSQL/servers",
+                            "apiVersion": "2017-12-01-preview",
+                            "kind": "",
+                            "location": "[parameters('location')]",
+                            "tags": "[parameters('resourceTags')]",
+                            "name": "[parameters('serverName')]",*/
+                        {
+                            /* https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/resource-manager-diagnostic-settings */
+                            "apiVersion": "2017-05-01-preview",
+                            "type": "Microsoft.DBforPostgreSQL/servers/providers/diagnosticSettings",
+                            "name": "[concat(parameters('serverName'), '/Microsoft.Insights/stream-logs-to-event-hub')]",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.DBforPostgreSQL/servers', parameters('serverName'))]"
+                            ],
+                            "properties": {
+                                "eventHubAuthorizationRuleId": "[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', parameters('eventHubName'), '/authorizationrules/RootManageSharedAccessKey')]",
+                                "eventHubName": "logs",
+                                "logs": [
+                                    {
+                                        "category": "PostgreSQLLogs",
+                                        "enabled": true
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },
@@ -276,6 +307,9 @@
                     },
                     "privateDnsZoneName": {
                         "value": "[parameters('privateDnsZoneName')]"
+                    },
+                    "eventHubName": {
+                        "value": "[parameters('eventHubName')]"
                     }
                 }
             }

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -89,7 +89,8 @@ main () {
       subnetName="$DB_2_SUBNET_NAME" \
       privateEndpointName="$CORE_DB_PRIVATE_ENDPOINT_NAME" \
       privateDnsZoneName="$PRIVATE_DNS_ZONE" \
-      resourceTags="$RESOURCE_TAGS"
+      resourceTags="$RESOURCE_TAGS" \
+      eventHubName="$EVENT_HUB_NAME"
 
   ### Database stuff
   # Create database within db server (command is idempotent)

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -177,7 +177,8 @@ main () {
       vnetName="$VNET_NAME" \
       subnetName="$DB_SUBNET_NAME" \
       privateEndpointName="$PRIVATE_ENDPOINT_NAME" \
-      privateDnsZoneName="$PRIVATE_DNS_ZONE"
+      privateDnsZoneName="$PRIVATE_DNS_ZONE" \
+      eventHubName="$EVENT_HUB_NAME"
 
 
   # The AD admin can't be specified in the PostgreSQL ARM template,


### PR DESCRIPTION
- Participant records DB
- Metrics "core" DB
- Only streams `PostgreSQLLogs` logs, does not include performance-related `QueryStoreRuntimeStatistics` or `QueryStoreWaitStatistics` logs

Partially addresses #969 