### PR TITLE
Change rule for consecutive recent benefit months in import schema

### DIFF
--- a/etl/docs/csv/import-schema.json
+++ b/etl/docs/csv/import-schema.json
@@ -67,7 +67,7 @@
       {
         "name": "recent_benefit_months",
         "type": "string",
-        "description": "List of up to the last 3 months that participant received benefits, formatted as yearmonths separated by spaces. Does not include current benefit month. Months need to be consecutive. Fewer than 3 months can be entered for newer participants.",
+        "description": "List of up to the last 3 months that participant received benefits, formatted as yearmonths separated by spaces. Does not include current benefit month. Months do not need to be consecutive. Fewer than 3 months can be entered for newer participants.",
         "constraints": {
           "pattern": "([0-9]{4}-[0-9]{1,2} ?){0,3}"
         }


### PR DESCRIPTION
Recent benefit months do not need to be consecutive. 

For example, if current month is July and an individual received benefits in March, April, and June (but not May), data can be `2021-03 2021-04 2021-06`

## Changelog

Relaxing bulk upload rule for `recent_benefit_months` requiring months needing to be consecutive. Recent Benefit Months no longer need to be consecutive. 