### PR TITLE
Add email and profile OIDC scopes

### DIFF
--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -179,7 +179,9 @@
                             "login": {
                                 "nameClaimType": "name",
                                 "scopes": [
-                                    "openid"
+                                    "openid",
+                                    "email",
+                                    "profile"
                                 ]
                             }
                         }

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -179,7 +179,9 @@
                             "login": {
                                 "nameClaimType": "name",
                                 "scopes": [
-                                    "openid"
+                                    "openid",
+                                    "email",
+                                    "profile"
                                 ]
                             }
                         }


### PR DESCRIPTION
Pull in the email and profile OIDC scopes by default for our App Service instances.