### PR TITLE
Refine docs and tools for calling secured APIs locally

### DIFF
--- a/dashboard/docs/dashboard.md
+++ b/dashboard/docs/dashboard.md
@@ -15,7 +15,9 @@ To run the app locally:
 export MetricsApiUri=https://tts-func-metricsapi-dev.azurewebsites.net/api/getparticipantuploads
 ```
 
-3. Run the app using the `dotnet run` CLI command:
+3. If using a remote metrics API URI, follow the [instructions](../../docs/securing-internal-apis.md) to assign your Azure user account the `Metrics.Read` role for the remote metrics API Function App and authorize the Azure CLI.
+
+4. Run the app using the `dotnet run` CLI command:
 ```
     cd dashboard/src/Piipan.Dashboard
     dotnet run
@@ -26,7 +28,7 @@ Alternatively, use the `watch` command to update the app upon file changes:
     dotnet watch run
 ```
 
-4. Visit https://localhost:5001
+5. Visit https://localhost:5001
 
 ## Building Assets
 

--- a/docs/securing-internal-apis.md
+++ b/docs/securing-internal-apis.md
@@ -18,6 +18,7 @@ This document details how the internal APIs are utilized, how to secure them, ho
 - [Configuring the server](#configuring-the-server)
 - [Configuring the client](#configuring-the-client)
 - [Making authenticated API calls](#making-authenticated-api-calls)
+- [Working locally](#working-locally)
 - [Definitions](#definitions)
 - [Miscellaneous notes](#miscellaneous-notes)
 - [Virtual Network Integration](#virtual-network-integration)
@@ -80,6 +81,38 @@ An illustrated version of this flow:
   <a href="./piipan-internal-authentication.png"><img src="./piipan-internal-authentication.png" alt="Authenticated API diagram"></a>
   <!-- Google Drawing: https://docs.google.com/drawings/d/1PlAZwHBbf1QkRC4LDkce7FmnUq25veJGj2Vafyj9-FY/edit?usp=sharing -->
 </p>
+
+## Working locally
+
+Developers occasionally need to connect locally running applications to remote APIs to perform testing. With App Service Authentication enabled, API requests that originate locally must follow the same authentication approach outlined above. However, instead of using a service principal, developers can use their locally authenticated CLI user:
+
+1. Log in to the AZ CLI:
+```
+az login
+```
+
+2. Use `assign-app-role` to assign your user account the necessary [application role](#application-roles):
+```
+./tools/assign-app-role.bash <azure-env> <function-app-name> <app-role-name>
+```
+
+3. Use `authorize-cli` to add the Azure CLI as an authorized client application for the Function's application registration:
+```
+./tools/authorize-cli.bash <azure-env> <function-app-name>
+```
+
+4. Modify the application to conditionally use the CLI to obtain access tokens when running locally. The specific approach will vary application to application, but may resemble (assuming the use of `Piipan.Shared.Authentication`):
+```
+ITokenProvider tokenProvider;
+if (_env.IsDevelopment())
+{
+    tokenProvider = new CliTokenProvider();
+}
+else
+{
+    tokenProvider = new EasyAuthTokenProvider();
+}
+```
 
 ## Definitions
 

--- a/match/docs/orchestrator-match.md
+++ b/match/docs/orchestrator-match.md
@@ -43,8 +43,7 @@ Local development is achieved by connecting a locally running instance of the or
 
 1. Run `func azure functionapp fetch-app-settings <remote orchestrator name>` to ensure you have up-to-date local settings configured in `local.settings.json`.
 1. Run `func settings add DEVELOPMENT true` to add a `"DEVELOPMENT"` setting with a value of `"true"` to `local.settings.json`. This triggers the orchestrator to use your Azure CLI credentials when authenticating with the state APIs.
-1. Assign your user account the `StateApi.Query` role for each state the orchestrator queries. Assignment can be done using the [`tools/assign-app-role.bash`](../../tools/assign-app-role.bash) script. E.g., `./assign-app-role.bash tts/dev <remote state function name> StateApi.Query`.
-1. Add the Azure CLI as an authorized client application to each state API's application object. This can be done using [`tools/authorize-cli.bash`](../../tools/authorize-cli.bash). E.g., `./authorize-cli.bash tts/dev <application ID URI>`, where [`application ID URI`](../../docs/securing-internal-apis.md#application-id-uri) is the base URL of the API's Azure Function *without a trailing slash*.
+1. Follow the [instructions](../../docs/securing-internal-apis.md) to assign your Azure user account the `StateApi.Query` role for the remote state Function App(s) and authorize the Azure CLI.
 
 With the orchestrator running locally (`func start` or `dotnet watch msbuild /t:RunFunctions`), any requests to the local endpoint will now use the user account authorized with Azure CLI to obtain access tokens from the per-state APIs.
 
@@ -63,7 +62,6 @@ func azure functionapp publish <app_name> --dotnet
 ## Remote testing
 
 To test the orchestrator remotely:
-1. Assign your user account the `OrchestratorApi.Query` role for the remote orchestrator application. Assignment can be done using the [`tools/assign-app-role.bash`](../../tools/assign-app-role.bash) script. E.g., `./assign-app-role.bash tts/dev <remote orchestrator name> OrchestratorApi.Query`.
-1. Ensure the Azure CLI has been added as an authorized client application to the orchestrator's application object (see [local development](#local-development)).
+1. Follow the [instructions](../../docs/securing-internal-apis.md) to assign your Azure user account the `OrchestratorApi.Query` role for the remote orchestrator Function App and authorize the Azure CLI.
 1. Retrieve a token for your user using the Azure CLI: `az account get-access-token --resource <orchestrator application ID URI>`.
 1. Send a request to the remote endpoint—perhaps using a tool like Postman or `curl`—and include the access token in the Authorization header: `Authorization: Bearer {token}`.

--- a/match/docs/state-match.md
+++ b/match/docs/state-match.md
@@ -75,7 +75,6 @@ Each Function App is configured to use Azure App Service Authentication (aka "Ea
 ## Remote testing
 
 To test a deployed state API from your local environment:
-1. Assign your Azure user account the `StateApi.Query` role for the remote state Function App. Assignment can be done using the [`tools/assign-app-role.bash`](../../tools/assign-app-role.bash) script. E.g., `./assign-app-role.bash tts/dev <remote state name> StateApi.Query`.
-1. Add the Azure CLI as an authorized client application to the remote state Function App's application object. This can be done using [`tools/authorize-cli.bash`](../../tools/authorize-cli.bash). E.g., `./authorize-cli.bash tts/dev <application ID URI>`, where [`application ID URI`](../../docs/securing-internal-apis.md#application-id-uri) is the base URL of the Function App *without a trailing slash*.
+1. Follow the [instructions](../../docs/securing-internal-apis.md) to assign your Azure user account the `StateApi.Query` role for the remote state Function App and authorize the Azure CLI.
 1. Retrieve a token for your user using the Azure CLI: `az account get-access-token --resource <application ID URI>`.
 1. Send a request to the remote endpoint—perhaps using a tool like Postman or `curl`—and include the access token in the Authorization header: `Authorization: Bearer {token}`.

--- a/query-tool/docs/query-tool.md
+++ b/query-tool/docs/query-tool.md
@@ -11,7 +11,14 @@ To run the app locally:
     dotnet dev-certs https --trust
 ```
 
