### PR TITLE
Add protect_location to match query api response

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -164,7 +164,7 @@ Status Code **200**
 |»» participant_id|string|false|none|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |»» benefits_end_month|string|false|none|Participant's ending benefits month|
 |»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
-|»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. Null values are treated as true, and individual's location info will not be shared with matching state.|
+|»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -164,7 +164,7 @@ Status Code **200**
 |»» participant_id|string|false|none|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |»» benefits_end_month|string|false|none|Participant's ending benefits month|
 |»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
-|»» protect_location|boolean¦null|false|none|Indicates location protection for vulnerable individuals. Null values provided to the system are treated as true.|
+|»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. Null values are treated as true, and individual's location info will not be shared with matching state.|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -78,7 +78,8 @@ Queries all state databases for any PII records that are an exact match to the l
         "2021-05",
         "2021-04",
         "2021-03"
-      ]
+      ],
+      "protect_location": true
     }
   ]
 }
@@ -115,7 +116,8 @@ Queries all state databases for any PII records that are an exact match to the l
         "2021-05",
         "2021-04",
         "2021-03"
-      ]
+      ],
+      "protect_location": true
     },
     {
       "first": null,
@@ -128,7 +130,8 @@ Queries all state databases for any PII records that are an exact match to the l
       "exception": null,
       "case_id": "string",
       "participant_id": null,
-      "benefits_end_month": null
+      "benefits_end_month": null,
+      "protect_location": null
     }
   ]
 }
@@ -161,6 +164,7 @@ Status Code **200**
 |»» participant_id|string|false|none|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |»» benefits_end_month|string|false|none|Participant's ending benefits month|
 |»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
+|»» protect_location|boolean¦null|false|none|Indicates location protection for vulnerable individuals. Null values provided to the system are treated as true.|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -137,7 +137,7 @@ paths:
                           type: boolean
                           nullable: true
                           example: true
-                          description: 'Location protection flag for vulnerable individuals. Null values are treated as true, and individual''s location info will not be shared with matching state.'
+                          description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
               examples:
                 Single:
                   description: A query returning a single match

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -133,6 +133,11 @@ paths:
                           minItems: 0
                           maxItems: 3
                           description: 'List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.'
+                        protect_location:
+                          type: boolean
+                          nullable: true
+                          example: true
+                          description: Indicates location protection for vulnerable individuals. Null values provided to the system are treated as true.
               examples:
                 Single:
                   description: A query returning a single match
@@ -154,6 +159,7 @@ paths:
                           - 2021-05
                           - 2021-04
                           - 2021-03
+                        protect_location: true
                 None:
                   description: A query returning no matches
                   value:
@@ -179,6 +185,7 @@ paths:
                           - 2021-05
                           - 2021-04
                           - 2021-03
+                        protect_location: true
                       - first: null
                         middle: null
                         last: string
@@ -190,6 +197,7 @@ paths:
                         case_id: string
                         participant_id: null
                         benefits_end_month: null
+                        protect_location: null
         '400':
           description: Bad request. Missing one of the required properties in the request body.
   '/lookup_ids/{id}':

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -137,7 +137,7 @@ paths:
                           type: boolean
                           nullable: true
                           example: true
