### PR TITLE
Automate configuration of IDP client secrets

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -62,12 +62,6 @@ The following environment variables are pre-configured by the Infrastructure-as-
 | `LookupConnectionString` | Azure Storage Account connection string for accessing Table Storage service used for storing lookup IDs. | Piipan.Match.Orchestrator |
 | `LookupTableName` | Name of the Table Storage table where lookup IDs are stored.  | Piipan.Match.Orchestrator |
 
-#### Manually configured
-The following environment variables are not configured by the Infrastructure-as-Code scripts, and thus need to be manually configured after each run.
-| Name | Value | Used by |
-|---|---|---|
-| `IDP_CLIENT_SECRET` | Client Secret for OIDC identity provider. | Piipan.Dashboard, Piipan.QueryTool |
-
 
 ## `SysType` resource tag
 
@@ -98,3 +92,4 @@ az resource list  --tag SysType=PerStateMatchApi --query "[? resourceGroup == 'r
 - Some Azure CLI provisioning commands will return before all of their behind-the-scenes operations complete in the Azure environment. Very occasionally, subsequent provisioning commands in `create-resources` will fail as it won't be able to locate services it expects to be present; e.g., `Can't find app with name` when publishing a Function to a Function App. As a workaround, re-run the script.
 - .NET 5 with Azure Functions v3 is [not (yet) supported by Microsoft](https://github.com/Azure/azure-functions-host/issues/6674).
 - `iac/.azure` contains local Azure CLI configuration that is used by `create-resources`
+- In order for IaC to automatically configure the OIDC client secrets for the Dashboard and Query Tool applications, the secrets need to be present in a key vault with a particular naming format. See `configure-oidc.bash` for details.

--- a/iac/configure-oidc.bash
+++ b/iac/configure-oidc.bash
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Sets the IDP_CLIENT_SECRET application setting for the web app with the 
+# given application name. Assumes an Azure user with the Global
+# Administrator role has signed in with the Azure CLI. Assumes the existence
+# of a keyvault that follows the naming convention: <prefix>-kv-oidc-<env>.
+# Assumes the keyvault contains a secret that follows the naming convention:
+# <app_name>-oidc-secret.
+#
+# usage: configure-oidc.bash <azure-env> <app-name>
+
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+
+main () {
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/iac-common.bash
+  verify_cloud
+
+  APP_NAME=$2
+
+  echo "Getting secret from keyvault"
+  secret=$(az keyvault secret show \
+    --vault-name "$PREFIX-kv-oidc-$ENV" \
+    --name "$APP_NAME-oidc-secret" \
+    --query value \
+    --output tsv)
+
+  echo "Setting IDP_CLIENT_SECRET for $APP_NAME"
+  # capture the output to prevent secret from being written to terminal
+  res=$(az webapp config appsettings set \
+    --name $APP_NAME \
+    --resource-group $RESOURCE_GROUP \
+    --settings IDP_CLIENT_SECRET=$secret)
+
+  script_completed
+}
+
+main "$@"

--- a/iac/configure-oidc.bash
+++ b/iac/configure-oidc.bash
@@ -23,18 +23,21 @@ main () {
   APP_NAME=$2
 
   echo "Getting secret from keyvault"
-  secret=$(az keyvault secret show \
-    --vault-name "$PREFIX-kv-oidc-$ENV" \
-    --name "$APP_NAME-oidc-secret" \
-    --query value \
-    --output tsv)
-
-  echo "Setting IDP_CLIENT_SECRET for $APP_NAME"
-  # capture the output to prevent secret from being written to terminal
-  res=$(az webapp config appsettings set \
-    --name "$APP_NAME" \
-    --resource-group "$RESOURCE_GROUP" \
-    --settings IDP_CLIENT_SECRET="$secret")
+  if secret=$(az keyvault secret show \
+      --vault-name "$PREFIX-kv-oidc-$ENV" \
+      --name "$APP_NAME-oidc-secret" \
+      --query value \
+      --output tsv)
+  then
+    echo "Setting IDP_CLIENT_SECRET for $APP_NAME"
+    # capture the output to prevent secret from being written to terminal
+    res=$(az webapp config appsettings set \
+      --name "$APP_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --settings IDP_CLIENT_SECRET="$secret")
+  else
+    echo "ERROR getting secret from keyvault"
+  fi
 
   script_completed
 }

--- a/iac/configure-oidc.bash
+++ b/iac/configure-oidc.bash
@@ -32,9 +32,9 @@ main () {
   echo "Setting IDP_CLIENT_SECRET for $APP_NAME"
   # capture the output to prevent secret from being written to terminal
   res=$(az webapp config appsettings set \
-    --name $APP_NAME \
-    --resource-group $RESOURCE_GROUP \
-    --settings IDP_CLIENT_SECRET=$secret)
+    --name "$APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --settings IDP_CLIENT_SECRET="$secret")
 
   script_completed
 }

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -277,6 +277,8 @@ main () {
       idpOidcConfigUri="$IDP_OIDC_CONFIG_URI" \
       idpClientId="$DASHBOARD_APP_IDP_CLIENT_ID"
 
+  ./configure-oidc.bash "$azure_env" "$DASHBOARD_APP_NAME"
+
   script_completed
 }
 main "$@"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -579,6 +579,8 @@ main () {
       idpOidcConfigUri="$IDP_OIDC_CONFIG_URI" \
       idpClientId="$QUERY_TOOL_APP_IDP_CLIENT_ID"
 
+  ./configure-oidc.bash "$azure_env" "$QUERY_TOOL_APP_NAME"
+
   # Establish metrics sub-system
   ./create-metrics-resources.bash "$azure_env"
 


### PR DESCRIPTION
Closes #1039 

Adds `configure-oidc.bash`, which, given an environment and application name, sets the `IDP_CLIENT_SECRET` after pulling the current value from the appropriate vault. This approach assumes the existence of a Key Vault which contains an OIDC secret, both following standard naming conventions. 

`configure-oidc.bash` is run as part of IaC for the Dashboard and Query Tool applications, but can be run as a one-off to accommodate updated client secrets.
