### PR TITLE
Update local development instructions

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -34,6 +34,17 @@ The following environment variables are required by both the Metrics Functions a
 | `CloudName` | [details](../../docs/iac.md#\:\~\:text=CloudName) |
 | `KeyVaultName` | [details](../../docs/iac.md#\:\~\:text=KeyVaultName) |
 
+## Local development
+
+Local development is currently limited as a result of using a managed identity to connect to the metrics database. The Instance Metadata Service used by managed identities to retrieve authentication tokens is not available locally. There are [potential solutions](https://docs.microsoft.com/en-us/dotnet/api/overview/azure/service-to-service-authentication#local-development-authentication) using the `Microsoft.Azure.Services.AppAuthentication` library. None have been implemented at this time.
+
+The app will still build and run locally. However, any valid request sent to the local endpoint will result in an exception when the app attempts to retrieve an access token. Invalid requests (e.g., malformed or missing data in the request body) will return proper error responses.
+
+To build and run the app with this limited functionality:
+
+1. Fetch any app settings using `func azure functionapp fetch-app-settings {app-name}`. The app name can be retrieved from the Portal.
+1. Run `func start` or, if hot reloading is desired, `dotnet watch msbuild /t:RunFunctions`.
+
 ## Testing
 
 `Piipan.Metrics.Test` holds all tests for the Piipan Metrics Subsystem


### PR DESCRIPTION
Closes #952 

- Verified that no undocumented steps are necessary to run the dashboard locally
- Added a `Local development` section to the Metrics README, which documents the same limitations to local development that are mentioned for the per-state APIs.