-                          description: Indicates location protection for vulnerable individuals. Null values provided to the system are treated as true.
+                          description: 'Location protection flag for vulnerable individuals. Null values are treated as true, and individual''s location info will not be shared with matching state.'
               examples:
                 Single:
                   description: A query returning a single match

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -75,7 +75,7 @@
       {
         "name": "protect_location",
         "type": "boolean",
-        "description": "Set true to indicate location protection for vulnerable individuals. Null or empty values will be treated as true throughout the system.",
+        "description": "Location protection flag for vulnerable individuals. Null values are treated as true, and individual's location info will not be shared with matching state.",
         "trueValues": [
           "true",
           "True",

--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -75,7 +75,7 @@
       {
         "name": "protect_location",
         "type": "boolean",
-        "description": "Location protection flag for vulnerable individuals. Null values are treated as true, and individual's location info will not be shared with matching state.",
+        "description": "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Null values can be provided if the risk of harm has not been assessed.",
         "trueValues": [
           "true",
           "True",

--- a/match/docs/openapi/schemas/pii-record.yaml
+++ b/match/docs/openapi/schemas/pii-record.yaml
@@ -57,7 +57,7 @@ PiiRecord:
       type: boolean
       nullable: true
       example: true
-      description: "Location protection flag for vulnerable individuals. Null values are treated as true, and individual's location info will not be shared with matching state."
+      description: "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values."
 
 PiiRecordExamples:
   All:

--- a/match/docs/openapi/schemas/pii-record.yaml
+++ b/match/docs/openapi/schemas/pii-record.yaml
@@ -53,6 +53,11 @@ PiiRecord:
       minItems: 0
       maxItems: 3
       description: "List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month."
+    protect_location:
+      type: boolean
+      nullable: true
+      example: true
+      description: "Indicates location protection for vulnerable individuals. Null values provided to the system are treated as true."
 
 PiiRecordExamples:
   All:
@@ -71,6 +76,7 @@ PiiRecordExamples:
       - "2021-05"
       - "2021-04"
       - "2021-03"
+    protect_location: true
   AllEB:
     first: "string"
     middle: "string"
@@ -87,6 +93,7 @@ PiiRecordExamples:
       - "2021-05"
       - "2021-04"
       - "2021-03"
+    protect_location: true
   Required:
     first: null
     middle: null
@@ -99,3 +106,4 @@ PiiRecordExamples:
     case_id: "string"
     participant_id: null
     benefits_end_month: null
+    protect_location: null

--- a/match/docs/openapi/schemas/pii-record.yaml
+++ b/match/docs/openapi/schemas/pii-record.yaml
@@ -57,7 +57,7 @@ PiiRecord:
       type: boolean
       nullable: true
       example: true
-      description: "Indicates location protection for vulnerable individuals. Null values provided to the system are treated as true."
+      description: "Location protection flag for vulnerable individuals. Null values are treated as true, and individual's location info will not be shared with matching state."
 
 PiiRecordExamples:
   All:

--- a/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
+++ b/match/src/Piipan.Match.Orchestrator/MatchResponse.cs
@@ -62,6 +62,9 @@ namespace Piipan.Match.Orchestrator
         [JsonConverter(typeof(JsonConverters.MonthEndArrayConverter))]
         public List<DateTime> RecentBenefitMonths { get; set; } = new List<DateTime>();
 
+        [JsonProperty("protect_location")]
+        public bool? ProtectLocation { get; set; }
+
         public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);

--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -100,7 +100,7 @@ namespace Piipan.Match.State
                 last = request.Query.Last,
                 first = request.Query.First,
             };
-            var sql = "SELECT upload_id, first, last, middle, dob, ssn, exception, case_id CaseId, participant_id ParticipantId, benefits_end_date BenefitsEndMonth, recent_benefit_months RecentBenefitMonths FROM participants " +
+            var sql = "SELECT upload_id, first, last, middle, dob, ssn, exception, case_id CaseId, participant_id ParticipantId, benefits_end_date BenefitsEndMonth, recent_benefit_months RecentBenefitMonths, protect_location ProtectLocation FROM participants " +
                         "WHERE ssn=@ssn AND dob=@dob AND upper(last)=upper(@last) " +
                         "AND upload_id=(SELECT id FROM uploads ORDER BY id DESC LIMIT 1)";
 

--- a/match/src/Piipan.Match.State/MatchResponse.cs
+++ b/match/src/Piipan.Match.State/MatchResponse.cs
@@ -72,6 +72,9 @@ namespace Piipan.Match.State
         [JsonConverter(typeof(JsonConverters.MonthEndArrayConverter))]
         public List<DateTime> RecentBenefitMonths { get; set; } = new List<DateTime>();
 
+        [JsonProperty("protect_location")]
+        public bool? ProtectLocation { get; set; }
+
         public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);

--- a/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
@@ -39,7 +39,8 @@ namespace Piipan.Match.Orchestrator.Tests
                   new DateTime(2021, 5, 31),
                   new DateTime(2021, 4, 30),
                   new DateTime(2021, 3, 31)
-                }
+                },
+                ProtectLocation = true
             };
         }
 
@@ -171,7 +172,7 @@ namespace Piipan.Match.Orchestrator.Tests
         [Fact]
         public void PiiRecordJson()
         {
-            var json = @"{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '000000000', case_id: 'foo', benefits_end_month: '2020-01', recent_benefit_months: ['2019-12', '2019-11', '2019-10']}";
+            var json = @"{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '000000000', case_id: 'foo', benefits_end_month: '2020-01', recent_benefit_months: ['2019-12', '2019-11', '2019-10'], protect_location: true}";
             var record = JsonConvert.DeserializeObject<PiiRecord>(json);
 
             string jsonRecord = record.ToJson();
@@ -189,6 +190,7 @@ namespace Piipan.Match.Orchestrator.Tests
             Assert.Contains("\"2019-12\",", jsonRecord);
             Assert.Contains("\"2019-11\",", jsonRecord);
             Assert.Contains("\"2019-10\"", jsonRecord);
+            Assert.Contains("\"protect_location\": true", jsonRecord);
 
             // Deprecated
             Assert.Contains("\"state_abbr\": null", record.ToJson());

--- a/match/tests/Piipan.Match.State.IntegrationTests/ApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.State.IntegrationTests/ApiIntegrationTests.cs
@@ -30,7 +30,8 @@ namespace Piipan.Match.State.IntegrationTests
                   new DateTime(2021, 5, 31),
                   new DateTime(2021, 4, 30),
                   new DateTime(2021, 3, 31)
-                }
+                },
+                ProtectLocation = true
             };
         }
 
