### PR TITLE
Revert monitoring to accommodate AzureUSGoverment

### DIFF
--- a/iac/arm-templates/blob-storage.json
+++ b/iac/arm-templates/blob-storage.json
@@ -10,12 +10,6 @@
         },
         "storageAccountName": {
             "type": "string"
-        },
-        "coreResourceGroup": {
-            "type": "String"
-        },
-        "eventHubName": {
-            "type": "String"
         }
     },
     "variables": {
@@ -52,34 +46,6 @@
                     ]
                 }
             ]
-        },
-        {
-            /* https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/resource-manager-diagnostic-settings#diagnostic-setting-for-azure-storage */
-            "apiVersion": "2017-05-01-preview",
-            "type": "Microsoft.Storage/storageAccounts/blobServices/providers/diagnosticSettings",
-            "name": "[concat(variables('uniqueStorageName'), '/default/Microsoft.Insights/stream-logs-to-event-hub')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('uniqueStorageName'))]"
-            ],
-            "properties": {
-                "eventHubAuthorizationRuleId": "[concat(subscription().id, '/resourceGroups/', parameters('coreResourceGroup'), '/providers/Microsoft.EventHub/namespaces/', parameters('eventHubName'), '/authorizationrules/RootManageSharedAccessKey')]",
-                "eventHubName": "logs",
-                "logs": [
-                    /* Category names from `az monitor diagnostic-settings categories list` */
-                    {
-                        "category": "StorageRead",
-                        "enabled": true
-                    },
-                    {
-                        "category": "StorageWrite",
-                        "enabled": true
-                    },
-                    {
-                        "category": "StorageDelete",
-                        "enabled": true
-                    }
-                ]
-            }
         }
     ],
     "outputs": {

--- a/iac/arm-templates/event-hub-monitoring.json
+++ b/iac/arm-templates/event-hub-monitoring.json
@@ -22,7 +22,7 @@
     "resources": [
         {
             "type": "Microsoft.EventHub/namespaces",
-            "apiVersion": "2021-01-01-preview",
+            "apiVersion": "2018-01-01-preview",
             "name": "[variables('namespace')]",
             "location": "[parameters('location')]",
             "tags": "[parameters('resourceTags')]",

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -145,9 +145,7 @@ main () {
       --parameters \
         storageAccountName="$func_stor_name" \
         resourceTags="$RESOURCE_TAGS" \
-        location="$LOCATION" \
-        coreResourceGroup="$RESOURCE_GROUP" \
-        eventHubName="$EVENT_HUB_NAME"
+        location="$LOCATION"
   done < states.csv
 
   # Avoid echoing passwords in a manner that may show up in process listing,


### PR DESCRIPTION
- Event Hub API version 2021-01-01-preview not supported in AzureUSGoverment:
  https://portal.azure.us/#blade/HubsExtension/ArmExplorerBlade
- Azure Monitor is not supported for Azure Blob Storage in AzureUSGovernment, reverts #950:
  https://docs.microsoft.com/en-us/azure/storage/blobs/monitor-blob-storage?tabs=azure-portal