### PR TITLE
Add resource tags to App Service Plan

### DIFF
--- a/iac/arm-templates/app-service-plan.json
+++ b/iac/arm-templates/app-service-plan.json
@@ -30,6 +30,9 @@
             "metadata": {
                 "description": "The type of App Service Plan."
             }
+        },
+        "resourceTags": {
+            "type": "object"
         }
     },
     "variables": {},
@@ -39,6 +42,7 @@
             "apiVersion": "2020-06-01",
             "name": "[parameters('name')]",
             "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
             "sku": {
                 "name": "[parameters('sku')]"
             },

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -280,7 +280,8 @@ main () {
       name="$APP_SERVICE_PLAN_FUNC_NAME" \
       location="$LOCATION" \
       kind="$APP_SERVICE_PLAN_FUNC_KIND" \
-      sku="$APP_SERVICE_PLAN_FUNC_SKU"
+      sku="$APP_SERVICE_PLAN_FUNC_SKU" \
+      resourceTags="$RESOURCE_TAGS"
 
   # Function apps need an Event Hub authorization rule ID for log streaming
   eh_rule_id=$(\


### PR DESCRIPTION
When reviewing cost estimates in the Portal, I noticed the `plan-apps1` App Service Plan was not tagged with our standard resource tags.