-2. Run the app using the `dotnet run` CLI command:
+2. Set the `OrchApiUri` environment variable to a local or remote instance of `Piipan.Match.Orchestrator`:
+```
+export OrchApiUri=https://tts-func-orchestrator-dev.azurewebsites.net/api/v1/
+```
+
+3. If using a remote orchestrator URI, follow the [instructions](../../docs/securing-internal-apis.md) to assign your Azure user account the `OrchestratorApi.Query` role for the remote orchestrator Function App and authorize the Azure CLI.
+
+4. Run the app using the `dotnet run` CLI command:
 ```
     cd query-tool/src/Piipan.QueryTool
     dotnet run
@@ -22,7 +29,8 @@ Alternatively, use the `watch` command to update the app upon file changes:
     dotnet watch run
 ```
 
-3. Visit https://localhost:5001
+5. Visit https://localhost:5001
+
 
 ### Building Assets
 

--- a/tools/assign-app-role.bash
+++ b/tools/assign-app-role.bash
@@ -1,13 +1,15 @@
 #!/bin/bash
 #
-# Assigns the current CLI user to the specified application role of the
+# Assigns the current CLI user the specified application role of the
 # specified Azure Function. Used to enable the use of Azure CLI credentials
 # (i.e., `Azure.Identity.AzureCliCredential`) when connecting to remote APIs
 # which have been secured using App Service Authentication. Only intended
 # for development environments.
 #
-# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# <azure-env> is the name of the deployment environment (e.g., "tts/dev").
 # See iac/env for available environments.
+# <func-app-name> is the name of the Function app resource.
+# <role-name> is the name of a valid application role
 #
 # usage: assign-app-role.bash <azure-env> <func-app-name> <role-name>
 
@@ -69,6 +71,8 @@ main () {
     --uri "https://graph${domain}/v1.0/users/${user}/appRoleAssignments" \
     --headers 'Content-Type=application/json' \
     --body "$json"
+
+  script_completed
 }
 
 main "$@"

--- a/tools/authorize-cli.bash
+++ b/tools/authorize-cli.bash
@@ -5,12 +5,11 @@
 # the CLI (e.g., `az account get-access-token <app-uri>`). Access tokens
 # can be used to call internal APIs which are protected by Easy Auth.
 #
-# azure-env is the name of the deployment environment (e.g., "tts/dev").
+# <azure-env> is the name of the deployment environment (e.g., "tts/dev").
 # See iac/env for available environments.
+# <func-app-name> is the name of the Function app resource.
 #
-# app-uri is the application ID URI. See docs/securing-internal-apis.md.
-#
-# usage: assign-app-role.bash <azure-env> <app-uri>
+# usage: assign-app-role.bash <azure-env> <func-app-name>
 
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/common.bash || exit
@@ -24,16 +23,16 @@ main () {
   source "$(dirname "$0")"/../iac/iac-common.bash
   verify_cloud
 
-  app_uri=$2
+  func=$2
 
   # For references to hard-coded ID see:
   # - https://docs.microsoft.com/en-us/azure-stack/user/azure-stack-rest-api-use?view=azs-2008#example
   # - https://github.com/Azure/azure-cli/blob/24e0b9ef8716e16b9e38c9bb123a734a6cf550eb/src/azure-cli-core/azure/cli/core/_profile.py#L65
   CLI_ID="04b07795-8ddb-461a-bbee-02f9e1bf7b46"
   object_id=$(\
-    az ad app show \
-      --id "$app_uri" \
-      --query objectId \
+    az ad app list \
+      --display-name "$func" \
+      --query "[0].objectId" \
       -o tsv)
   # shellcheck disable=SC2016
   permission_id=$(\
@@ -56,6 +55,8 @@ main () {
     -u "https://graph.microsoft.com/v1.0/applications/${object_id}" \
     --headers 'Content-Type=application/json' \
     --body "$json"
+
+  script_completed
 }
 
 main "$@"


### PR DESCRIPTION
- Bring tool parameters into sync
- Centralize docs, link out in sub-system docs

Closes #1091.
Follow up from #1092.