### PR TITLE
Deprecate metrics resource group in tts/test

### DIFF
--- a/iac/env/tts/test.bash
+++ b/iac/env/tts/test.bash
@@ -13,7 +13,7 @@ RESOURCE_GROUP=rg-core-$ENV
 MATCH_RESOURCE_GROUP=rg-match-$ENV
 
 # Resource group for metrics
-METRICS_RESOURCE_GROUP=rg-metrics-$ENV
+METRICS_RESOURCE_GROUP=$RESOURCE_GROUP
 
 # Prefix for resource identifiers
 PREFIX=tts


### PR DESCRIPTION
This change keeps tts/test in sync with tts/dev