### PR TITLE
Restrict Metrics Collector to Event Grid at network level

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -4,7 +4,7 @@
 
 All prerequisites are available in [Azure Cloud Shell](https://docs.microsoft.com/en-us/azure/cloud-shell/overview).
 
-- [Azure Command Line Interface (CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [Azure Command Line Interface (CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) >= 2.23.0
 - [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 - [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download)
 - `bash` shell, `/dev/urandom` – included in macOS, Linux, Git for Windows

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -72,6 +72,22 @@ main () {
     --subnet "$FUNC_SUBNET_NAME" \
     --vnet "$VNET_NAME"
 
+  # Allow only incoming traffic from Event Grid
+  # Only set rule if it does not exist, to avoid error
+  exists=$(\
+    az functionapp config access-restriction show \
+      -n "$METRICS_COLLECT_APP_NAME" \
+      -g "$METRICS_RESOURCE_GROUP" \
+      --query "ipSecurityRestrictions[?ip_address == 'AzureEventGrid'].ip_address" \
+      -o tsv)
+  if [ -z "$exists" ]; then
+    az functionapp config access-restriction add \
+      -n "$METRICS_COLLECT_APP_NAME" \
+      -g "$METRICS_RESOURCE_GROUP" \
+      --priority 100 \
+      --service-tag AzureEventGrid
+  fi
+
   # Configure log streaming for function app
   metrics_collect_function_id=$(\
     az functionapp show \


### PR DESCRIPTION
- Conditionally add access restriction for `AzureEventGrid` service tag
- Requires AZ CLI >= 2.23, earlier versions [throw error](https://github.com/Azure/azure-cli/issues/16661#issuecomment-839551317) when using `--service-tag` parameter (could also be resolved by switching to an ARM template)

Closes #1055. Implementing managed identities has been adding to the backlog as #1111.