### PR TITLE
Add protect_location field to bulk upload import

### DIFF
--- a/ddl/per-state.sql
+++ b/ddl/per-state.sql
@@ -27,10 +27,11 @@ CREATE TABLE IF NOT EXISTS participants(
 	ssn text NOT NULL,
 	exception text,
 	upload_id integer REFERENCES uploads (id),
-  	case_id text NOT NULL,
-  	participant_id text,
+    	case_id text NOT NULL,
+    	participant_id text,
 	benefits_end_date date,
-  	recent_benefit_months date[]
+    	recent_benefit_months date[],
+    	protect_location boolean
 );
 
 COMMENT ON TABLE participants IS 'Program participant Personally Identifiable Information (PII)';
@@ -44,6 +45,7 @@ COMMENT ON COLUMN participants.case_id IS 'Participant''s state-specific case id
 COMMENT ON COLUMN participants.participant_id IS 'Participant''s state-specific identifier';
 COMMENT ON COLUMN participants.benefits_end_date IS 'Participant''s ending benefits date';
 COMMENT ON COLUMN participants.recent_benefit_months IS 'Participant''s recent benefit months';
+COMMENT ON COLUMN participants.protect_location IS 'Participant''s vulnerability status';
 
 CREATE INDEX IF NOT EXISTS participants_ssn_idx ON participants (ssn, upload_id);
 

--- a/etl/docs/csv/example.csv
+++ b/etl/docs/csv/example.csv
@@ -1,11 +1,11 @@
-last,first,middle,dob,ssn,exception,case_id,participant_id,benefits_end_month,recent_benefit_months
-Farrington,Theodore,Carri,1931-10-13,000-12-3456,ReasonXYZ,caseid1,,2021-05,2021-04 2021-03 2021-02
-Lynn,Wesley,Eura,1940-08-01,000-12-3457,,caseid2,,,2021-05 2021-04
-Cullen,S,,2015-01-01,000-12-3458,,caseid3,,,2021-05
-Alger,Megan,Kamala,2020-01-25,000-12-3459,,caseid4,,,
-Yu,,,1973-11-02,000-12-3460,,caseid5,,,
-Wallen,Homer,Madonna,1913-04-04,000-12-3461,ReasonXYZ,caseid6,,,
-Benner,Cristina,Wilton,1961-07-22,000-12-3462,,caseid7,,,
-Whittaker,Troy,G,1985-02-15,000-12-3463,,caseid8,,,
-Grier,Paulette,Tequila,1997-12-24,000-12-3464,,caseid9,,,
-Suarez,Amelia,Shavonda,1950-01-19,000-12-3465,,caseid10,participantid1,,
+last,first,middle,dob,ssn,exception,case_id,participant_id,benefits_end_month,recent_benefit_months,protect_location
+Farrington,Theodore,Carri,1931-10-13,000-12-3456,ReasonXYZ,caseid1,,2021-05,2021-04 2021-03 2021-02,true
+Lynn,Wesley,Eura,1940-08-01,000-12-3457,,caseid2,,,2021-05 2021-04,false
+Cullen,S,,2015-01-01,000-12-3458,,caseid3,,,2021-05,
+Alger,Megan,Kamala,2020-01-25,000-12-3459,,caseid4,,,,
+Yu,,,1973-11-02,000-12-3460,,caseid5,,,,
+Wallen,Homer,Madonna,1913-04-04,000-12-3461,ReasonXYZ,caseid6,,,,
+Benner,Cristina,Wilton,1961-07-22,000-12-3462,,caseid7,,,,
+Whittaker,Troy,G,1985-02-15,000-12-3463,,caseid8,,,,
+Grier,Paulette,Tequila,1997-12-24,000-12-3464,,caseid9,,,,
+Suarez,Amelia,Shavonda,1950-01-19,000-12-3465,,caseid10,participantid1,,,

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -71,6 +71,23 @@
         "constraints": {
           "pattern": "([0-9]{4}-[0-9]{1,2} ?){0,3}"
         }
