### PR TITLE
Configure CIS Azure Benchmark policy as part of IaC

### DIFF
--- a/iac/configure-cis-policy.bash
+++ b/iac/configure-cis-policy.bash
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# Assigns the CIS Microsoft Azure Foundations Benchmark policy set
+# to the core and match resource groups. Assumes an Azure user with
+# the Global Administrator role has signed in with the Azure CLI.
+#
+# usage: configure-cis-policy.bash <azure-env>
 
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/../tools/common.bash || exit

--- a/iac/configure-cis-policy.bash
+++ b/iac/configure-cis-policy.bash
@@ -10,7 +10,9 @@
 source "$(dirname "$0")"/../tools/common.bash || exit
 
 set_constants () {
-  CIS_POLICY_DISPLAY_NAME="[Preview]: CIS Microsoft Azure Foundations Benchmark v1.3.0"
+  # https://docs.microsoft.com/en-us/azure/governance/policy/samples/cis-azure-1-3-0
+  # The policy "name" is the UUID of the set-definition
+  CIS_POLICY_SET_DEFINITION_NAME="612b5213-9160-4969-8578-1518bd2a000c"
 }
 
 main () {
@@ -23,25 +25,23 @@ main () {
 
   set_constants
 
-  cis_policy_set_definition_name=$(az policy set-definition list \
-    --query "[?displayName=='$CIS_POLICY_DISPLAY_NAME'] | [0] | name" \
-    --output tsv)
-
-  echo "Assigning $cis_policy_set_definition_name to $RESOURCE_GROUP"
+  echo "Assigning $CIS_POLICY_SET_DEFINITION_NAME to $RESOURCE_GROUP"
   az policy assignment create \
-    --policy-set-definition "$cis_policy_set_definition_name" \
+    --policy-set-definition "$CIS_POLICY_SET_DEFINITION_NAME" \
     --resource-group "$RESOURCE_GROUP" \
     --name "cis-1_3-$RESOURCE_GROUP" \
     --location "$LOCATION" \
     --assign-identity
 
-  echo "Assigning $cis_policy_set_definition_name to $MATCH_RESOURCE_GROUP"
+  echo "Assigning $CIS_POLICY_SET_DEFINITION_NAME to $MATCH_RESOURCE_GROUP"
   az policy assignment create \
-    --policy-set-definition "$cis_policy_set_definition_name" \
+    --policy-set-definition "$CIS_POLICY_SET_DEFINITION_NAME" \
     --resource-group "$MATCH_RESOURCE_GROUP" \
     --name "cis-1_3-$MATCH_RESOURCE_GROUP" \
     --location "$LOCATION" \
     --assign-identity
+
+  script_completed
 }
 
 main "$@"

--- a/iac/configure-cis-policy.bash
+++ b/iac/configure-cis-policy.bash
@@ -36,14 +36,6 @@ main () {
     --name "cis-1_3-$MATCH_RESOURCE_GROUP" \
     --location "$LOCATION" \
     --assign-identity
-
-  echo "Assigning $cis_policy_set_definition_name to $METRICS_RESOURCE_GROUP"
-  az policy assignment create \
-    --policy-set-definition "$cis_policy_set_definition_name" \
-    --resource-group "$METRICS_RESOURCE_GROUP" \
-    --name "cis-1_3-$METRICS_RESOURCE_GROUP" \
-    --location "$LOCATION" \
-    --assign-identity
 }
 
 main "$@"

--- a/iac/configure-cis-policy.bash
+++ b/iac/configure-cis-policy.bash
@@ -26,7 +26,7 @@ main () {
     --policy-set-definition "$cis_policy_set_definition_name" \
     --resource-group "$RESOURCE_GROUP" \
     --name "cis-1_3-$RESOURCE_GROUP" \
-    --location $LOCATION \
+    --location "$LOCATION" \
     --assign-identity
 
   echo "Assigning $cis_policy_set_definition_name to $MATCH_RESOURCE_GROUP"
@@ -34,7 +34,7 @@ main () {
     --policy-set-definition "$cis_policy_set_definition_name" \
     --resource-group "$MATCH_RESOURCE_GROUP" \
     --name "cis-1_3-$MATCH_RESOURCE_GROUP" \
-    --location $LOCATION \
+    --location "$LOCATION" \
     --assign-identity
 
   echo "Assigning $cis_policy_set_definition_name to $METRICS_RESOURCE_GROUP"
@@ -42,7 +42,7 @@ main () {
     --policy-set-definition "$cis_policy_set_definition_name" \
     --resource-group "$METRICS_RESOURCE_GROUP" \
     --name "cis-1_3-$METRICS_RESOURCE_GROUP" \
-    --location $LOCATION \
+    --location "$LOCATION" \
     --assign-identity
 }
 

--- a/iac/configure-cis-policy.bash
+++ b/iac/configure-cis-policy.bash
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+
+set_constants () {
+  CIS_POLICY_DISPLAY_NAME="[Preview]: CIS Microsoft Azure Foundations Benchmark v1.3.0"
+}
+
+main () {
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/iac-common.bash
+  verify_cloud
+
+  set_constants
+
+  cis_policy_set_definition_name=$(az policy set-definition list \
+    --query "[?displayName=='$CIS_POLICY_DISPLAY_NAME'] | [0] | name" \
+    --output tsv)
+
+  echo "Assigning $cis_policy_set_definition_name to $RESOURCE_GROUP"
+  az policy assignment create \
+    --policy-set-definition "$cis_policy_set_definition_name" \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "cis-1_3-$RESOURCE_GROUP" \
+    --location $LOCATION \
+    --assign-identity
+
+  echo "Assigning $cis_policy_set_definition_name to $MATCH_RESOURCE_GROUP"
+  az policy assignment create \
+    --policy-set-definition "$cis_policy_set_definition_name" \
+    --resource-group "$MATCH_RESOURCE_GROUP" \
+    --name "cis-1_3-$MATCH_RESOURCE_GROUP" \
+    --location $LOCATION \
+    --assign-identity
+
+  echo "Assigning $cis_policy_set_definition_name to $METRICS_RESOURCE_GROUP"
+  az policy assignment create \
+    --policy-set-definition "$cis_policy_set_definition_name" \
+    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --name "cis-1_3-$METRICS_RESOURCE_GROUP" \
+    --location $LOCATION \
+    --assign-identity
+}
+
+main "$@"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -601,6 +601,8 @@ main () {
     "$RESOURCE_GROUP" \
     "$PG_SERVER_NAME"
 
+  ./configure-cis-policy.bash "$azure_env"
+
   script_completed
 }
 

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -601,6 +601,7 @@ main () {
     "$RESOURCE_GROUP" \
     "$PG_SERVER_NAME"
 
+  # Assign CIS Microsoft Azure Foundations Benchmark policy set-definition
   ./configure-cis-policy.bash "$azure_env"
 
   script_completed


### PR DESCRIPTION
Closes #828 

Adds `configure-cis-policy.bash`, which assigns the CIS Microsoft Azure Foundations Benchmark to both the core and match resource groups.