### PR TITLE
Enable Azure Defender for storage accounts

### DIFF
--- a/iac/configure-defender.bash
+++ b/iac/configure-defender.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Enables Azure Defender at the subscription level for storage 
+# accounts. Assumes an Azure user with the Global Administrator
+# role has signed in with the Azure CLI.
+#
+# usage: configure-defender.bash <azure-env>
+
+# shellcheck source=./tools/common.bash
+source "$(dirname "$0")"/../tools/common.bash || exit
+
+main () {
+  # Load agency/subscription/deployment-specific settings
+  azure_env=$1
+  source "$(dirname "$0")"/env/"${azure_env}".bash
+  # shellcheck source=./iac/iac-common.bash
+  source "$(dirname "$0")"/iac-common.bash
+  verify_cloud
+
+  az security pricing create \
+    --name StorageAccounts \
+    --tier standard
+
+  script_completed
+}
+
+main "$@"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -579,6 +579,7 @@ main () {
       idpOidcConfigUri="$QUERY_TOOL_APP_IDP_OIDC_CONFIG_URI" \
       idpClientId="$QUERY_TOOL_APP_IDP_CLIENT_ID"
 
+  # Sets the OIDC client secrets for web applications
   ./configure-oidc.bash "$azure_env" "$QUERY_TOOL_APP_NAME"
 
   # Establish metrics sub-system
@@ -594,6 +595,10 @@ main () {
   #   - PerStateMatchApi and OrchestratorApi
   #   - OrchestratorApi and QueryApp
   ./configure-easy-auth.bash "$azure_env"
+
+  # Configures Azure Defender at the subscription level for:
+  #   - Storage accounts
+  ./configure-defender.bash "$azure_env"
 
   echo "Secure database connection"
   ./remove-external-network.bash \


### PR DESCRIPTION
Closes #392 

Adds `configure-defender.bash`, which enables Azure Defender at the `standard` tier for all storage accounts at the subscription level. 