+      },
+      {
+        "name": "protect_location",
+        "type": "boolean",
+        "description": "Set true to indicate location protection for vulnerable individuals. Null or empty values will be treated as true throughout the system.",
+        "trueValues": [
+          "true",
+          "True",
+          "TRUE",
+          "1"
+        ],
+        "falseValues": [
+          "false",
+          "False",
+          "FALSE",
+          "0"
+        ]
       }
     ]
   }

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -77,16 +77,10 @@
         "type": "boolean",
         "description": "Set true to indicate location protection for vulnerable individuals. Null or empty values will be treated as true throughout the system.",
         "trueValues": [
-          "true",
-          "True",
-          "TRUE",
-          "1"
+          "true"
         ],
         "falseValues": [
-          "false",
-          "False",
-          "FALSE",
-          "0"
+          "false"
         ]
       }
     ]

--- a/etl/src/Piipan.Etl/BulkUpload.cs
+++ b/etl/src/Piipan.Etl/BulkUpload.cs
@@ -147,8 +147,8 @@ namespace Piipan.Etl
                     using (var cmd = factory.CreateCommand())
                     {
                         cmd.Connection = conn;
-                        cmd.CommandText = "INSERT INTO participants (last, first, middle, dob, ssn, exception, upload_id, case_id, participant_id, benefits_end_date, recent_benefit_months) " +
-                            "VALUES (@last, @first, @middle, @dob, @ssn, @exception, @upload_id, @case_id, @participant_id, @benefits_end_date, @recent_benefit_months::date[])";
+                        cmd.CommandText = "INSERT INTO participants (last, first, middle, dob, ssn, exception, upload_id, case_id, participant_id, benefits_end_date, recent_benefit_months, protect_location) " +
+                            "VALUES (@last, @first, @middle, @dob, @ssn, @exception, @upload_id, @case_id, @participant_id, @benefits_end_date, @recent_benefit_months::date[], @protect_location)";
 
                         AddWithValue(cmd, DbType.String, "last", record.Last);
                         AddWithValue(cmd, DbType.String, "first", (object)record.First ?? DBNull.Value);
@@ -161,6 +161,7 @@ namespace Piipan.Etl
                         AddWithValue(cmd, DbType.String, "participant_id", (object)record.ParticipantId ?? DBNull.Value);
                         AddWithValue(cmd, DbType.DateTime, "benefits_end_date", (object)record.BenefitsEndDate ?? DBNull.Value);
                         AddWithValue(cmd, DbType.Object, "recent_benefit_months", (object)DateFormatters.FormatDatesAsPgArray(record.RecentBenefitMonths));
+                        AddWithValue(cmd, DbType.Boolean, "protect_location", (object)record.ProtectLocation ?? DBNull.Value);
 
                         cmd.ExecuteNonQuery();
                     }

--- a/etl/src/Piipan.Etl/PiiRecord.cs
+++ b/etl/src/Piipan.Etl/PiiRecord.cs
@@ -30,8 +30,8 @@ namespace Piipan.Etl
         // Set Boolean values here, based on:
         // https://joshclose.github.io/CsvHelper/examples/configuration/attributes/
         // Values should mimic what is set in the Bulk Upload import schema
-        [BooleanTrueValues("true","True","TRUE","1")]
-        [BooleanFalseValues("false","False","FALSE","0")]
+        [BooleanTrueValues("true")]
+        [BooleanFalseValues("false")]
         public bool? ProtectLocation { get; set; }
     }
 }

--- a/etl/src/Piipan.Etl/PiiRecord.cs
+++ b/etl/src/Piipan.Etl/PiiRecord.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using CsvHelper.Configuration.Attributes;
 
 #nullable enable
 
@@ -26,5 +27,11 @@ namespace Piipan.Etl
         public string? Exception { get; set; }
         public DateTime? BenefitsEndDate { get; set; }
         public List<DateTime> RecentBenefitMonths { get; set; } = new List<DateTime>();
+        // Set Boolean values here, based on:
+        // https://joshclose.github.io/CsvHelper/examples/configuration/attributes/
+        // Values should mimic what is set in the Bulk Upload import schema
+        [BooleanTrueValues("true","True","TRUE","1")]
+        [BooleanFalseValues("false","False","FALSE","0")]
+        public bool? ProtectLocation { get; set; }
     }
 }

--- a/etl/src/Piipan.Etl/PiiRecordMap.cs
+++ b/etl/src/Piipan.Etl/PiiRecordMap.cs
@@ -85,6 +85,9 @@ namespace Piipan.Etl
                 })
                 .TypeConverter<ToMonthEndArrayConverter>();
 
+            Map(m => m.ProtectLocation).Name("protect_location")
+                .TypeConverterOption.NullValues(string.Empty);
+
         }
     }
 