@@ -89,6 +90,7 @@ namespace Piipan.Match.State.IntegrationTests
             Assert.Equal("ea", resultRecord.Matches[0].State);
             Assert.Equal(record.BenefitsEndMonth, resultRecord.Matches[0].BenefitsEndMonth);
             Assert.Equal(record.RecentBenefitMonths, resultRecord.Matches[0].RecentBenefitMonths);
+            Assert.Equal(record.ProtectLocation, resultRecord.Matches[0].ProtectLocation);
         }
 
         [Fact]
@@ -143,7 +145,8 @@ namespace Piipan.Match.State.IntegrationTests
                   new DateTime(2021, 5, 31),
                   new DateTime(2021, 4, 30),
                   new DateTime(2021, 3, 31)
-                }
+                },
+                ProtectLocation = true
             };
             var logger = Mock.Of<ILogger>();
             var mockRequest = MockRequest(JsonBody(query));
@@ -191,7 +194,7 @@ namespace Piipan.Match.State.IntegrationTests
         }
 
         [Fact]
-        public async void BenefitsEndMonthCanBeNull()
+        public async void NullPropertiesCanBeNull()
         {
             var query = "{last: 'Farrington', first: 'Foo', middle: 'Bar', dob: '1931-10-13', ssn: '000-12-3456'}";
             var record = new PiiRecord
@@ -215,11 +218,13 @@ namespace Piipan.Match.State.IntegrationTests
             var resultRecord = result.Value as MatchQueryResponse;
 
             // Assert
+            Assert.Null(resultRecord.Matches[0].ParticipantId);
             Assert.Null(resultRecord.Matches[0].BenefitsEndMonth);
+            Assert.Null(resultRecord.Matches[0].ProtectLocation);
         }
 
         [Fact]
-        public async void RecentBenefitMonthsCanBeEmpty()
+        public async void EmptyValuesCanBeEmpty()
         {
             var query = "{last: 'Farrington', first: 'Foo', middle: 'Bar', dob: '1931-10-13', ssn: '000-12-3456'}";
             var record = new PiiRecord

--- a/match/tests/Piipan.Match.State.IntegrationTests/DbFixture.cs
+++ b/match/tests/Piipan.Match.State.IntegrationTests/DbFixture.cs
@@ -119,7 +119,8 @@ namespace Piipan.Match.State.IntegrationTests
                         case_id text NOT NULL,
                         participant_id text,
                         benefits_end_date date,
-                        recent_benefit_months date[]
+                        recent_benefit_months date[],
+                        protect_location boolean
                       );";
                     cmd.ExecuteNonQuery();
                 }
@@ -166,8 +167,8 @@ namespace Piipan.Match.State.IntegrationTests
                 using (var cmd = factory.CreateCommand())
                 {
                     cmd.Connection = conn;
-                    cmd.CommandText = "INSERT INTO participants (last, first, middle, dob, ssn, exception, upload_id, case_id, participant_id, benefits_end_date, recent_benefit_months) " +
-                           "VALUES (@last, @first, @middle, @dob, @ssn, @exception, @upload_id, @case_id, @participant_id, @benefits_end_date, @recent_benefit_months::date[])";
+                    cmd.CommandText = "INSERT INTO participants (last, first, middle, dob, ssn, exception, upload_id, case_id, participant_id, benefits_end_date, recent_benefit_months, protect_location) " +
+                           "VALUES (@last, @first, @middle, @dob, @ssn, @exception, @upload_id, @case_id, @participant_id, @benefits_end_date, @recent_benefit_months::date[], @protect_location)";
 
                     AddWithValue(cmd, DbType.String, "last", record.Last);
                     AddWithValue(cmd, DbType.String, "first", (object)record.First ?? DBNull.Value);
@@ -180,6 +181,7 @@ namespace Piipan.Match.State.IntegrationTests
                     AddWithValue(cmd, DbType.String, "participant_id", (object)record.ParticipantId ?? DBNull.Value);
                     AddWithValue(cmd, DbType.DateTime, "benefits_end_date", (object)record.BenefitsEndMonth ?? DBNull.Value);
                     AddWithValue(cmd, DbType.Object, "recent_benefit_months", (object)DateFormatters.FormatDatesAsPgArray(record.RecentBenefitMonths));
+                    AddWithValue(cmd, DbType.Boolean, "protect_location", (object)record.ProtectLocation ?? DBNull.Value);
 
                     cmd.ExecuteNonQuery();
                 }

