### PR TITLE
Wordsmithing protect location field description

### DIFF
--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -75,7 +75,7 @@
       {
         "name": "protect_location",
         "type": "boolean",
-        "description": "Set true to indicate location protection for vulnerable individuals. Null or empty values will be treated as true throughout the system.",
+        "description": "Location protection flag for vulnerable individuals. True values indicate that the individual's location must be protected from disclosure to avoid harm to the individual. The field value can be omitted if the risk of harm has not been assessed.",
         "trueValues": [
           "true"
         ],


### PR DESCRIPTION
Should generally match query response API description