### PR TITLE
Log managed identity when executing match API requests

### DIFF
--- a/match/src/Piipan.Match.Orchestrator/Api.cs
+++ b/match/src/Piipan.Match.Orchestrator/Api.cs
@@ -42,6 +42,8 @@ namespace Piipan.Match.Orchestrator
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
             ILogger log)
         {
+            log.LogInformation("Executing request from user {User}", req.HttpContext?.User.Identity.Name);
+
             var incoming = await new StreamReader(req.Body).ReadToEndAsync();
             var request = Parse(incoming, log);
             if (request.Query == null)
@@ -91,6 +93,8 @@ namespace Piipan.Match.Orchestrator
             string lookupId,
             ILogger log)
         {
+            log.LogInformation("Executing request from user {User}", req.HttpContext?.User.Identity.Name);
+
             LookupResponse response = new LookupResponse { Data = null };
             response.Data = await Lookup.Retrieve(lookupId, _lookupStorage, log);
 

--- a/match/src/Piipan.Match.State/Api.cs
+++ b/match/src/Piipan.Match.State/Api.cs
@@ -36,6 +36,8 @@ namespace Piipan.Match.State
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
             ILogger log)
         {
+            log.LogInformation("Executing request from user {User}", req.HttpContext?.User.Identity.Name);
+
             SqlMapper.AddTypeHandler(new DateTimeListHandler());
 
             var incoming = await new StreamReader(req.Body).ReadToEndAsync();

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/GetParticipantUploads.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/GetParticipantUploads.cs
@@ -27,7 +27,8 @@ namespace Piipan.Metrics.Api
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
             ILogger log)
         {
-            log.LogInformation("C# HTTP trigger function processed a request.");
+            log.LogInformation("Executing request from user {User}", req.HttpContext?.User.Identity.Name);
+
             try
             {
                 var dbfactory = NpgsqlFactory.Instance;


### PR DESCRIPTION
Covers all HTTP triggered Functions with EasyAuth enabled:

- State query call
- Orchestrator query call
- Orchestrator lookup_ids call

The log message displays as `Executing request from user (null)` in a couple contexts:
- If `HttpRequest.HttpContext.User` is not set, as is the case in local development where the Function does not sit behind EasyAuth
- If `HttpRequest` does not contain an `HttpContext` object, as is the case when running tests with a mocked `HttpRequest`

Partially addresses #970.