### PR TITLE
Add benefits_end_month to openapi examples

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -104,7 +104,8 @@ Queries all state databases for any PII records that are an exact match to the l
       "state_abbr": "eb",
       "exception": "string",
       "case_id": "string",
-      "participant_id": "string"
+      "participant_id": "string",
+      "benefits_end_month": "2021-01"
     },
     {
       "first": null,
@@ -116,7 +117,8 @@ Queries all state databases for any PII records that are an exact match to the l
       "state_abbr": "ec",
       "exception": null,
       "case_id": "string",
-      "participant_id": null
+      "participant_id": null,
+      "benefits_end_month": null
     }
   ]
 }

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -140,6 +140,7 @@ paths:
                         exception: string
                         case_id: string
                         participant_id: string
+                        benefits_end_month: 2021-01
                 None:
                   description: A query returning no matches
                   value:
@@ -160,6 +161,7 @@ paths:
                         exception: string
                         case_id: string
                         participant_id: string
+                        benefits_end_month: 2021-01
                       - first: null
                         middle: null
                         last: string
@@ -170,6 +172,7 @@ paths:
                         exception: null
                         case_id: string
                         participant_id: null
+                        benefits_end_month: null
         '400':
           description: Bad request. Missing one of the required properties in the request body.
   '/lookup_ids/{id}':

--- a/match/docs/openapi/schemas/pii-record.yaml
+++ b/match/docs/openapi/schemas/pii-record.yaml
@@ -57,6 +57,7 @@ PiiRecordExamples:
     exception: "string"
     case_id: "string"
     participant_id: "string"
+    benefits_end_month: "2021-01"
   AllEB:
     first: "string"
     middle: "string"
@@ -68,6 +69,7 @@ PiiRecordExamples:
     exception: "string"
     case_id: "string"
     participant_id: "string"
+    benefits_end_month: "2021-01"
   Required:
     first: null
     middle: null
@@ -79,3 +81,4 @@ PiiRecordExamples:
     exception: null
     case_id: "string"
     participant_id: null
+    benefits_end_month: null


### PR DESCRIPTION
With #898 complete, adds new `benefits_end_month` field to examples.