### PR TITLE
Add recent benefit months and protect location to query tool results

### DIFF
--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -13,6 +13,8 @@
             <th scope="col">Case ID</th>
             <th scope="col">Participant ID</th>
             <th scope="col">Benefits End</th>
+            <th scope="col">Recent Benefit Months</th>
+            <th scope="col">Protect Location</th>
         </tr>
     </thead>
     <tbody>
@@ -26,6 +28,8 @@
                     <td>@record.CaseId</td>
                     <td>@record.ParticipantId</td>
                     <td>@record.BenefitsEndMonth</td>
+                    <td>@record.RecentBenefitMonthsDisplay</td>
+                    <td>@record.ProtectLocationDisplay</td>
                 </tr>
             }
         </tbody>

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -12,9 +12,9 @@
             <th scope="col">State</th>
             <th scope="col">Case ID</th>
             <th scope="col">Participant ID</th>
-            <th scope="col">Benefits End</th>
-            <th scope="col">Recent Benefit Months</th>
-            <th scope="col">Protect Location</th>
+            <th scope="col">Benefits end month</th>
+            <th scope="col">Recent benefits months</th>
+            <th scope="col">Protected location for vulnerable individuals</th>
         </tr>
     </thead>
     <tbody>

--- a/query-tool/src/Piipan.QueryTool/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool/PiiRecord.cs
@@ -59,5 +59,27 @@ namespace Piipan.QueryTool
         [Display(Name = "Benefits End Month")]
         [JsonPropertyName("benefits_end_month")]
         public string BenefitsEndMonth { get; set; }
+
+        [Display(Name = "Recent Benefit Months")]
+        [JsonPropertyName("recent_benefit_months")]
+        public string[] RecentBenefitMonths { get; set; } = new string[0];
+
+        public string RecentBenefitMonthsDisplay
+        {
+            get { return String.Join(", ", this.RecentBenefitMonths); }
+        }
+
+        [Display(Name = "Protect Location")]
+        [JsonPropertyName("protect_location")]
+        public bool? ProtectLocation { get; set; }
+
+        public string ProtectLocationDisplay
+        {
+            get
+            {
+                if (this.ProtectLocation == null) return "Yes";
+                return (bool)this.ProtectLocation ? "Yes" : "No";
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #869 
Closes #851 

- null `protect_location` values will show up as "Yes"; true as "Yes"; false as "No"
- No `recent_benefit_months` is shown as an empty column

@cjhskippy @erinzstrenio See image below. Thoughts on wording for these new columns?

Also, the results table is getting pretty scrunched. A common way to handle that is by giving the table a fixed width and making it horizontally scrollable. This results in some of the trailing data being hidden unless the user scrolls. I'd welcome any ideas on the design of that, or we can hold off until Julia gets back. 

<img width="1031" alt="Screen Shot 2021-06-14 at 2 07 53 PM" src="https://user-images.githubusercontent.com/4267629/121947325-8ab71f00-cd1b-11eb-91d2-a973b2a6fe40.png">
