### PR TITLE
Clear app firewall rules for dashboard and query tool

### DIFF
--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -32,6 +32,7 @@
         "sku": "S1",
         "baseSiteConfig": {
             "linuxFxVersion": "DOTNETCORE|3.1",
+            "ipSecurityRestrictions": [],
             "ftpsState": "Disabled",
             "appSettings": [
                 // Environment Variables

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -32,6 +32,7 @@
         "sku": "S1",
         "baseSiteConfig": {
             "linuxFxVersion": "DOTNETCORE|3.1",
+            "ipSecurityRestrictions": [],
             "ftpsState": "Disabled",
             "appSettings": [
                 // Environment Variables


### PR DESCRIPTION
Removing the ipSecurityRestrictions property in ARM template does not clear any existing firewall rules, but leaves it unchanged. Need to explicitly set the property to an empty array.

Firewall rules can be cleared since Easy Auth is enabled since 622b1a9b17b2fb63abf366f282130ed97587b91d