--- a/match/tests/Piipan.Match.State.Tests/ApiModelTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiModelTests.cs
@@ -29,7 +29,8 @@ namespace Piipan.Match.State.Tests
                   new DateTime(2021, 5, 31),
                   new DateTime(2021, 4, 30),
                   new DateTime(2021, 3, 31)
-                }
+                },
+                ProtectLocation = true
             };
         }
 
@@ -53,7 +54,7 @@ namespace Piipan.Match.State.Tests
             // Arrange
             SetEnvironment();
             var record = FullRecord();
-            var expected = "{\n  \"last\": \"Last\",\n  \"first\": \"First\",\n  \"middle\": \"Middle\",\n  \"ssn\": \"000-00-0000\",\n  \"dob\": \"1970-01-01\",\n  \"exception\": \"Exception\",\n  \"state\": \"ea\",\n  \"state_abbr\": \"ea\",\n  \"case_id\": \"CaseIdExample\",\n  \"participant_id\": \"ParticipantIdExample\",\n  \"benefits_end_month\": \"1970-01\",\n  \"recent_benefit_months\": [\n    \"2021-05\",\n    \"2021-04\",\n    \"2021-03\"\n  ]\n}";
+            var expected = "{\n  \"last\": \"Last\",\n  \"first\": \"First\",\n  \"middle\": \"Middle\",\n  \"ssn\": \"000-00-0000\",\n  \"dob\": \"1970-01-01\",\n  \"exception\": \"Exception\",\n  \"state\": \"ea\",\n  \"state_abbr\": \"ea\",\n  \"case_id\": \"CaseIdExample\",\n  \"participant_id\": \"ParticipantIdExample\",\n  \"benefits_end_month\": \"1970-01\",\n  \"recent_benefit_months\": [\n    \"2021-05\",\n    \"2021-04\",\n    \"2021-03\"\n  ],\n  \"protect_location\": true\n}";
 
             // Assert
             Assert.Equal(expected, record.ToJson());
@@ -71,7 +72,7 @@ namespace Piipan.Match.State.Tests
             };
             var expected = "{\n  \"matches\": [\n    {" +
                     "\n      \"last\": \"Last\",\n      \"first\": \"First\",\n      \"middle\": \"Middle\",\n      \"ssn\": \"000-00-0000\",\n      \"dob\": \"1970-01-01\",\n      \"exception\": \"Exception\",\n      \"state\": \"ea\",\n      \"state_abbr\": \"ea\",\n" +
-                    "      \"case_id\": \"CaseIdExample\",\n      \"participant_id\": \"ParticipantIdExample\",\n      \"benefits_end_month\": \"1970-01\",\n      \"recent_benefit_months\": [\n        \"2021-05\",\n        \"2021-04\",\n        \"2021-03\"\n      ]" +
+                    "      \"case_id\": \"CaseIdExample\",\n      \"participant_id\": \"ParticipantIdExample\",\n      \"benefits_end_month\": \"1970-01\",\n      \"recent_benefit_months\": [\n        \"2021-05\",\n        \"2021-04\",\n        \"2021-03\"\n      ],\n      \"protect_location\": true" +
                     "\n    }\n  ]\n}";
 
             // Act

--- a/match/tests/Piipan.Match.State.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.State.Tests/ApiTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -26,7 +27,16 @@ namespace Piipan.Match.State.Tests
                 Last = "Last",
                 Dob = new DateTime(1970, 1, 1),
                 Ssn = "000-00-0000",
-                Exception = "Exception"
+                Exception = "Exception",
+                CaseId = "CaseIdExample",
+                ParticipantId = "ParticipantIdExample",
+                BenefitsEndMonth = new DateTime(1970, 1, 31),
+                RecentBenefitMonths = new List<DateTime>() {
+                  new DateTime(2021, 5, 31),
+                  new DateTime(2021, 4, 30),
+                  new DateTime(2021, 3, 31)
+                },
+                ProtectLocation = true
             };
         }
 


### PR DESCRIPTION
Closes #989 

## Changelog

### Adds
- Adds protect_location field to matches in Duplicate Participation query responses