### PR TITLE
Remove METRICS_RESOURCE_GROUP from IaC scripts

### DIFF
--- a/iac/create-resource-groups.bash
+++ b/iac/create-resource-groups.bash
@@ -24,9 +24,6 @@ main () {
   az group create --name "$RESOURCE_GROUP" -l "$LOCATION" --tags Project="$PROJECT_TAG"
   echo "Creating match APIs resource group"
   az group create --name "$MATCH_RESOURCE_GROUP" -l "$LOCATION" --tags Project="$PROJECT_TAG"
-  # Create Metrics resource group
-  echo "Creating $METRICS_RESOURCE_GROUP group"
-  az group create --name "$METRICS_RESOURCE_GROUP" -l "$LOCATION" --tags Project="$PROJECT_TAG"
 
   script_completed
 }

--- a/iac/create-service-principal.bash
+++ b/iac/create-service-principal.bash
@@ -34,7 +34,7 @@ main () {
   output=${3:-json}
 
   # Array of groups to which the service principal will be scoped
-  RESOURCE_GROUPS=("$RESOURCE_GROUP" "$METRICS_RESOURCE_GROUP" "$MATCH_RESOURCE_GROUP")
+  RESOURCE_GROUPS=("$RESOURCE_GROUP" "$MATCH_RESOURCE_GROUP")
 
   # Create space-separated list of resource group IDs
   for g in "${RESOURCE_GROUPS[@]}"

--- a/iac/delete-resources.bash
+++ b/iac/delete-resources.bash
@@ -36,7 +36,6 @@ main () {
 
     purge "$RESOURCE_GROUP"
     purge "$MATCH_RESOURCE_GROUP"
-    purge "$METRICS_RESOURCE_GROUP"
 
   else
     exit 1

--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -12,9 +12,6 @@ RESOURCE_GROUP=rg-core-$ENV
 # Resource group for matching API
 MATCH_RESOURCE_GROUP=rg-match-$ENV
 
-# Resource group for metrics
-METRICS_RESOURCE_GROUP=$RESOURCE_GROUP
-
 # Prefix for resource identifiers
 PREFIX=tts
 

--- a/iac/env/tts/test.bash
+++ b/iac/env/tts/test.bash
@@ -12,9 +12,6 @@ RESOURCE_GROUP=rg-core-$ENV
 # Resource group for matching API
 MATCH_RESOURCE_GROUP=rg-match-$ENV
 
-# Resource group for metrics
-METRICS_RESOURCE_GROUP=$RESOURCE_GROUP
-
 # Prefix for resource identifiers
 PREFIX=tts
 

--- a/metrics/tools/test-metricsapi.bash
+++ b/metrics/tools/test-metricsapi.bash
@@ -23,7 +23,7 @@ main () {
   # grab url for metrics api
   function_uri=$(az functionapp function show \
     --name "$METRICS_API_APP_NAME" \
-    --resource-group "$METRICS_RESOURCE_GROUP" \
+    --resource-group "$RESOURCE_GROUP" \
     --function-name $METRICS_API_FUNCTION_NAME \
     --query invokeUrlTemplate \
     --output tsv)


### PR DESCRIPTION
Closes #1025 

Removes all references to `METRICS_RESOURCE_GROUP` and replaces them with `RESOURCE_GROUP`.