### PR TITLE
Stream Policy operations from Activity Log to event hub

### DIFF
--- a/iac/arm-templates/activity-log.json
+++ b/iac/arm-templates/activity-log.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "eventHubName": {
+      "type": "string"
+    },
+    "coreResourceGroup": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "apiVersion": "2017-05-01-preview",
+      "name": "stream-logs-to-event-hub",
+      "dependsOn": [],
+      "properties": {
+        "eventHubAuthorizationRuleId": "[concat(subscription().id, '/resourceGroups/', parameters('coreResourceGroup'), '/providers/Microsoft.EventHub/namespaces/', parameters('eventHubName'), '/authorizationrules/RootManageSharedAccessKey')]",
+        "eventHubName": "logs",
+        "logs": [
+          {
+            "category": "Policy",
+            "enabled": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -151,6 +151,15 @@ main () {
       prefix="$PREFIX" \
       receiverId="$siem_app_id"
 
+  # Send Policy events from subscription's activity log to event hub
+  az deployment sub create \
+    --name activity-log-diagnostics \
+    --location "$LOCATION" \
+    --template-file ./arm-templates/activity-log.json \
+    --parameters \
+      eventHubName="$EVENT_HUB_NAME" \
+      coreResourceGroup="$RESOURCE_GROUP"
+
   # For each participating state, create a separate storage account.
   # Each account has a blob storage container named `upload`.
   while IFS=, read -r abbr name ; do


### PR DESCRIPTION
Adds a diagnostic setting to the subscription's Activity Log which sends `Policy` logs to [event hub](https://github.com/18F/piipan/blob/dev/docs/log-streaming.md).

Closes #1093. See that issue for more details on log messages.