### PR TITLE
Change App Service instances to Windows

### DIFF
--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -40,6 +40,7 @@
                     "value": "dotnetcore"
                 }
             ],
+            // Use 64-bit runtime on Windows for consistency with local Linux and macOS dev environments
             "use32BitWorkerProcess": false,
             "ipSecurityRestrictions": [],
             "ftpsState": "Disabled",
@@ -67,6 +68,7 @@
             },
             "kind": "windows",
             "properties": {
+                // Must be false for Windows deployments
                 "reserved": false
             }
         },

--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -31,7 +31,16 @@
         "appName": "[concat(parameters('appName'))]",
         "sku": "S1",
         "baseSiteConfig": {
-            "linuxFxVersion": "DOTNETCORE|3.1",
+            // .NET 3.1 Core uses "v4.0", .NET 5 uses "v5.0"
+            "netFrameworkVersion": "v4.0",
+            "metadata": [
+                {
+                    // .NET 3.1 Core uses "dotnetcore", .NET 5 uses "dotnet"
+                    "name": "CURRENT_STACK",
+                    "value": "dotnetcore"
+                }
+            ],
+            "use32BitWorkerProcess": false,
             "ipSecurityRestrictions": [],
             "ftpsState": "Disabled",
             "appSettings": [
@@ -56,9 +65,9 @@
             "sku": {
                 "name": "[variables('sku')]"
             },
-            "kind": "linux",
+            "kind": "windows",
             "properties": {
-                "reserved": true
+                "reserved": false
             }
         },
         {

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -40,6 +40,7 @@
                     "value": "dotnetcore"
                 }
             ],
+            // Use 64-bit runtime on Windows for consistency with local Linux and macOS dev environments
             "use32BitWorkerProcess": false,
             "ipSecurityRestrictions": [],
             "ftpsState": "Disabled",
@@ -67,6 +68,7 @@
             },
             "kind": "windows",
             "properties": {
+                // Must be false for Windows deployments
                 "reserved": false
             }
         },

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -31,7 +31,16 @@
         "appName": "[concat(parameters('appName'))]",
         "sku": "S1",
         "baseSiteConfig": {
-            "linuxFxVersion": "DOTNETCORE|3.1",
+            // .NET 3.1 Core uses "v4.0", .NET 5 uses "v5.0"
+            "netFrameworkVersion": "v4.0",
+            "metadata": [
+                {
+                    // .NET 3.1 Core uses "dotnetcore", .NET 5 uses "dotnet"
+                    "name": "CURRENT_STACK",
+                    "value": "dotnetcore"
+                }
+            ],
+            "use32BitWorkerProcess": false,
             "ipSecurityRestrictions": [],
             "ftpsState": "Disabled",
             "appSettings": [
@@ -56,9 +65,9 @@
             "sku": {
                 "name": "[variables('sku')]"
             },
-            "kind": "linux",
+            "kind": "windows",
             "properties": {
-                "reserved": true
+                "reserved": false
             }
         },
         {

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -21,7 +21,7 @@ CURRENT_USER_OBJID=$(az ad signed-in-user show --query objectId --output tsv)
 SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 
 # Name of App Service Plan, used by both query tool and dashboard
-APP_SERVICE_PLAN=piipan-app-plan
+APP_SERVICE_PLAN=plan-apps2-$ENV
 
 # App Service Plan used by function apps with VNet integration
 APP_SERVICE_PLAN_FUNC_NAME=plan-apps1-$ENV


### PR DESCRIPTION
Closes #1042. App Service instances under Linux to not have as many logging options and do not have the networking UI in the portal that makes it easy to understand the networking config.

Updated IaC has been run on tts/dev.

Deploy notes:
- manually drop existing app service instances as cannot update in place due to platform change/service plan change
- rerun IaC
- manually drop obsolete Linux service plan `piipan-app-plan`