### PR TITLE
Specify CSV fields that are optional

### DIFF
--- a/etl/src/Piipan.Etl/PiiRecordMap.cs
+++ b/etl/src/Piipan.Etl/PiiRecordMap.cs
@@ -21,10 +21,10 @@ namespace Piipan.Etl
             });
 
             Map(m => m.First).Name("first")
-                .TypeConverterOption.NullValues(string.Empty);
+                .TypeConverterOption.NullValues(string.Empty).Optional();
 
             Map(m => m.Middle).Name("middle")
-                .TypeConverterOption.NullValues(string.Empty);
+                .TypeConverterOption.NullValues(string.Empty).Optional();
 
             Map(m => m.Dob).Name("dob");
 
@@ -35,7 +35,7 @@ namespace Piipan.Etl
             });
 
             Map(m => m.Exception).Name("exception")
-                .TypeConverterOption.NullValues(string.Empty);
+                .TypeConverterOption.NullValues(string.Empty).Optional();
 
             Map(m => m.CaseId).Name("case_id").Validate(field =>
             {
@@ -43,7 +43,7 @@ namespace Piipan.Etl
             });
 
             Map(m => m.ParticipantId).Name("participant_id")
-                .TypeConverterOption.NullValues(string.Empty);
+                .TypeConverterOption.NullValues(string.Empty).Optional();
 
             Map(m => m.BenefitsEndDate)
                 .Name("benefits_end_month")
@@ -61,7 +61,7 @@ namespace Piipan.Etl
                     if (!result) return false;
                   return true;
                 })
-                .TypeConverter<ToMonthEndConverter>();
+                .TypeConverter<ToMonthEndConverter>().Optional();
 
             Map(m => m.RecentBenefitMonths)
                 .Name("recent_benefit_months")
@@ -83,10 +83,10 @@ namespace Piipan.Etl
                   }
                   return true;
                 })
-                .TypeConverter<ToMonthEndArrayConverter>();
+                .TypeConverter<ToMonthEndArrayConverter>().Optional();
 
             Map(m => m.ProtectLocation).Name("protect_location")
-                .TypeConverterOption.NullValues(string.Empty);
+                .TypeConverterOption.NullValues(string.Empty).Optional();
 
         }
     }


### PR DESCRIPTION
This permits the CSV header to be omitted from CSV file for optional fields, which will be important for preserving backwards compatibility.

Consistency should be maintained between optional fields in import-schema.json, which C# members are marked as nullable, and what maps are Optional.

*Note*: we want validate.py to still look for – and fail – if all of our currently defined columns are not present, as we want devs to move towards all the current columns. May have to revisit once the API has reached "1.0" status and support validation of previous versions.

## Changelog
### Adds
- For backwards compatibility, columns, not just field values, are optional when CSV schema does not list them as required. validator.py will still fail if all defined columns are not present.