### PR TITLE
Use managed identity when metrics functions connect to database

### DIFF
--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/Piipan.Metrics.Api.csproj
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/Piipan.Metrics.Api.csproj
@@ -22,5 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Piipan.Metrics.Models\Piipan.Metrics.Models.csproj" />
+    <ProjectReference Include="..\..\..\..\shared\src\Piipan.Shared\Piipan.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/packages.lock.json
@@ -1584,6 +1584,13 @@
       },
       "piipan.metrics.models": {
         "type": "Project"
+      },
+      "piipan.shared": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Core": "1.15.0",
+          "Azure.Identity": "1.4.0"
+        }
       }
     }
   }

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Collect/Piipan.Metrics.Collect.csproj
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Collect/Piipan.Metrics.Collect.csproj
@@ -21,4 +21,7 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\shared\src\Piipan.Shared\Piipan.Shared.csproj" />
+  </ItemGroup>
 </Project>

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Collect/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Collect/packages.lock.json
@@ -1622,6 +1622,13 @@
           "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "10.0.2"
         }
+      },
+      "piipan.shared": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Core": "1.15.0",
+          "Azure.Identity": "1.4.0"
+        }
       }
     }
   }

--- a/metrics/tests/Piipan.Metrics.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Tests/packages.lock.json
@@ -1847,7 +1847,8 @@
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
           "Npgsql": "5.0.7",
-          "Piipan.Metrics.Models": "1.0.0"
+          "Piipan.Metrics.Models": "1.0.0",
+          "Piipan.Shared": "1.0.0"
         }
       },
       "piipan.metrics.collect": {
@@ -1857,11 +1858,19 @@
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "2.1.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "5.0.7"
+          "Npgsql": "5.0.7",
+          "Piipan.Shared": "1.0.0"
         }
       },
       "piipan.metrics.models": {
         "type": "Project"
+      },
+      "piipan.shared": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Core": "1.15.0",
+          "Azure.Identity": "1.4.0"
+        }
       }
     }
   }


### PR DESCRIPTION
- Update connection strings, switching user to system-assigned identity
- Remove unnecessary Key Vault configuration
- Move system-assigned identity creation to initial function creation command
- Update application code to use managed identity and shared authentication library when building database connection string

Closes #409.

IaC has been run against `tts/dev`.

Deploy notes:
- Manually delete unused `kv-metrics` Key Vault
- Manually revoke permissions in `kv-core` for each Function app:
```
principalId=$(az functionapp identity show \
  -g "RESOURCE_GROUP" \
  -n "$METRICS_COLLECT_APP_NAME" \
  --query principalId \
  -o tsv)
az keyvault delete-policy \
  -n "$VAULT_NAME" \
  --object-id "$principalId"
```