### PR TITLE
Change working dir to app tree before publishing

### DIFF
--- a/dashboard/build.bash
+++ b/dashboard/build.bash
@@ -20,6 +20,12 @@ run_deploy () {
   verify_cloud
   set_constants
 
+
+  # Don't publish at solution level as it will publish both src and tests
+  # to the same directory resulting in a failed deployment:
+  # https://github.com/dotnet/sdk/issues/7238
+  pushd "$(dirname "$0")"/src/Piipan.Dashboard
+
   echo "Publishing project"
   dotnet publish -o ./artifacts
   echo "Deploying to Azure Environment ${azure_env}"
@@ -31,6 +37,8 @@ run_deploy () {
     -g "$RESOURCE_GROUP" \
     -n "$DASHBOARD_APP_NAME" \
     --src ./artifacts/dashboard.zip
+
+  popd
 }
 
 main "$@"

--- a/query-tool/build.bash
+++ b/query-tool/build.bash
@@ -21,6 +21,12 @@ run_deploy () {
   source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
   set_constants
+
+  # Don't publish at solution level as it will publish both src and tests
+  # to the same directory resulting in a failed deployment:
+  # https://github.com/dotnet/sdk/issues/7238
+  pushd "$(dirname "$0")"/src/Piipan.QueryTool
+
   echo "Publishing project"
   dotnet publish -o ./artifacts
   echo "Deploying to Azure Environment ${azure_env}"
@@ -32,6 +38,8 @@ run_deploy () {
     -g "$RESOURCE_GROUP" \
     -n "$QUERY_TOOL_APP_NAME" \
     --src ./artifacts/dashboard.zip
+
+  popd
 }
 
 main "$@"


### PR DESCRIPTION
Closes #949.

This avoids problem where solution file publishes both src and test trees resulting in a failed deploy. It doesn't solve the problem exactly as #949 suggests, but it should get the job done and is similar to how the deploy is written for our function apps.