### PR TITLE
Pass template database to psql when creating new database

### DIFF
--- a/iac/create-core-databases.bash
+++ b/iac/create-core-databases.bash
@@ -37,7 +37,7 @@ init_db () {
 
 create_db () {
   db=$1
-  psql "${PSQL_OPTS[@]}" -d "$db" -f - <<EOF
+  psql "${PSQL_OPTS[@]}" -d "$TEMPLATE_DB" -f - <<EOF
     SELECT 'CREATE DATABASE $db TEMPLATE $TEMPLATE_DB'
       WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$db')\gexec
 EOF


### PR DESCRIPTION
Fixes IaC bug in `create-core-databases`.

If creating a new database, passing the incoming database name to psql as the `-d` parameter will throw an error. Instead, pass `TEMPLATE_DB`.

Precursor to #701.