### PR TITLE
Give read/write role privileges for sequences

### DIFF
--- a/iac/create-core-databases.bash
+++ b/iac/create-core-databases.bash
@@ -145,6 +145,7 @@ grant_read_write_access () {
 
   psql "${PSQL_OPTS[@]}" -d "$db" -f - <<EOF
     GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA public TO $role;
+    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $role;
 EOF
 }
 


### PR DESCRIPTION
I missed this with #1100 — the read/write role was granted privileges for tables but not sequences, resulting in errors like:

```
[Error] 42501: permission denied for sequence participant_uploads_id_seq
```