--- a/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
+++ b/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
@@ -17,7 +17,7 @@ namespace Piipan.Etl.Tests
             var writer = new StreamWriter(stream);
             if (includeHeader)
             {
-                writer.WriteLine("last,first,middle,dob,ssn,exception,case_id,participant_id,benefits_end_month,recent_benefit_months");
+                writer.WriteLine("last,first,middle,dob,ssn,exception,case_id,participant_id,benefits_end_month,recent_benefit_months,protect_location");
             }
             foreach (var record in records)
             {
@@ -57,7 +57,8 @@ namespace Piipan.Etl.Tests
                   new DateTime(2021, 5, 31),
                   new DateTime(2021, 4, 30),
                   new DateTime(2021, 3, 31)
-                }
+                },
+                ProtectLocation = true
             };
         }
 
@@ -103,7 +104,7 @@ namespace Piipan.Etl.Tests
         {
             var logger = Mock.Of<ILogger>();
             var stream = CsvFixture(new string[] {
-                "Last,First,Middle,1970-01-01,000-00-0000,Exception,CaseId,ParticipantId,1970-01,2021-05 2021-04 2021-03"
+                "Last,First,Middle,1970-01-01,000-00-0000,Exception,CaseId,ParticipantId,1970-01,2021-05 2021-04 2021-03,true"
             });
 
             var records = BulkUpload.Read(stream, logger);
@@ -119,6 +120,7 @@ namespace Piipan.Etl.Tests
                 Assert.Equal("ParticipantId", record.ParticipantId);
                 Assert.Equal(new DateTime(1970, 1, 31), record.BenefitsEndDate);
                 Assert.Equal(new DateTime(2021, 5, 31), record.RecentBenefitMonths[0]);
+                Assert.Equal(true, record.ProtectLocation);
             }
         }
 
@@ -139,6 +141,7 @@ namespace Piipan.Etl.Tests
                 Assert.Null(record.ParticipantId);
                 Assert.Null(record.BenefitsEndDate);
                 Assert.Empty(record.RecentBenefitMonths);
+                Assert.Null(record.ProtectLocation);
             }
         }
 
@@ -156,6 +159,23 @@ namespace Piipan.Etl.Tests
 
             var records = BulkUpload.Read(stream, logger);
             Assert.Throws<CsvHelper.FieldValidationException>(() =>
+            {
+                foreach (var record in records)
+                {
+                    ;
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData("Last,,,1970-01-01,000-00-0000,,caseId,,,,foobar")] // Malformed Protect Location
+        public void ExpectTypeConverterError(String inline)
+        {
+            var logger = Mock.Of<ILogger>();
+            var stream = CsvFixture(new string[] { inline });
+
+            var records = BulkUpload.Read(stream, logger);
+            Assert.Throws<CsvHelper.TypeConversion.TypeConverterException>(() =>
             {
                 foreach (var record in records)
                 {

--- a/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
+++ b/etl/tests/Piipan.Etl.Tests/BulkUploadTests.cs
@@ -202,6 +202,23 @@ namespace Piipan.Etl.Tests
             });
         }
 
+        [Theory]
+        [InlineData("Last,,,1970-01-01,000-00-0000,,caseId,,,")] // Missing last column
+        public void ExpectMissingFieldError(String inline)
+        {
+            var logger = Mock.Of<ILogger>();
+            var stream = CsvFixture(new string[] { inline });
+
+            var records = BulkUpload.Read(stream, logger);
+            Assert.Throws<CsvHelper.MissingFieldException>(() =>
+            {
+                foreach (var record in records)
+                {
+                    ;
+                }
+            });
+        }
+
         [Fact]
         public async void CountInserts()
         {


### PR DESCRIPTION
Closes #850 

## Notes
- I was unable to get a mishandled Boolean field to throw a Validation Exception. They seem to be caught at the conversion level. After some googling, I [found](https://stackoverflow.com/a/22998705) that a custom validator may be the only way to catch validation errors with booleans. A custom validator didn't seem necessary at this time, since acceptable values for true and false are provided [in other ways](https://joshclose.github.io/CsvHelper/examples/configuration/attributes/). 

## Changelog
### Adds
- Adds optional `protect_location` boolean field to Bulk Upload API 
- Adds `protect_location` column to example upload csv

## Deploy
- Since database schema is changed, I'll merge once iac has been run on tts/dev for these changes. 