### PR TITLE
Change match query API schema to accept and return arrays

### DIFF
--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: "Duplicate Participation API"
   version: 1.0.0
-  description: "The API for the Duplicate Participation system where matching and lookups will occur"
+  description: "The API where matching and lookups will occur"
 servers:
   - url: "/v1"
 paths:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -268,8 +268,8 @@ Status Code **200**
 |»»» state|string|false|none|State/territory two-letter postal abbreviation|
 |»»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
 |»»» exception|string|false|none|Placeholder for value indicating special processing instructions|
-|»»» case_id|string|false|none|Participant's state-specific case identifier|
-|»»» participant_id|string|false|none|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
+|»»» case_id|string|false|none|Participant's state-specific case identifier. Can be the same for multiple participants.|
+|»»» participant_id|string|false|none|Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.|
 |»»» benefits_end_month|string|false|none|Participant's ending benefits month|
 |»»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
 |»»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -70,6 +70,7 @@ Queries all state databases for any PII records that are an exact match to the l
 {
   "data": [
     {
+      "index": 0,
       "lookup_id": "string",
       "matches": [
         {
@@ -103,6 +104,7 @@ Queries all state databases for any PII records that are an exact match to the l
 {
   "data": [
     {
+      "index": 0,
       "lookup_id": null,
       "matches": []
     }
@@ -116,6 +118,7 @@ Queries all state databases for any PII records that are an exact match to the l
 {
   "data": [
     {
+      "index": 0,
       "lookup_id": "string",
       "matches": [
         {
@@ -163,6 +166,7 @@ Queries all state databases for any PII records that are an exact match to the l
 {
   "data": [
     {
+      "index": 0,
       "lookup_id": "string",
       "matches": [
         {
@@ -182,6 +186,7 @@ Queries all state databases for any PII records that are an exact match to the l
       ]
     },
     {
+      "index": 1,
       "lookup_id": "string",
       "matches": [
         {
@@ -218,6 +223,7 @@ Status Code **200**
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |» data|array|false|none|none|
+|»» index|integer|true|none|Index of match query request item that match query response item corresponds to, starting from 0. For every match query item provided in the request, a match response item is returned, even if no matches are found. Index is derived from the implicit order of match query request items provided in the request.|
 |»» lookup_id|string¦null|false|none|the identifier of the match request|
 |»» matches|[object]|false|none|none|
 |»»» first|string|false|none|First name|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -44,15 +44,23 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "query": {
-    "first": "string",
-    "middle": "string",
-    "last": "string",
-    "ssn": "000-00-0000",
-    "dob": "1970-01-01"
-  }
+  "query": [
+    {
+      "first": "string",
+      "middle": "string",
+      "last": "string",
+      "ssn": "000-00-0000",
+      "dob": "1970-01-01"
+    }
+  ]
 }
 ```
+
+<h3 id="query-for-matches-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|query|body|[[#/paths/~1query/post/requestBody/content/application~1json/schema/properties/query/items](#schema#/paths/~1query/post/requestbody/content/application~1json/schema/properties/query/items)]|true|none|
 
 > Example responses
 
@@ -60,26 +68,30 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "lookup_id": "string",
-  "matches": [
+  "data": [
     {
-      "first": "string",
-      "middle": "string",
-      "last": "string",
-      "ssn": "000-00-0000",
-      "dob": "1970-01-01",
-      "state": "ea",
-      "state_abbr": "ea",
-      "exception": "string",
-      "case_id": "string",
-      "participant_id": "string",
-      "benefits_end_month": "2021-01",
-      "recent_benefit_months": [
-        "2021-05",
-        "2021-04",
-        "2021-03"
-      ],
-      "protect_location": true
+      "lookup_id": "string",
+      "matches": [
+        {
+          "first": "string",
+          "middle": "string",
+          "last": "string",
+          "ssn": "000-00-0000",
+          "dob": "1970-01-01",
+          "state": "ea",
+          "state_abbr": "ea",
+          "exception": "string",
+          "case_id": "string",
+          "participant_id": "string",
+          "benefits_end_month": "2021-01",
+          "recent_benefit_months": [
+            "2021-05",
+            "2021-04",
+            "2021-03"
+          ],
+          "protect_location": true
+        }
+      ]
     }
   ]
 }
@@ -89,49 +101,104 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "lookup_id": null,
-  "matches": []
+  "data": [
+    {
+      "lookup_id": null,
+      "matches": []
+    }
+  ]
 }
 ```
 
-> A query returning multiple matches
+> A query returning multiple matches for one record
 
 ```json
 {
-  "lookup_id": "string",
-  "matches": [
+  "data": [
     {
-      "first": "string",
-      "middle": "string",
-      "last": "string",
-      "ssn": "000-00-0000",
-      "dob": "1970-01-01",
-      "state": "eb",
-      "state_abbr": "eb",
-      "exception": "string",
-      "case_id": "string",
-      "participant_id": "string",
-      "benefits_end_month": "2021-01",
-      "recent_benefit_months": [
-        "2021-05",
-        "2021-04",
-        "2021-03"
-      ],
-      "protect_location": true
+      "lookup_id": "string",
+      "matches": [
+        {
+          "first": "string",
+          "middle": "string",
+          "last": "string",
+          "ssn": "000-00-0000",
+          "dob": "1970-01-01",
+          "state": "eb",
+          "state_abbr": "eb",
+          "exception": "string",
+          "case_id": "string",
+          "participant_id": "string",
+          "benefits_end_month": "2021-01",
+          "recent_benefit_months": [
+            "2021-05",
+            "2021-04",
+            "2021-03"
+          ],
+          "protect_location": true
+        },
+        {
+          "first": null,
+          "middle": null,
+          "last": "string",
+          "ssn": "000-00-0000",
+          "dob": "1970-01-01",
+          "state": "ec",
+          "state_abbr": "ec",
+          "exception": null,
+          "case_id": "string",
+          "participant_id": null,
+          "benefits_end_month": null,
+          "protect_location": null
+        }
+      ]
+    }
+  ]
+}
+```
+
+> A query returning one match for multiple records
+
+```json
+{
+  "data": [
+    {
+      "lookup_id": "string",
+      "matches": [
+        {
+          "first": null,
+          "middle": null,
+          "last": "string",
+          "ssn": "000-00-0000",
+          "dob": "1970-01-01",
+          "state": "ec",
+          "state_abbr": "ec",
+          "exception": null,
+          "case_id": "string",
+          "participant_id": null,
+          "benefits_end_month": null,
+          "protect_location": null
+        }
+      ]
     },
     {
-      "first": null,
-      "middle": null,
-      "last": "string",
-      "ssn": "000-00-0000",
-      "dob": "1970-01-01",
-      "state": "ec",
-      "state_abbr": "ec",
-      "exception": null,
-      "case_id": "string",
-      "participant_id": null,
-      "benefits_end_month": null,
-      "protect_location": null
+      "lookup_id": "string",
+      "matches": [
+        {
+          "first": null,
+          "middle": null,
+          "last": "string",
+          "ssn": "000-00-0000",
+          "dob": "1970-01-01",
+          "state": "ec",
+          "state_abbr": "ec",
+          "exception": null,
+          "case_id": "string",
+          "participant_id": null,
+          "benefits_end_month": null,
+          "protect_location": null
+        }
+      ]
     }
   ]
 }
@@ -150,21 +217,22 @@ Status Code **200**
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» lookup_id|string¦null|false|none|the identifier of the match request|
-|» matches|[object]|false|none|none|
-|»» first|string|false|none|First name|
-|»» middle|string|false|none|Middle name|
-|»» last|string|true|none|Last name|
-|»» ssn|string|true|none|Social Security number|
-|»» dob|string(date)|true|none|Date of birth|
-|»» state|string|false|none|State/territory two-letter postal abbreviation|
-|»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
-|»» exception|string|false|none|Placeholder for value indicating special processing instructions|
-|»» case_id|string|false|none|Participant's state-specific case identifier|
-|»» participant_id|string|false|none|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
-|»» benefits_end_month|string|false|none|Participant's ending benefits month|
-|»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
-|»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
+|» data|array|false|none|none|
+|»» lookup_id|string¦null|false|none|the identifier of the match request|
+|»» matches|[object]|false|none|none|
+|»»» first|string|false|none|First name|
+|»»» middle|string|false|none|Middle name|
+|»»» last|string|true|none|Last name|
+|»»» ssn|string|true|none|Social Security number|
+|»»» dob|string(date)|true|none|Date of birth|
+|»»» state|string|false|none|State/territory two-letter postal abbreviation|
+|»»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
+|»»» exception|string|false|none|Placeholder for value indicating special processing instructions|
+|»»» case_id|string|false|none|Participant's state-specific case identifier|
+|»»» participant_id|string|false|none|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
+|»»» benefits_end_month|string|false|none|Participant's ending benefits month|
+|»»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
+|»»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -4,7 +4,7 @@
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
-The API for the Duplicate Participation system where matching and lookups will occur
+The API where matching and lookups will occur
 
 Base URLs:
 
@@ -213,7 +213,7 @@ Queries all state databases for any PII records that are an exact match to the l
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Matching PII records, if any exist|Inline|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response. Returns match response items.|Inline|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Missing one of the required properties in the request body.|None|
 
 <h3 id="query-for-matches-responseschema">Response Schema</h3>
@@ -223,8 +223,8 @@ Status Code **200**
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |» data|array|true|none|Array of match query response items. For every match query item provided in the request, a match response item is returned, even if no matches are found.|
-|»» index|integer|true|none|Index of match query request item that match query response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.|
-|»» lookup_id|string¦null|false|none|the identifier of the match request|
+|»» index|integer|true|none|The index of the request item that the response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.|
+|»» lookup_id|string¦null|false|none|The identifier of the match request item, if a match is present. This ID can be used for looking up the PII of the original match request item.|
 |»» matches|[object]|false|none|none|
 |»»» first|string|false|none|First name|
 |»»» middle|string|false|none|Middle name|
@@ -263,7 +263,7 @@ curl -X GET /v1/lookup_ids/{id} \
 
 `GET /lookup_ids/{id}`
 
-*get the original match data related to a Lookup ID*
+*Get the original match data related to a Lookup ID*
 
 User can provide a Lookup ID and receive the match data associated with it
 
@@ -300,9 +300,9 @@ User can provide a Lookup ID and receive the match data associated with it
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|original active match data|Inline|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response. Returns original match query request item.|Inline|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|None|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|None|
 
 <h3 id="get-lookups-by-id-responseschema">Response Schema</h3>
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -222,8 +222,8 @@ Status Code **200**
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» data|array|false|none|none|
-|»» index|integer|true|none|Index of match query request item that match query response item corresponds to, starting from 0. For every match query item provided in the request, a match response item is returned, even if no matches are found. Index is derived from the implicit order of match query request items provided in the request.|
+|» data|array|true|none|Array of match query response items. For every match query item provided in the request, a match response item is returned, even if no matches are found.|
+|»» index|integer|true|none|Index of match query request item that match query response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.|
 |»» lookup_id|string¦null|false|none|the identifier of the match request|
 |»» matches|[object]|false|none|none|
 |»»» first|string|false|none|First name|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -40,7 +40,7 @@ Queries all state databases for any PII records that are an exact match to the l
 
 > Body parameter
 
-> A request with values for all fields
+> An example request to query a single individual, with values for all fields
 
 ```json
 {
@@ -64,7 +64,7 @@ Queries all state databases for any PII records that are an exact match to the l
 
 > Example responses
 
-> A query returning a single match
+> A query for a single individual returning a single match
 
 ```json
 {
@@ -98,7 +98,7 @@ Queries all state databases for any PII records that are an exact match to the l
 }
 ```
 
-> A query returning no matches
+> A query for a single individual returning no matches
 
 ```json
 {
@@ -112,7 +112,7 @@ Queries all state databases for any PII records that are an exact match to the l
 }
 ```
 
-> A query returning multiple matches for one record
+> A query for one individual returning multiple matches
 
 ```json
 {
@@ -160,7 +160,7 @@ Queries all state databases for any PII records that are an exact match to the l
 }
 ```
 
-> A query returning one match for multiple records
+> A query for two individuals returning one match for each individual
 
 ```json
 {
@@ -184,6 +184,40 @@ Queries all state databases for any PII records that are an exact match to the l
           "protect_location": null
         }
       ]
+    },
+    {
+      "index": 1,
+      "lookup_id": "string",
+      "matches": [
+        {
+          "first": null,
+          "middle": null,
+          "last": "string",
+          "ssn": "000-00-0000",
+          "dob": "1970-01-01",
+          "state": "ec",
+          "state_abbr": "ec",
+          "exception": null,
+          "case_id": "string",
+          "participant_id": null,
+          "benefits_end_month": null,
+          "protect_location": null
+        }
+      ]
+    }
+  ]
+}
+```
+
+> A query for two individuals returning no matches for one individual and a match for the other
+
+```json
+{
+  "data": [
+    {
+      "index": 0,
+      "lookup_id": null,
+      "matches": []
     },
     {
       "index": 1,

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -68,9 +68,6 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "meta": {
-    "total": 1
-  },
   "data": {
     "results": [
       {
@@ -108,9 +105,6 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "meta": {
-    "total": 1
-  },
   "data": {
     "results": [
       {
@@ -128,9 +122,6 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "meta": {
-    "total": 1
-  },
   "data": {
     "results": [
       {
@@ -182,9 +173,6 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "meta": {
-    "total": 2
-  },
   "data": {
     "results": [
       {
@@ -237,9 +225,6 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "meta": {
-    "total": 2
-  },
   "data": {
     "results": [
       {
@@ -277,9 +262,6 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "meta": {
-    "total": 2
-  },
   "data": {
     "results": [
       {
@@ -327,8 +309,6 @@ Status Code **200**
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» meta|object¦null|false|none|Provides meta information about the response. A meta property will be present whenever a data property is present.|
-|»» total|integer|true|none|The sum total of results plus errors in the data object. This should equal the number of persons provided in the request.|
 |» data|object¦null|false|none|The response payload. Either an errors or data property will be present in the response, but not both.|
 |»» results|array|true|none|Array of query results. For every person provided in the request, a result is returned for every successful query, even if no matches are found. If a query fails, the failure data will be in the errors array.|
 |»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -36,15 +36,15 @@ curl -X POST /v1/query \
 
 *Search for all matching PII records*
 
-Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number in the request body's `query` property.
+Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number of persons provided in the request.
 
 > Body parameter
 
-> An example request to query a single individual, with values for all fields
+> An example request to query a single person, with values for all fields
 
 ```json
 {
-  "query": [
+  "persons": [
     {
       "first": "string",
       "middle": "string",
@@ -60,186 +60,257 @@ Queries all state databases for any PII records that are an exact match to the l
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|query|body|[[#/paths/~1query/post/requestBody/content/application~1json/schema/properties/query/items](#schema#/paths/~1query/post/requestbody/content/application~1json/schema/properties/query/items)]|true|none|
+|persons|body|[[#/paths/~1query/post/requestBody/content/application~1json/schema/properties/persons/items](#schema#/paths/~1query/post/requestbody/content/application~1json/schema/properties/persons/items)]|true|none|
 
 > Example responses
 
-> A query for a single individual returning a single match
+> A query for a single person returning a single match
 
 ```json
 {
-  "data": [
-    {
-      "index": 0,
-      "lookup_id": "string",
-      "matches": [
-        {
-          "first": "string",
-          "middle": "string",
-          "last": "string",
-          "ssn": "000-00-0000",
-          "dob": "1970-01-01",
-          "state": "ea",
-          "state_abbr": "ea",
-          "exception": "string",
-          "case_id": "string",
-          "participant_id": "string",
-          "benefits_end_month": "2021-01",
-          "recent_benefit_months": [
-            "2021-05",
-            "2021-04",
-            "2021-03"
-          ],
-          "protect_location": true
-        }
-      ]
-    }
-  ]
+  "meta": {
+    "total": 1
+  },
+  "data": {
+    "results": [
+      {
+        "index": 0,
+        "lookup_id": "string",
+        "matches": [
+          {
+            "first": "string",
+            "middle": "string",
+            "last": "string",
+            "ssn": "000-00-0000",
+            "dob": "1970-01-01",
+            "state": "ea",
+            "state_abbr": "ea",
+            "exception": "string",
+            "case_id": "string",
+            "participant_id": "string",
+            "benefits_end_month": "2021-01",
+            "recent_benefit_months": [
+              "2021-05",
+              "2021-04",
+              "2021-03"
+            ],
+            "protect_location": true
+          }
+        ]
+      }
+    ],
+    "errors": []
+  }
 }
 ```
 
-> A query for a single individual returning no matches
+> A query for a single person returning no matches
 
 ```json
 {
-  "data": [
-    {
-      "index": 0,
-      "lookup_id": null,
-      "matches": []
-    }
-  ]
+  "meta": {
+    "total": 1
+  },
+  "data": {
+    "results": [
+      {
+        "index": 0,
+        "lookup_id": null,
+        "matches": []
+      }
+    ],
+    "errors": []
+  }
 }
 ```
 
-> A query for one individual returning multiple matches
+> A query for one person returning multiple matches
 
 ```json
 {
-  "data": [
-    {
-      "index": 0,
-      "lookup_id": "string",
-      "matches": [
-        {
-          "first": "string",
-          "middle": "string",
-          "last": "string",
-          "ssn": "000-00-0000",
-          "dob": "1970-01-01",
-          "state": "eb",
-          "state_abbr": "eb",
-          "exception": "string",
-          "case_id": "string",
-          "participant_id": "string",
-          "benefits_end_month": "2021-01",
-          "recent_benefit_months": [
-            "2021-05",
-            "2021-04",
-            "2021-03"
-          ],
-          "protect_location": true
-        },
-        {
-          "first": null,
-          "middle": null,
-          "last": "string",
-          "ssn": "000-00-0000",
-          "dob": "1970-01-01",
-          "state": "ec",
-          "state_abbr": "ec",
-          "exception": null,
-          "case_id": "string",
-          "participant_id": null,
-          "benefits_end_month": null,
-          "protect_location": null
-        }
-      ]
-    }
-  ]
+  "meta": {
+    "total": 1
+  },
+  "data": {
+    "results": [
+      {
+        "index": 0,
+        "lookup_id": "string",
+        "matches": [
+          {
+            "first": "string",
+            "middle": "string",
+            "last": "string",
+            "ssn": "000-00-0000",
+            "dob": "1970-01-01",
+            "state": "eb",
+            "state_abbr": "eb",
+            "exception": "string",
+            "case_id": "string",
+            "participant_id": "string",
+            "benefits_end_month": "2021-01",
+            "recent_benefit_months": [
+              "2021-05",
+              "2021-04",
+              "2021-03"
+            ],
+            "protect_location": true
+          },
+          {
+            "first": null,
+            "middle": null,
+            "last": "string",
+            "ssn": "000-00-0000",
+            "dob": "1970-01-01",
+            "state": "ec",
+            "state_abbr": "ec",
+            "exception": null,
+            "case_id": "string",
+            "participant_id": null,
+            "benefits_end_month": null,
+            "protect_location": null
+          }
+        ]
+      }
+    ],
+    "errors": []
+  }
 }
 ```
 
-> A query for two individuals returning one match for each individual
+> A query for two persons returning one match for each person
 
 ```json
 {
-  "data": [
-    {
-      "index": 0,
-      "lookup_id": "string",
-      "matches": [
-        {
-          "first": null,
-          "middle": null,
-          "last": "string",
-          "ssn": "000-00-0000",
-          "dob": "1970-01-01",
-          "state": "ec",
-          "state_abbr": "ec",
-          "exception": null,
-          "case_id": "string",
-          "participant_id": null,
-          "benefits_end_month": null,
-          "protect_location": null
-        }
-      ]
-    },
-    {
-      "index": 1,
-      "lookup_id": "string",
-      "matches": [
-        {
-          "first": null,
-          "middle": null,
-          "last": "string",
-          "ssn": "000-00-0000",
-          "dob": "1970-01-01",
-          "state": "ec",
-          "state_abbr": "ec",
-          "exception": null,
-          "case_id": "string",
-          "participant_id": null,
-          "benefits_end_month": null,
-          "protect_location": null
-        }
-      ]
-    }
-  ]
+  "meta": {
+    "total": 2
+  },
+  "data": {
+    "results": [
+      {
+        "index": 0,
+        "lookup_id": "string",
+        "matches": [
+          {
+            "first": null,
+            "middle": null,
+            "last": "string",
+            "ssn": "000-00-0000",
+            "dob": "1970-01-01",
+            "state": "ec",
+            "state_abbr": "ec",
+            "exception": null,
+            "case_id": "string",
+            "participant_id": null,
+            "benefits_end_month": null,
+            "protect_location": null
+          }
+        ]
+      },
+      {
+        "index": 1,
+        "lookup_id": "string",
+        "matches": [
+          {
+            "first": null,
+            "middle": null,
+            "last": "string",
+            "ssn": "000-00-0000",
+            "dob": "1970-01-01",
+            "state": "ec",
+            "state_abbr": "ec",
+            "exception": null,
+            "case_id": "string",
+            "participant_id": null,
+            "benefits_end_month": null,
+            "protect_location": null
+          }
+        ]
+      }
+    ],
+    "errors": []
+  }
 }
 ```
 
-> A query for two individuals returning no matches for one individual and a match for the other
+> A query for two persons returning no matches for one person and a match for the other
 
 ```json
 {
-  "data": [
-    {
-      "index": 0,
-      "lookup_id": null,
-      "matches": []
-    },
-    {
-      "index": 1,
-      "lookup_id": "string",
-      "matches": [
-        {
-          "first": null,
-          "middle": null,
-          "last": "string",
-          "ssn": "000-00-0000",
-          "dob": "1970-01-01",
-          "state": "ec",
-          "state_abbr": "ec",
-          "exception": null,
-          "case_id": "string",
-          "participant_id": null,
-          "benefits_end_month": null,
-          "protect_location": null
-        }
-      ]
-    }
-  ]
+  "meta": {
+    "total": 2
+  },
+  "data": {
+    "results": [
+      {
+        "index": 0,
+        "lookup_id": null,
+        "matches": []
+      },
+      {
+        "index": 1,
+        "lookup_id": "string",
+        "matches": [
+          {
+            "first": null,
+            "middle": null,
+            "last": "string",
+            "ssn": "000-00-0000",
+            "dob": "1970-01-01",
+            "state": "ec",
+            "state_abbr": "ec",
+            "exception": null,
+            "case_id": "string",
+            "participant_id": null,
+            "benefits_end_month": null,
+            "protect_location": null
+          }
+        ]
+      }
+    ],
+    "errors": []
+  }
+}
+```
+
+> A query for two persons returning a successful result for one person and an error for the other person
+
+```json
+{
+  "meta": {
+    "total": 2
+  },
+  "data": {
+    "results": [
+      {
+        "index": 1,
+        "lookup_id": "string",
+        "matches": [
+          {
+            "first": null,
+            "middle": null,
+            "last": "string",
+            "ssn": "000-00-0000",
+            "dob": "1970-01-01",
+            "state": "ec",
+            "state_abbr": "ec",
+            "exception": null,
+            "case_id": "string",
+            "participant_id": null,
+            "benefits_end_month": null,
+            "protect_location": null
+          }
+        ]
+      }
+    ],
+    "errors": [
+      {
+        "index": 0,
+        "code": "InternalServerException",
+        "message": "Unexpected Server Error. Please try again."
+      }
+    ]
+  }
 }
 ```
 
@@ -256,23 +327,33 @@ Status Code **200**
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|» data|array|true|none|Array of match query response items. For every match query item provided in the request, a match response item is returned, even if no matches are found.|
-|»» index|integer|true|none|The index of the request item that the response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.|
-|»» lookup_id|string¦null|false|none|The identifier of the match request item, if a match is present. This ID can be used for looking up the PII of the original match request item.|
-|»» matches|[object]|false|none|none|
-|»»» first|string|false|none|First name|
-|»»» middle|string|false|none|Middle name|
-|»»» last|string|true|none|Last name|
-|»»» ssn|string|true|none|Social Security number|
-|»»» dob|string(date)|true|none|Date of birth|
-|»»» state|string|false|none|State/territory two-letter postal abbreviation|
-|»»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
-|»»» exception|string|false|none|Placeholder for value indicating special processing instructions|
-|»»» case_id|string|false|none|Participant's state-specific case identifier. Can be the same for multiple participants.|
-|»»» participant_id|string|false|none|Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.|
-|»»» benefits_end_month|string|false|none|Participant's ending benefits month|
-|»»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
-|»»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
+|» meta|object¦null|false|none|Provides meta information about the response. A meta property will be present whenever a data property is present.|
+|»» total|integer|true|none|The sum total of results plus errors in the data object. This should equal the number of persons provided in the request.|
+|» data|object¦null|false|none|The response payload. Either an errors or data property will be present in the response, but not both.|
+|»» results|array|true|none|Array of query results. For every person provided in the request, a result is returned for every successful query, even if no matches are found. If a query fails, the failure data will be in the errors array.|
+|»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
+|»»» lookup_id|string¦null|false|none|The identifier of the person data, if a match is present. This ID can be used for looking up the PII of the person provided in the original request.|
+|»»» matches|[object]|false|none|none|
+|»»»» first|string|false|none|First name|
+|»»»» middle|string|false|none|Middle name|
+|»»»» last|string|true|none|Last name|
+|»»»» ssn|string|true|none|Social Security number|
+|»»»» dob|string(date)|true|none|Date of birth|
+|»»»» state|string|false|none|State/territory two-letter postal abbreviation|
+|»»»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
+|»»»» exception|string|false|none|Placeholder for value indicating special processing instructions|
+|»»»» case_id|string|false|none|Participant's state-specific case identifier. Can be the same for multiple participants.|
+|»»»» participant_id|string|false|none|Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.|
+|»»»» benefits_end_month|string|false|none|Participant's ending benefits month|
+|»»»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
+|»»»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
+|»» errors|array|true|none|Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here.|
+|»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
+|»»» code|string|true|none|The error code|
+|»»» message|string|true|none|The error message|
+|» errors|array¦null|false|none|Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both.|
+|»» code|string|true|none|The error code|
+|»» message|string|true|none|The error message|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -60,7 +60,7 @@ Queries all state databases for any PII records that are an exact match to the l
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|persons|body|[[#/paths/~1query/post/requestBody/content/application~1json/schema/properties/persons/items](#schema#/paths/~1query/post/requestbody/content/application~1json/schema/properties/persons/items)]|true|none|
+|data|body|[[#/paths/~1query/post/requestBody/content/application~1json/schema/properties/data/items](#schema#/paths/~1query/post/requestbody/content/application~1json/schema/properties/data/items)]|true|none|
 
 > Example responses
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -44,7 +44,7 @@ Queries all state databases for any PII records that are an exact match to the l
 
 ```json
 {
-  "persons": [
+  "data": [
     {
       "first": "string",
       "middle": "string",

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -333,7 +333,7 @@ Status Code **200**
 |»» results|array|true|none|Array of query results. For every person provided in the request, a result is returned for every successful query, even if no matches are found. If a query fails, the failure data will be in the errors array.|
 |»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
 |»»» lookup_id|string¦null|false|none|The identifier of the person data, if a match is present. This ID can be used for looking up the PII of the person provided in the original request.|
-|»»» matches|[object]|false|none|none|
+|»»» matches|[object]|true|none|none|
 |»»»» first|string|false|none|First name|
 |»»»» middle|string|false|none|Middle name|
 |»»»» last|string|true|none|Last name|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -288,11 +288,27 @@ Queries all state databases for any PII records that are an exact match to the l
     "errors": [
       {
         "index": 0,
-        "code": "InternalServerException",
-        "message": "Unexpected Server Error. Please try again."
+        "code": "XYZ",
+        "title": "Internal Server Exception",
+        "detail": "Unexpected Server Error. Please try again."
       }
     ]
   }
+}
+```
+
+> An example response for an invalid request
+
+```json
+{
+  "errors": [
+    {
+      "status": "400",
+      "code": "XYZ",
+      "title": "Bad Request",
+      "detail": "Request payload exceeds maxiumum count"
+    }
+  ]
 }
 ```
 
@@ -329,11 +345,14 @@ Status Code **200**
 |»»»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
 |»» errors|array|true|none|Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here.|
 |»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
-|»»» code|string|true|none|The error code|
-|»»» message|string|true|none|The error message|
+|»»» code|string|false|none|The application-specific error code|
+|»»» title|string|false|none|The short, human-readable summary of the error, consistent across all occurrences of the error|
+|»»» detail|string|false|none|The human-readable explanation specific to this occurrence of the error|
 |» errors|array¦null|false|none|Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both.|
-|»» code|string|true|none|The error code|
-|»» message|string|true|none|The error message|
+|»» status|string|true|none|The HTTP status code|
+|»» code|string|false|none|The application-specific error code|
+|»» title|string|false|none|The short, human-readable summary of the error, consistent across all occurrences of the error|
+|»» detail|string|false|none|The human-readable explanation specific to this occurrence of the error|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -51,7 +51,7 @@ paths:
                         description: PII record's date of birth
             examples:
               All fields:
-                description: A request with values for all fields
+                description: 'An example request to query a single individual, with values for all fields'
                 value:
                   query:
                     - first: string
@@ -165,7 +165,7 @@ paths:
                               description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
               examples:
                 Single:
-                  description: A query returning a single match
+                  description: A query for a single individual returning a single match
                   value:
                     data:
                       - index: 0
@@ -188,14 +188,14 @@ paths:
                               - 2021-03
                             protect_location: true
                 None:
-                  description: A query returning no matches
+                  description: A query for a single individual returning no matches
                   value:
                     data:
                       - index: 0
                         lookup_id: null
                         matches: []
                 Multiple:
-                  description: A query returning multiple matches for one record
+                  description: A query for one individual returning multiple matches
                   value:
                     data:
                       - index: 0
@@ -230,13 +230,24 @@ paths:
                             benefits_end_month: null
                             protect_location: null
                 MultipleRecords:
-                  description: A query returning one match for multiple records
+                  description: A query for two individuals returning one match for each individual
                   value:
                     data:
                       - index: 0
                         lookup_id: string
                         matches:
                           - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
+                      - index: 1
+                        lookup_id: string
+                        matches:
+                          - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
+                MultipleRecordsOneMatch:
+                  description: A query for two individuals returning no matches for one individual and a match for the other
+                  value:
+                    data:
+                      - index: 0
+                        lookup_id: null
+                        matches: []
                       - index: 1
                         lookup_id: string
                         matches:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -23,48 +23,62 @@ paths:
                 - query
               properties:
                 query:
-                  type: object
-                  required:
-                    - first
-                    - last
-                    - dob
-                    - ssn
-                  properties:
-                    first:
-                      type: string
-                      description: PII record's first name
-                    middle:
-                      type: string
-                      description: PII record's middle name
-                    last:
-                      type: string
-                      description: PII record's last name
-                    ssn:
-                      type: string
-                      description: PII record's social security number
-                      pattern: '^\d{3}-\d{2}-\d{4}$'
-                    dob:
-                      type: string
-                      format: date
-                      description: PII record's date of birth
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - first
+                      - last
+                      - dob
+                      - ssn
+                    properties:
+                      first:
+                        type: string
+                        description: PII record's first name
+                      middle:
+                        type: string
+                        description: PII record's middle name
+                      last:
+                        type: string
+                        description: PII record's last name
+                      ssn:
+                        type: string
+                        description: PII record's social security number
+                        pattern: '^\d{3}-\d{2}-\d{4}$'
+                      dob:
+                        type: string
+                        format: date
+                        description: PII record's date of birth
             examples:
               All fields:
                 description: A request with values for all fields
                 value:
                   query:
-                    first: string
-                    middle: string
-                    last: string
-                    ssn: 000-00-0000
-                    dob: '1970-01-01'
+                    - first: string
+                      middle: string
+                      last: string
+                      ssn: 000-00-0000
+                      dob: '1970-01-01'
               Only requried fields:
                 description: A request with values only for required fields
                 value:
                   query:
-                    first: string
-                    last: string
-                    ssn: 000-00-0000
-                    dob: '1970-01-01'
+                    - first: string
+                      last: string
+                      ssn: 000-00-0000
+                      dob: '1970-01-01'
+              Multiple Records:
+                description: A request with multiple records
+                value:
+                  query:
+                    - first: string
+                      last: string
+                      ssn: 000-00-0000
+                      dob: '1970-01-01'
+                    - first: string
+                      last: string
+                      ssn: 000-00-0001
+                      dob: '1970-01-02'
       responses:
         '200':
           description: 'Matching PII records, if any exist'
@@ -73,131 +87,147 @@ paths:
               schema:
                 type: object
                 properties:
-                  lookup_id:
-                    type: string
-                    nullable: true
-                    description: the identifier of the match request
-                  matches:
+                  data:
                     type: array
-                    items:
-                      type: object
-                      required:
-                        - last
-                        - ssn
-                        - dob
-                      properties:
-                        first:
-                          type: string
-                          description: First name
-                        middle:
-                          type: string
-                          description: Middle name
-                        last:
-                          type: string
-                          description: Last name
-                        ssn:
-                          type: string
-                          description: Social Security number
-                          pattern: '^\d{3}-\d{2}-\d{4}$'
-                        dob:
-                          type: string
-                          format: date
-                          description: Date of birth
-                        state:
-                          type: string
-                          description: State/territory two-letter postal abbreviation
-                        state_abbr:
-                          type: string
-                          description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
-                          deprecated: true
-                        exception:
-                          type: string
-                          description: Placeholder for value indicating special processing instructions
-                        case_id:
-                          type: string
-                          description: Participant's state-specific case identifier
-                        participant_id:
-                          type: string
-                          description: Participant's state-specific identifier. Must not be social security number or any personal identifiable information.
-                        benefits_end_month:
-                          type: string
-                          pattern: '^\d{4}-\d{2}$'
-                          example: 2021-01
-                          description: Participant's ending benefits month
-                        recent_benefit_months:
-                          type: array
-                          items:
-                            type: string
-                            pattern: '^\d{4}-\d{2}$'
-                            example: 2021-01
-                          minItems: 0
-                          maxItems: 3
-                          description: 'List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.'
-                        protect_location:
-                          type: boolean
-                          nullable: true
-                          example: true
-                          description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
+                    properties:
+                      lookup_id:
+                        type: string
+                        nullable: true
+                        description: the identifier of the match request
+                      matches:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - last
+                            - ssn
+                            - dob
+                          properties:
+                            first:
+                              type: string
+                              description: First name
+                            middle:
+                              type: string
+                              description: Middle name
+                            last:
+                              type: string
+                              description: Last name
+                            ssn:
+                              type: string
+                              description: Social Security number
+                              pattern: '^\d{3}-\d{2}-\d{4}$'
+                            dob:
+                              type: string
+                              format: date
+                              description: Date of birth
+                            state:
+                              type: string
+                              description: State/territory two-letter postal abbreviation
+                            state_abbr:
+                              type: string
+                              description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
+                              deprecated: true
+                            exception:
+                              type: string
+                              description: Placeholder for value indicating special processing instructions
+                            case_id:
+                              type: string
+                              description: Participant's state-specific case identifier
+                            participant_id:
+                              type: string
+                              description: Participant's state-specific identifier. Must not be social security number or any personal identifiable information.
+                            benefits_end_month:
+                              type: string
+                              pattern: '^\d{4}-\d{2}$'
+                              example: 2021-01
+                              description: Participant's ending benefits month
+                            recent_benefit_months:
+                              type: array
+                              items:
+                                type: string
+                                pattern: '^\d{4}-\d{2}$'
+                                example: 2021-01
+                              minItems: 0
+                              maxItems: 3
+                              description: 'List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.'
+                            protect_location:
+                              type: boolean
+                              nullable: true
+                              example: true
+                              description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
               examples:
                 Single:
                   description: A query returning a single match
                   value:
-                    lookup_id: string
-                    matches:
-                      - first: string
-                        middle: string
-                        last: string
-                        ssn: 000-00-0000
-                        dob: '1970-01-01'
-                        state: ea
-                        state_abbr: ea
-                        exception: string
-                        case_id: string
-                        participant_id: string
-                        benefits_end_month: 2021-01
-                        recent_benefit_months:
-                          - 2021-05
-                          - 2021-04
-                          - 2021-03
-                        protect_location: true
+                    data:
+                      - lookup_id: string
+                        matches:
+                          - first: string
+                            middle: string
+                            last: string
+                            ssn: 000-00-0000
+                            dob: '1970-01-01'
+                            state: ea
+                            state_abbr: ea
+                            exception: string
+                            case_id: string
+                            participant_id: string
+                            benefits_end_month: 2021-01
+                            recent_benefit_months:
+                              - 2021-05
+                              - 2021-04
+                              - 2021-03
+                            protect_location: true
                 None:
                   description: A query returning no matches
                   value:
-                    lookup_id: null
-                    matches: []
+                    data:
+                      - lookup_id: null
+                        matches: []
                 Multiple:
-                  description: A query returning multiple matches
+                  description: A query returning multiple matches for one record
                   value:
-                    lookup_id: string
-                    matches:
-                      - first: string
-                        middle: string
-                        last: string
-                        ssn: 000-00-0000
-                        dob: '1970-01-01'
-                        state: eb
-                        state_abbr: eb
-                        exception: string
-                        case_id: string
-                        participant_id: string
-                        benefits_end_month: 2021-01
-                        recent_benefit_months:
-                          - 2021-05
-                          - 2021-04
-                          - 2021-03
-                        protect_location: true
-                      - first: null
-                        middle: null
-                        last: string
-                        ssn: 000-00-0000
-                        dob: '1970-01-01'
-                        state: ec
-                        state_abbr: ec
-                        exception: null
-                        case_id: string
-                        participant_id: null
-                        benefits_end_month: null
-                        protect_location: null
+                    data:
+                      - lookup_id: string
+                        matches:
+                          - first: string
+                            middle: string
+                            last: string
+                            ssn: 000-00-0000
+                            dob: '1970-01-01'
+                            state: eb
+                            state_abbr: eb
+                            exception: string
+                            case_id: string
+                            participant_id: string
+                            benefits_end_month: 2021-01
+                            recent_benefit_months:
+                              - 2021-05
+                              - 2021-04
+                              - 2021-03
+                            protect_location: true
+                          - first: null
+                            middle: null
+                            last: string
+                            ssn: 000-00-0000
+                            dob: '1970-01-01'
+                            state: ec
+                            state_abbr: ec
+                            exception: null
+                            case_id: string
+                            participant_id: null
+                            benefits_end_month: null
+                            protect_location: null
+                MultipleRecords:
+                  description: A query returning one match for multiple records
+                  value:
+                    data:
+                      - lookup_id: string
+                        matches:
+                          - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
+                      - lookup_id: string
+                        matches:
+                          - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
         '400':
           description: Bad request. Missing one of the required properties in the request body.
   '/lookup_ids/{id}':
@@ -218,7 +248,7 @@ paths:
                   - data
                 properties:
                   data:
-                    $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/query'
+                    $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/query/items'
               examples:
                 All:
                   description: A response showing a query with values for all fields

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Duplicate Participation API
   version: 1.0.0
-  description: The API for the Duplicate Participation system where matching and lookups will occur
+  description: The API where matching and lookups will occur
 servers:
   - url: /v1
 paths:
@@ -81,7 +81,7 @@ paths:
                       dob: '1970-01-02'
       responses:
         '200':
-          description: 'Matching PII records, if any exist'
+          description: Successful response. Returns match response items.
           content:
             application/json:
               schema:
@@ -97,11 +97,11 @@ paths:
                     properties:
                       index:
                         type: integer
-                        description: 'Index of match query request item that match query response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.'
+                        description: 'The index of the request item that the response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.'
                       lookup_id:
                         type: string
                         nullable: true
-                        description: the identifier of the match request
+                        description: 'The identifier of the match request item, if a match is present. This ID can be used for looking up the PII of the original match request item.'
                       matches:
                         type: array
                         items:
@@ -248,11 +248,11 @@ paths:
       operationId: Get Lookups by ID
       tags:
         - Lookup
-      summary: get the original match data related to a Lookup ID
+      summary: Get the original match data related to a Lookup ID
       description: User can provide a Lookup ID and receive the match data associated with it
       responses:
         '200':
-          description: original active match data
+          description: Successful response. Returns original match query request item.
           content:
             application/json:
               schema:
@@ -283,7 +283,7 @@ paths:
         '400':
           description: Bad request
         '404':
-          description: Not Found
+          description: Not found
 security:
   - ApiKeyAuth: []
 components:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -89,7 +89,12 @@ paths:
                 properties:
                   data:
                     type: array
+                    required:
+                      - index
                     properties:
+                      index:
+                        type: integer
+                        description: 'Index of match query request item that match query response item corresponds to, starting from 0. For every match query item provided in the request, a match response item is returned, even if no matches are found. Index is derived from the implicit order of match query request items provided in the request.'
                       lookup_id:
                         type: string
                         nullable: true
@@ -160,7 +165,8 @@ paths:
                   description: A query returning a single match
                   value:
                     data:
-                      - lookup_id: string
+                      - index: 0
+                        lookup_id: string
                         matches:
                           - first: string
                             middle: string
@@ -182,13 +188,15 @@ paths:
                   description: A query returning no matches
                   value:
                     data:
-                      - lookup_id: null
+                      - index: 0
+                        lookup_id: null
                         matches: []
                 Multiple:
                   description: A query returning multiple matches for one record
                   value:
                     data:
-                      - lookup_id: string
+                      - index: 0
+                        lookup_id: string
                         matches:
                           - first: string
                             middle: string
@@ -222,10 +230,12 @@ paths:
                   description: A query returning one match for multiple records
                   value:
                     data:
-                      - lookup_id: string
+                      - index: 0
+                        lookup_id: string
                         matches:
                           - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
-                      - lookup_id: string
+                      - index: 1
+                        lookup_id: string
                         matches:
                           - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
         '400':

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -86,15 +86,18 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - data
                 properties:
                   data:
                     type: array
+                    description: 'Array of match query response items. For every match query item provided in the request, a match response item is returned, even if no matches are found.'
                     required:
                       - index
                     properties:
                       index:
                         type: integer
-                        description: 'Index of match query request item that match query response item corresponds to, starting from 0. For every match query item provided in the request, a match response item is returned, even if no matches are found. Index is derived from the implicit order of match query request items provided in the request.'
+                        description: 'Index of match query request item that match query response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.'
                       lookup_id:
                         type: string
                         nullable: true

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -140,10 +140,10 @@ paths:
                               description: Placeholder for value indicating special processing instructions
                             case_id:
                               type: string
-                              description: Participant's state-specific case identifier
+                              description: Participant's state-specific case identifier. Can be the same for multiple participants.
                             participant_id:
                               type: string
-                              description: Participant's state-specific identifier. Must not be social security number or any personal identifiable information.
+                              description: Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.
                             benefits_end_month:
                               type: string
                               pattern: '^\d{4}-\d{2}$'

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -89,16 +89,6 @@ paths:
               schema:
                 type: object
                 properties:
-                  meta:
-                    type: object
-                    nullable: true
-                    description: Provides meta information about the response. A meta property will be present whenever a data property is present.
-                    required:
-                      - total
-                    properties:
-                      total:
-                        type: integer
-                        description: The sum total of results plus errors in the data object. This should equal the number of persons provided in the request.
                   data:
                     type: object
                     nullable: true
@@ -217,8 +207,6 @@ paths:
                 Single:
                   description: A query for a single person returning a single match
                   value:
-                    meta:
-                      total: 1
                     data:
                       results:
                         - index: 0
@@ -244,8 +232,6 @@ paths:
                 None:
                   description: A query for a single person returning no matches
                   value:
-                    meta:
-                      total: 1
                     data:
                       results:
                         - index: 0
@@ -255,8 +241,6 @@ paths:
                 Multiple:
                   description: A query for one person returning multiple matches
                   value:
-                    meta:
-                      total: 1
                     data:
                       results:
                         - index: 0
@@ -294,8 +278,6 @@ paths:
                 MultipleRecords:
                   description: A query for two persons returning one match for each person
                   value:
-                    meta:
-                      total: 2
                     data:
                       results:
                         - index: 0
@@ -310,8 +292,6 @@ paths:
                 MultipleRecordsOneMatch:
                   description: A query for two persons returning no matches for one person and a match for the other
                   value:
-                    meta:
-                      total: 2
                     data:
                       results:
                         - index: 0
@@ -325,8 +305,6 @@ paths:
                 MultipleRecordsOneError:
                   description: A query for two persons returning a successful result for one person and an error for the other person
                   value:
-                    meta:
-                      total: 2
                     data:
                       results:
                         - index: 1

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -55,7 +55,7 @@ paths:
               All fields:
                 description: 'An example request to query a single person, with values for all fields'
                 value:
-                  persons:
+                  data:
                     - first: string
                       middle: string
                       last: string
@@ -64,7 +64,7 @@ paths:
               Only requried fields:
                 description: A request to query a single person with values only for required fields
                 value:
-                  persons:
+                  data:
                     - first: string
                       last: string
                       ssn: 000-00-0000
@@ -72,7 +72,7 @@ paths:
               Multiple Persons:
                 description: A request with multiple persons
                 value:
-                  persons:
+                  data:
                     - first: string
                       last: string
                       ssn: 000-00-0000

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -112,6 +112,7 @@ paths:
                         description: 'Array of query results. For every person provided in the request, a result is returned for every successful query, even if no matches are found. If a query fails, the failure data will be in the errors array.'
                         required:
                           - index
+                          - matches
                         properties:
                           index:
                             type: integer

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -177,32 +177,38 @@ paths:
                         description: 'Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here.'
                         required:
                           - index
-                          - code
-                          - message
                         properties:
                           index:
                             type: integer
                             description: 'The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.'
                           code:
                             type: string
-                            description: The error code
-                          message:
+                            description: The application-specific error code
+                          title:
                             type: string
-                            description: The error message
+                            description: 'The short, human-readable summary of the error, consistent across all occurrences of the error'
+                          detail:
+                            type: string
+                            description: The human-readable explanation specific to this occurrence of the error
                   errors:
                     type: array
                     nullable: true
                     description: 'Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both.'
                     required:
-                      - code
-                      - message
+                      - status
                     properties:
+                      status:
+                        type: string
+                        description: The HTTP status code
                       code:
                         type: string
-                        description: The error code
-                      message:
+                        description: The application-specific error code
+                      title:
                         type: string
-                        description: The error message
+                        description: 'The short, human-readable summary of the error, consistent across all occurrences of the error'
+                      detail:
+                        type: string
+                        description: The human-readable explanation specific to this occurrence of the error
               examples:
                 Single:
                   description: A query for a single person returning a single match
@@ -313,8 +319,17 @@ paths:
                             - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
                       errors:
                         - index: 0
-                          code: InternalServerException
-                          message: Unexpected Server Error. Please try again.
+                          code: XYZ
+                          title: Internal Server Exception
+                          detail: Unexpected Server Error. Please try again.
+                TopLevelError:
+                  description: An example response for an invalid request
+                  value:
+                    errors:
+                      - status: '400'
+                        code: XYZ
+                        title: Bad Request
+                        detail: Request payload exceeds maxiumum count
         '400':
           description: Bad request. Missing one of the required properties in the request body.
   '/lookup_ids/{id}':

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -12,7 +12,7 @@ paths:
       tags:
         - Match
       summary: Search for all matching PII records
-      description: 'Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number in the request body''s `query` property.'
+      description: 'Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number of persons provided in the request.'
       requestBody:
         required: true
         content:
@@ -20,10 +20,12 @@ paths:
             schema:
               type: object
               required:
-                - query
+                - persons
               properties:
-                query:
+                persons:
                   type: array
+                  minItems: 1
+                  maxItems: 50
                   items:
                     type: object
                     required:
@@ -51,26 +53,26 @@ paths:
                         description: PII record's date of birth
             examples:
               All fields:
-                description: 'An example request to query a single individual, with values for all fields'
+                description: 'An example request to query a single person, with values for all fields'
                 value:
-                  query:
+                  persons:
                     - first: string
                       middle: string
                       last: string
                       ssn: 000-00-0000
                       dob: '1970-01-01'
               Only requried fields:
-                description: A request with values only for required fields
+                description: A request to query a single person with values only for required fields
                 value:
-                  query:
+                  persons:
                     - first: string
                       last: string
                       ssn: 000-00-0000
                       dob: '1970-01-01'
-              Multiple Records:
-                description: A request with multiple records
+              Multiple Persons:
+                description: A request with multiple persons
                 value:
-                  query:
+                  persons:
                     - first: string
                       last: string
                       ssn: 000-00-0000
@@ -86,172 +88,254 @@ paths:
             application/json:
               schema:
                 type: object
-                required:
-                  - data
                 properties:
-                  data:
-                    type: array
-                    description: 'Array of match query response items. For every match query item provided in the request, a match response item is returned, even if no matches are found.'
+                  meta:
+                    type: object
+                    nullable: true
+                    description: Provides meta information about the response. A meta property will be present whenever a data property is present.
                     required:
-                      - index
+                      - total
                     properties:
-                      index:
+                      total:
                         type: integer
-                        description: 'The index of the request item that the response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.'
-                      lookup_id:
-                        type: string
-                        nullable: true
-                        description: 'The identifier of the match request item, if a match is present. This ID can be used for looking up the PII of the original match request item.'
-                      matches:
+                        description: The sum total of results plus errors in the data object. This should equal the number of persons provided in the request.
+                  data:
+                    type: object
+                    nullable: true
+                    description: 'The response payload. Either an errors or data property will be present in the response, but not both.'
+                    required:
+                      - results
+                      - errors
+                    properties:
+                      results:
                         type: array
-                        items:
-                          type: object
-                          required:
-                            - last
-                            - ssn
-                            - dob
-                          properties:
-                            first:
-                              type: string
-                              description: First name
-                            middle:
-                              type: string
-                              description: Middle name
-                            last:
-                              type: string
-                              description: Last name
-                            ssn:
-                              type: string
-                              description: Social Security number
-                              pattern: '^\d{3}-\d{2}-\d{4}$'
-                            dob:
-                              type: string
-                              format: date
-                              description: Date of birth
-                            state:
-                              type: string
-                              description: State/territory two-letter postal abbreviation
-                            state_abbr:
-                              type: string
-                              description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
-                              deprecated: true
-                            exception:
-                              type: string
-                              description: Placeholder for value indicating special processing instructions
-                            case_id:
-                              type: string
-                              description: Participant's state-specific case identifier. Can be the same for multiple participants.
-                            participant_id:
-                              type: string
-                              description: Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.
-                            benefits_end_month:
-                              type: string
-                              pattern: '^\d{4}-\d{2}$'
-                              example: 2021-01
-                              description: Participant's ending benefits month
-                            recent_benefit_months:
-                              type: array
-                              items:
-                                type: string
-                                pattern: '^\d{4}-\d{2}$'
-                                example: 2021-01
-                              minItems: 0
-                              maxItems: 3
-                              description: 'List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.'
-                            protect_location:
-                              type: boolean
-                              nullable: true
-                              example: true
-                              description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
+                        description: 'Array of query results. For every person provided in the request, a result is returned for every successful query, even if no matches are found. If a query fails, the failure data will be in the errors array.'
+                        required:
+                          - index
+                        properties:
+                          index:
+                            type: integer
+                            description: 'The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.'
+                          lookup_id:
+                            type: string
+                            nullable: true
+                            description: 'The identifier of the person data, if a match is present. This ID can be used for looking up the PII of the person provided in the original request.'
+                          matches:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                                - last
+                                - ssn
+                                - dob
+                              properties:
+                                first:
+                                  type: string
+                                  description: First name
+                                middle:
+                                  type: string
+                                  description: Middle name
+                                last:
+                                  type: string
+                                  description: Last name
+                                ssn:
+                                  type: string
+                                  description: Social Security number
+                                  pattern: '^\d{3}-\d{2}-\d{4}$'
+                                dob:
+                                  type: string
+                                  format: date
+                                  description: Date of birth
+                                state:
+                                  type: string
+                                  description: State/territory two-letter postal abbreviation
+                                state_abbr:
+                                  type: string
+                                  description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
+                                  deprecated: true
+                                exception:
+                                  type: string
+                                  description: Placeholder for value indicating special processing instructions
+                                case_id:
+                                  type: string
+                                  description: Participant's state-specific case identifier. Can be the same for multiple participants.
+                                participant_id:
+                                  type: string
+                                  description: Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.
+                                benefits_end_month:
+                                  type: string
+                                  pattern: '^\d{4}-\d{2}$'
+                                  example: 2021-01
+                                  description: Participant's ending benefits month
+                                recent_benefit_months:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: '^\d{4}-\d{2}$'
+                                    example: 2021-01
+                                  minItems: 0
+                                  maxItems: 3
+                                  description: 'List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.'
+                                protect_location:
+                                  type: boolean
+                                  nullable: true
+                                  example: true
+                                  description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
+                      errors:
+                        type: array
+                        description: 'Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here.'
+                        required:
+                          - index
+                          - code
+                          - message
+                        properties:
+                          index:
+                            type: integer
+                            description: 'The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.'
+                          code:
+                            type: string
+                            description: The error code
+                          message:
+                            type: string
+                            description: The error message
+                  errors:
+                    type: array
+                    nullable: true
+                    description: 'Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both.'
+                    required:
+                      - code
+                      - message
+                    properties:
+                      code:
+                        type: string
+                        description: The error code
+                      message:
+                        type: string
+                        description: The error message
               examples:
                 Single:
-                  description: A query for a single individual returning a single match
+                  description: A query for a single person returning a single match
                   value:
+                    meta:
+                      total: 1
                     data:
-                      - index: 0
-                        lookup_id: string
-                        matches:
-                          - first: string
-                            middle: string
-                            last: string
-                            ssn: 000-00-0000
-                            dob: '1970-01-01'
-                            state: ea
-                            state_abbr: ea
-                            exception: string
-                            case_id: string
-                            participant_id: string
-                            benefits_end_month: 2021-01
-                            recent_benefit_months:
-                              - 2021-05
-                              - 2021-04
-                              - 2021-03
-                            protect_location: true
+                      results:
+                        - index: 0
+                          lookup_id: string
+                          matches:
+                            - first: string
+                              middle: string
+                              last: string
+                              ssn: 000-00-0000
+                              dob: '1970-01-01'
+                              state: ea
+                              state_abbr: ea
+                              exception: string
+                              case_id: string
+                              participant_id: string
+                              benefits_end_month: 2021-01
+                              recent_benefit_months:
+                                - 2021-05
+                                - 2021-04
+                                - 2021-03
+                              protect_location: true
+                      errors: []
                 None:
-                  description: A query for a single individual returning no matches
+                  description: A query for a single person returning no matches
                   value:
+                    meta:
+                      total: 1
                     data:
-                      - index: 0
-                        lookup_id: null
-                        matches: []
+                      results:
+                        - index: 0
+                          lookup_id: null
+                          matches: []
+                      errors: []
                 Multiple:
-                  description: A query for one individual returning multiple matches
+                  description: A query for one person returning multiple matches
                   value:
+                    meta:
+                      total: 1
                     data:
-                      - index: 0
-                        lookup_id: string
-                        matches:
-                          - first: string
-                            middle: string
-                            last: string
-                            ssn: 000-00-0000
-                            dob: '1970-01-01'
-                            state: eb
-                            state_abbr: eb
-                            exception: string
-                            case_id: string
-                            participant_id: string
-                            benefits_end_month: 2021-01
-                            recent_benefit_months:
-                              - 2021-05
-                              - 2021-04
-                              - 2021-03
-                            protect_location: true
-                          - first: null
-                            middle: null
-                            last: string
-                            ssn: 000-00-0000
-                            dob: '1970-01-01'
-                            state: ec
-                            state_abbr: ec
-                            exception: null
-                            case_id: string
-                            participant_id: null
-                            benefits_end_month: null
-                            protect_location: null
+                      results:
+                        - index: 0
+                          lookup_id: string
+                          matches:
+                            - first: string
+                              middle: string
+                              last: string
+                              ssn: 000-00-0000
+                              dob: '1970-01-01'
+                              state: eb
+                              state_abbr: eb
+                              exception: string
+                              case_id: string
+                              participant_id: string
+                              benefits_end_month: 2021-01
+                              recent_benefit_months:
+                                - 2021-05
+                                - 2021-04
+                                - 2021-03
+                              protect_location: true
+                            - first: null
+                              middle: null
+                              last: string
+                              ssn: 000-00-0000
+                              dob: '1970-01-01'
+                              state: ec
+                              state_abbr: ec
+                              exception: null
+                              case_id: string
+                              participant_id: null
+                              benefits_end_month: null
+                              protect_location: null
+                      errors: []
                 MultipleRecords:
-                  description: A query for two individuals returning one match for each individual
+                  description: A query for two persons returning one match for each person
                   value:
+                    meta:
+                      total: 2
                     data:
-                      - index: 0
-                        lookup_id: string
-                        matches:
-                          - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
-                      - index: 1
-                        lookup_id: string
-                        matches:
-                          - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
+                      results:
+                        - index: 0
+                          lookup_id: string
+                          matches:
+                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                        - index: 1
+                          lookup_id: string
+                          matches:
+                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                      errors: []
                 MultipleRecordsOneMatch:
-                  description: A query for two individuals returning no matches for one individual and a match for the other
+                  description: A query for two persons returning no matches for one person and a match for the other
                   value:
+                    meta:
+                      total: 2
                     data:
-                      - index: 0
-                        lookup_id: null
-                        matches: []
-                      - index: 1
-                        lookup_id: string
-                        matches:
-                          - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/0/matches/1'
+                      results:
+                        - index: 0
+                          lookup_id: null
+                          matches: []
+                        - index: 1
+                          lookup_id: string
+                          matches:
+                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                      errors: []
+                MultipleRecordsOneError:
+                  description: A query for two persons returning a successful result for one person and an error for the other person
+                  value:
+                    meta:
+                      total: 2
+                    data:
+                      results:
+                        - index: 1
+                          lookup_id: string
+                          matches:
+                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                      errors:
+                        - index: 0
+                          code: InternalServerException
+                          message: Unexpected Server Error. Please try again.
         '400':
           description: Bad request. Missing one of the required properties in the request body.
   '/lookup_ids/{id}':
@@ -272,7 +356,7 @@ paths:
                   - data
                 properties:
                   data:
-                    $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/query/items'
+                    $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/persons/items'
               examples:
                 All:
                   description: A response showing a query with values for all fields

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -20,9 +20,9 @@ paths:
             schema:
               type: object
               required:
-                - persons
+                - data
               properties:
-                persons:
+                data:
                   type: array
                   minItems: 1
                   maxItems: 50
@@ -350,7 +350,7 @@ paths:
                   - data
                 properties:
                   data:
-                    $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/persons/items'
+                    $ref: '#/paths/~1query/post/requestBody/content/application~1json/schema/properties/data/items'
               examples:
                 All:
                   description: A response showing a query with values for all fields

--- a/match/docs/openapi/lookup/id.yaml
+++ b/match/docs/openapi/lookup/id.yaml
@@ -2,11 +2,11 @@ get:
   operationId: "Get Lookups by ID"
   tags:
     - "Lookup"
-  summary: "get the original match data related to a Lookup ID"
+  summary: "Get the original match data related to a Lookup ID"
   description: "User can provide a Lookup ID and receive the match data associated with it"
   responses:
     '200':
-      description: "original active match data"
+      description: "Successful response. Returns original match query request item."
       content:
         application/json:
           schema:
@@ -16,4 +16,4 @@ get:
     '400':
       description: "Bad request"
     '404':
-      description: "Not Found"
+      description: "Not found"

--- a/match/docs/openapi/orchestrator/query.yaml
+++ b/match/docs/openapi/orchestrator/query.yaml
@@ -8,7 +8,7 @@ post:
     $ref: '../schemas/match-query.yaml#/MatchQueryRequest'
   responses:
     '200':
-      description: "Matching PII records, if any exist"
+      description: "Successful response. Returns match response items."
       content:
         application/json:
           schema:

--- a/match/docs/openapi/orchestrator/query.yaml
+++ b/match/docs/openapi/orchestrator/query.yaml
@@ -3,17 +3,17 @@ post:
   tags:
     - "Match"
   summary: "Search for all matching PII records"
-  description: "Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number in the request body's `query` property."
+  description: "Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number of persons provided in the request."
   requestBody:
-    $ref: '../schemas/match-query.yaml#/MatchQueryRequest'
+    $ref: '../schemas/match-query.yaml#/MatchRequest'
   responses:
     '200':
       description: "Successful response. Returns match response items."
       content:
         application/json:
           schema:
-            $ref: '../schemas/match-query.yaml#/MatchQueryResponse'
+            $ref: '../schemas/match-query.yaml#/MatchResponse'
           examples:
-            $ref: '../schemas/match-query.yaml#/MatchQueryResponseExamples'
+            $ref: '../schemas/match-query.yaml#/MatchResponseExamples'
     '400':
       description: "Bad request. Missing one of the required properties in the request body."

--- a/match/docs/openapi/schemas/lookup.yaml
+++ b/match/docs/openapi/schemas/lookup.yaml
@@ -5,7 +5,7 @@ LookupIdResponse:
     - data
   properties:
     data:
-      $ref: 'match-query.yaml#/MatchQuery'
+      $ref: 'match-query.yaml#/MatchQueryRequestItem'
 
 LookupIdResponseExamples:
   All:

--- a/match/docs/openapi/schemas/lookup.yaml
+++ b/match/docs/openapi/schemas/lookup.yaml
@@ -5,7 +5,7 @@ LookupIdResponse:
     - data
   properties:
     data:
-      $ref: 'match-query.yaml#/MatchQueryRequestItem'
+      $ref: 'match-query.yaml#/Person'
 
 LookupIdResponseExamples:
   All:

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -9,10 +9,12 @@ MatchQueryRequest:
             - query
         properties:
           query:
-            $ref: '#/MatchQuery'
+            type: array
+            items:
+              $ref: '#/MatchQueryRequestItem'
       examples:
         $ref: '#/MatchQueryRequestExamples'
-MatchQuery:
+MatchQueryRequestItem:
   type: object
   required:
     - first
@@ -42,22 +44,41 @@ MatchQueryRequestExamples:
     description: "A request with values for all fields"
     value:
       query:
-        first: "string"
-        middle: "string"
-        last: "string"
-        ssn: "000-00-0000"
-        dob: "1970-01-01"
+        - first: "string"
+          middle: "string"
+          last: "string"
+          ssn: "000-00-0000"
+          dob: "1970-01-01"
   "Only requried fields":
     description: "A request with values only for required fields"
     value:
       query:
-        first: "string"
-        last: "string"
-        ssn: "000-00-0000"
-        dob: "1970-01-01"
+        - first: "string"
+          last: "string"
+          ssn: "000-00-0000"
+          dob: "1970-01-01"
+  "Multiple Records":
+    description: "A request with multiple records"
+    value:
+      query:
+        - first: "string"
+          last: "string"
+          ssn: "000-00-0000"
+          dob: "1970-01-01"
+        - first: "string"
+          last: "string"
+          ssn: "000-00-0001"
+          dob: "1970-01-02"
 
 #/components/schemas/MatchQueryResponse
 MatchQueryResponse:
+  type: object
+  properties:
+    data:
+      type: array
+      $ref: '#/MatchQueryResponseItem'
+
+MatchQueryResponseItem:
   type: object
   properties:
     lookup_id:
@@ -73,18 +94,31 @@ MatchQueryResponseExamples:
   Single:
     description: "A query returning a single match"
     value:
-      lookup_id: "string"
-      matches:
-        - $ref: './pii-record.yaml#/PiiRecordExamples/All'
+      data:
+        - lookup_id: "string"
+          matches:
+            - $ref: './pii-record.yaml#/PiiRecordExamples/All'
   None:
     description: "A query returning no matches"
     value:
-      lookup_id: null
-      matches: []
+      data:
+        - lookup_id: null
+          matches: []
   Multiple:
-    description: "A query returning multiple matches"
+    description: "A query returning multiple matches for one record"
     value:
-      lookup_id: "string"
-      matches:
-        - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
-        - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+      data:
+        - lookup_id: "string"
+          matches:
+            - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
+            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+  MultipleRecords:
+    description: "A query returning one match for multiple records"
+    value:
+      data:
+        - lookup_id: "string"
+          matches:
+            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        - lookup_id: "string"
+          matches:
+            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -73,10 +73,13 @@ MatchQueryRequestExamples:
 #/components/schemas/MatchQueryResponse
 MatchQueryResponse:
   type: object
+  required:
+    - data
   properties:
     data:
       type: array
       $ref: '#/MatchQueryResponseItem'
+      description: Array of match query response items. For every match query item provided in the request, a match response item is returned, even if no matches are found.
 
 MatchQueryResponseItem:
   type: object
@@ -85,7 +88,7 @@ MatchQueryResponseItem:
   properties:
     index:
       type: integer
-      description: Index of match query request item that match query response item corresponds to, starting from 0. For every match query item provided in the request, a match response item is returned, even if no matches are found. Index is derived from the implicit order of match query request items provided in the request.
+      description: Index of match query request item that match query response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.
     lookup_id:
       type: string
       nullable: true

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -88,11 +88,11 @@ MatchQueryResponseItem:
   properties:
     index:
       type: integer
-      description: Index of match query request item that match query response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.
+      description: The index of the request item that the response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.
     lookup_id:
       type: string
       nullable: true
-      description: "the identifier of the match request"
+      description: "The identifier of the match request item, if a match is present. This ID can be used for looking up the PII of the original match request item."
     matches:
       type: array
       items:

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -80,7 +80,12 @@ MatchQueryResponse:
 
 MatchQueryResponseItem:
   type: object
+  required:
+    - index
   properties:
+    index:
+      type: integer
+      description: Index of match query request item that match query response item corresponds to, starting from 0. For every match query item provided in the request, a match response item is returned, even if no matches are found. Index is derived from the implicit order of match query request items provided in the request.
     lookup_id:
       type: string
       nullable: true
@@ -95,20 +100,23 @@ MatchQueryResponseExamples:
     description: "A query returning a single match"
     value:
       data:
-        - lookup_id: "string"
+        - index: 0
+          lookup_id: "string"
           matches:
             - $ref: './pii-record.yaml#/PiiRecordExamples/All'
   None:
     description: "A query returning no matches"
     value:
       data:
-        - lookup_id: null
+        - index: 0
+          lookup_id: null
           matches: []
   Multiple:
     description: "A query returning multiple matches for one record"
     value:
       data:
-        - lookup_id: "string"
+        - index: 0
+          lookup_id: "string"
           matches:
             - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
             - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
@@ -116,9 +124,11 @@ MatchQueryResponseExamples:
     description: "A query returning one match for multiple records"
     value:
       data:
-        - lookup_id: "string"
+        - index: 0
+          lookup_id: "string"
           matches:
             - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
-        - lookup_id: "string"
+        - index: 1
+          lookup_id: "string"
           matches:
             - $ref: './pii-record.yaml#/PiiRecordExamples/Required'

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -41,7 +41,7 @@ MatchQueryRequestItem:
       description: "PII record's date of birth"
 MatchQueryRequestExamples:
   "All fields":
-    description: "A request with values for all fields"
+    description: "An example request to query a single individual, with values for all fields"
     value:
       query:
         - first: "string"
@@ -100,7 +100,7 @@ MatchQueryResponseItem:
 
 MatchQueryResponseExamples:
   Single:
-    description: "A query returning a single match"
+    description: "A query for a single individual returning a single match"
     value:
       data:
         - index: 0
@@ -108,14 +108,14 @@ MatchQueryResponseExamples:
           matches:
             - $ref: './pii-record.yaml#/PiiRecordExamples/All'
   None:
-    description: "A query returning no matches"
+    description: "A query for a single individual returning no matches"
     value:
       data:
         - index: 0
           lookup_id: null
           matches: []
   Multiple:
-    description: "A query returning multiple matches for one record"
+    description: "A query for one individual returning multiple matches"
     value:
       data:
         - index: 0
@@ -124,13 +124,24 @@ MatchQueryResponseExamples:
             - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
             - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
   MultipleRecords:
-    description: "A query returning one match for multiple records"
+    description: "A query for two individuals returning one match for each individual"
     value:
       data:
         - index: 0
           lookup_id: "string"
           matches:
             - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        - index: 1
+          lookup_id: "string"
+          matches:
+            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+  MultipleRecordsOneMatch:
+    description: "A query for two individuals returning no matches for one individual and a match for the other"
+    value:
+      data:
+        - index: 0
+          lookup_id: null
+          matches: []
         - index: 1
           lookup_id: "string"
           matches:

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -112,6 +112,7 @@ Result:
   type: object
   required:
     - index
+    - matches
   properties:
     index:
       type: integer

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -45,7 +45,7 @@ MatchRequestExamples:
   "All fields":
     description: "An example request to query a single person, with values for all fields"
     value:
-      persons:
+      data:
         - first: "string"
           middle: "string"
           last: "string"
@@ -54,7 +54,7 @@ MatchRequestExamples:
   "Only requried fields":
     description: "A request to query a single person with values only for required fields"
     value:
-      persons:
+      data:
         - first: "string"
           last: "string"
           ssn: "000-00-0000"
@@ -62,7 +62,7 @@ MatchRequestExamples:
   "Multiple Persons":
     description: "A request with multiple persons"
     value:
-      persons:
+      data:
         - first: "string"
           last: "string"
           ssn: "000-00-0000"

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -76,16 +76,6 @@ MatchRequestExamples:
 MatchResponse:
   type: object
   properties:
-    meta:
-      type: object
-      nullable: true
-      description: Provides meta information about the response. A meta property will be present whenever a data property is present.
-      required:
-        - total
-      properties:
-        total:
-          type: integer
-          description: The sum total of results plus errors in the data object. This should equal the number of persons provided in the request.
     data:
       type: object
       nullable: true
@@ -130,8 +120,6 @@ MatchResponseExamples:
   Single:
     description: "A query for a single person returning a single match"
     value:
-      meta:
-        total: 1
       data:
         results:
           - index: 0
@@ -142,8 +130,6 @@ MatchResponseExamples:
   None:
     description: "A query for a single person returning no matches"
     value:
-      meta:
-        total: 1
       data:
         results:
           - index: 0
@@ -153,8 +139,6 @@ MatchResponseExamples:
   Multiple:
     description: "A query for one person returning multiple matches"
     value:
-      meta:
-        total: 1
       data:
         results:
           - index: 0
@@ -166,8 +150,6 @@ MatchResponseExamples:
   MultipleRecords:
     description: "A query for two persons returning one match for each person"
     value:
-      meta:
-        total: 2
       data:
         results:
           - index: 0
@@ -182,8 +164,6 @@ MatchResponseExamples:
   MultipleRecordsOneMatch:
     description: "A query for two persons returning no matches for one person and a match for the other"
     value:
-      meta:
-        total: 2
       data:
         results:
           - index: 0
@@ -197,8 +177,6 @@ MatchResponseExamples:
   MultipleRecordsOneError:
     description: "A query for two persons returning a successful result for one person and an error for the other person"
     value:
-      meta:
-        total: 2
       data:
         results:
           - index: 1

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -1,20 +1,22 @@
-#/components/requestBodies/MatchQueryRequest
-MatchQueryRequest:
+#/components/requestBodies/MatchRequest
+MatchRequest:
   required: true
   content:
     application/json:
       schema:
         type: object
         required:
-            - query
+            - persons
         properties:
-          query:
+          persons:
             type: array
+            minItems: 1
+            maxItems: 50
             items:
-              $ref: '#/MatchQueryRequestItem'
+              $ref: '#/Person'
       examples:
-        $ref: '#/MatchQueryRequestExamples'
-MatchQueryRequestItem:
+        $ref: '#/MatchRequestExamples'
+Person:
   type: object
   required:
     - first
@@ -39,28 +41,28 @@ MatchQueryRequestItem:
       type: string
       format: "date"
       description: "PII record's date of birth"
-MatchQueryRequestExamples:
+MatchRequestExamples:
   "All fields":
-    description: "An example request to query a single individual, with values for all fields"
+    description: "An example request to query a single person, with values for all fields"
     value:
-      query:
+      persons:
         - first: "string"
           middle: "string"
           last: "string"
           ssn: "000-00-0000"
           dob: "1970-01-01"
   "Only requried fields":
-    description: "A request with values only for required fields"
+    description: "A request to query a single person with values only for required fields"
     value:
-      query:
+      persons:
         - first: "string"
           last: "string"
           ssn: "000-00-0000"
           dob: "1970-01-01"
-  "Multiple Records":
-    description: "A request with multiple records"
+  "Multiple Persons":
+    description: "A request with multiple persons"
     value:
-      query:
+      persons:
         - first: "string"
           last: "string"
           ssn: "000-00-0000"
@@ -70,79 +72,168 @@ MatchQueryRequestExamples:
           ssn: "000-00-0001"
           dob: "1970-01-02"
 
-#/components/schemas/MatchQueryResponse
-MatchQueryResponse:
+#/components/schemas/MatchResponse
+MatchResponse:
   type: object
-  required:
-    - data
   properties:
+    meta:
+      type: object
+      nullable: true
+      description: Provides meta information about the response. A meta property will be present whenever a data property is present.
+      required:
+        - total
+      properties:
+        total:
+          type: integer
+          description: The sum total of results plus errors in the data object. This should equal the number of persons provided in the request.
     data:
+      type: object
+      nullable: true
+      description: The response payload. Either an errors or data property will be present in the response, but not both.
+      required:
+        - results
+        - errors
+      properties:
+        results:
+          type: array
+          $ref: '#/Result'
+          description: "Array of query results. For every person provided in the request, a result is returned for every successful query, even if no matches are found. If a query fails, the failure data will be in the errors array."
+        errors:
+          type: array
+          description: "Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here."
+          $ref: '#/DataError'
+    errors:
       type: array
-      $ref: '#/MatchQueryResponseItem'
-      description: Array of match query response items. For every match query item provided in the request, a match response item is returned, even if no matches are found.
+      nullable: true
+      description: "Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both."
+      $ref: '#/ResponseError'
 
-MatchQueryResponseItem:
+Result:
   type: object
   required:
     - index
   properties:
     index:
       type: integer
-      description: The index of the request item that the response item corresponds to, starting from 0. Index is derived from the implicit order of match query request items provided in the request.
+      description: "The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request."
     lookup_id:
       type: string
       nullable: true
-      description: "The identifier of the match request item, if a match is present. This ID can be used for looking up the PII of the original match request item."
+      description: "The identifier of the person data, if a match is present. This ID can be used for looking up the PII of the person provided in the original request."
     matches:
       type: array
       items:
         $ref: './pii-record.yaml#/PiiRecord'
 
-MatchQueryResponseExamples:
+MatchResponseExamples:
   Single:
-    description: "A query for a single individual returning a single match"
+    description: "A query for a single person returning a single match"
     value:
+      meta:
+        total: 1
       data:
-        - index: 0
-          lookup_id: "string"
-          matches:
-            - $ref: './pii-record.yaml#/PiiRecordExamples/All'
+        results:
+          - index: 0
+            lookup_id: "string"
+            matches:
+              - $ref: './pii-record.yaml#/PiiRecordExamples/All'
+        errors: []
   None:
-    description: "A query for a single individual returning no matches"
+    description: "A query for a single person returning no matches"
     value:
+      meta:
+        total: 1
       data:
-        - index: 0
-          lookup_id: null
-          matches: []
+        results:
+          - index: 0
+            lookup_id: null
+            matches: []
+        errors: []
   Multiple:
-    description: "A query for one individual returning multiple matches"
+    description: "A query for one person returning multiple matches"
     value:
+      meta:
+        total: 1
       data:
-        - index: 0
-          lookup_id: "string"
-          matches:
-            - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
-            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        results:
+          - index: 0
+            lookup_id: "string"
+            matches:
+              - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
+              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        errors: []
   MultipleRecords:
-    description: "A query for two individuals returning one match for each individual"
+    description: "A query for two persons returning one match for each person"
     value:
+      meta:
+        total: 2
       data:
-        - index: 0
-          lookup_id: "string"
-          matches:
-            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
-        - index: 1
-          lookup_id: "string"
-          matches:
-            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        results:
+          - index: 0
+            lookup_id: "string"
+            matches:
+              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+          - index: 1
+            lookup_id: "string"
+            matches:
+              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        errors: []
   MultipleRecordsOneMatch:
-    description: "A query for two individuals returning no matches for one individual and a match for the other"
+    description: "A query for two persons returning no matches for one person and a match for the other"
     value:
+      meta:
+        total: 2
       data:
-        - index: 0
-          lookup_id: null
-          matches: []
-        - index: 1
-          lookup_id: "string"
-          matches:
-            - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        results:
+          - index: 0
+            lookup_id: null
+            matches: []
+          - index: 1
+            lookup_id: "string"
+            matches:
+              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        errors: []
+  MultipleRecordsOneError:
+    description: "A query for two persons returning a successful result for one person and an error for the other person"
+    value:
+      meta:
+        total: 2
+      data:
+        results:
+          - index: 1
+            lookup_id: "string"
+            matches:
+              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+        errors:
+          - index: 0
+            code: "InternalServerException"
+            message: "Unexpected Server Error. Please try again."
+DataError:
+  type: object
+  required:
+    - index
+    - code
+    - message
+  properties:
+    index:
+      type: integer
+      description: "The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request."
+    code:
+      type: string
+      description: "The error code"
+    message:
+      type: string
+      description: "The error message"
+
+ResponseError:
+  type: object
+  required:
+    - code
+    - message
+  properties:
+    code:
+      type: string
+      description: "The error code"
+    message:
+      type: string
+      description: "The error message"

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -6,9 +6,9 @@ MatchRequest:
       schema:
         type: object
         required:
-            - persons
+            - data
         properties:
-          persons:
+          data:
             type: array
             minItems: 1
             maxItems: 50

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -185,34 +185,50 @@ MatchResponseExamples:
               - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
         errors:
           - index: 0
-            code: "InternalServerException"
-            message: "Unexpected Server Error. Please try again."
+            code: "XYZ"
+            title: "Internal Server Exception"
+            detail: "Unexpected Server Error. Please try again."
+  TopLevelError:
+    description: "An example response for an invalid request"
+    value:
+      errors:
+        - status: "400"
+          code: "XYZ"
+          title: "Bad Request"
+          detail: "Request payload exceeds maxiumum count"
+
 DataError:
   type: object
   required:
     - index
-    - code
-    - message
   properties:
     index:
       type: integer
       description: "The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request."
     code:
       type: string
-      description: "The error code"
-    message:
+      description: "The application-specific error code"
+    title:
       type: string
-      description: "The error message"
+      description: "The short, human-readable summary of the error, consistent across all occurrences of the error"
+    detail:
+      type: string
+      description: "The human-readable explanation specific to this occurrence of the error"
 
 ResponseError:
   type: object
   required:
-    - code
-    - message
+    - status
   properties:
+    status:
+      type: string
+      description: "The HTTP status code"
     code:
       type: string
-      description: "The error code"
-    message:
+      description: "The application-specific error code"
+    title:
       type: string
-      description: "The error message"
+      description: "The short, human-readable summary of the error, consistent across all occurrences of the error"
+    detail:
+      type: string
+      description: "The human-readable explanation specific to this occurrence of the error"

--- a/match/docs/openapi/schemas/pii-record.yaml
+++ b/match/docs/openapi/schemas/pii-record.yaml
@@ -35,10 +35,10 @@ PiiRecord:
       description: "Placeholder for value indicating special processing instructions"
     case_id:
       type: string
-      description: "Participant's state-specific case identifier"
+      description: "Participant's state-specific case identifier. Can be the same for multiple participants."
     participant_id:
       type: string
-      description: "Participant's state-specific identifier. Must not be social security number or any personal identifiable information."
+      description: "Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII."
     benefits_end_month:
       type: string
       pattern: '^\d{4}-\d{2}$'


### PR DESCRIPTION
Satisfies schema/documentation changes only for #368 

I found it easiest to review the changes by viewing the `docs/openapi/generated/duplicate-participation-api/openapi.md` file for this branch. 

Summarizing the different areas we talked about:

Switching to a Bulk API means:
1. we need both item-level and top-level error handling
1. we need to properly relate people requested to their results
1. metadata may become more important 
1. parameter and property names will change

All these things pushed us to think about standardizing our response schemas across our APIs. We're considering [JSON API](https://github.com/18F/piipan/pull/1119) for this purpose. 

### Error handling
See the schema for how top-level and item-level errors are handled. 

For item-level errors, we're using Amazon's Bulk API approach to having either a result or errors object for each person in the response. 

Note that JSON API has either a `data` or `errors` property in its top-level response, but not both.

### Relating People to their Results
Also takes the Amazon approach of using an index for each result and errors object. See the schema for more details on index.

### Metadata
JSON API has an optional top-level `meta` property. Since we can't think of useful metadata for this endpoint at the moment, we're going to leave it off of this response. 

### Naming
Apart from the top-level JSON API spec names, we decided to be as semantic as we could with API naming so it's easier for states to understand. The PII is representing persons, so that's what we call them in the API. 

Since using JSON API spec names for responses but not requests was a bit illogical, I've conformed the request body to use `data` instead of `persons`. I also updated the proposed [ADR](https://github.com/18F/piipan/pull/1119/files) to reflect that. 



