### PR TITLE
Disallow usage of all-access APIM keys

### DIFF
--- a/iac/apim-policy.xml
+++ b/iac/apim-policy.xml
@@ -1,0 +1,22 @@
+<!-- Generated via IaC -->
+
+<policies>
+    <inbound>
+        <choose>
+            <when condition="@(context.Subscription != null &amp;&amp; context.Subscription.Id == &quot;master&quot;)">
+                <return-response>
+                    <set-status code="401" reason="Access Denied" />
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/json; charset=UTF-8</value>
+                    </set-header>
+                    <set-body>{"statusCode": 401, "message": "Access denied due to invalid subscription key. Make sure to provide a valid key for an active subscription."}</set-body>
+                </return-response>
+            </when>
+        </choose>
+    </inbound>
+    <backend>
+        <forward-request />
+    </backend>
+    <outbound />
+    <on-error />
+</policies>

--- a/iac/apim-policy.xml
+++ b/iac/apim-policy.xml
@@ -2,6 +2,7 @@
 
 <policies>
     <inbound>
+        <!-- APIM issues a "master" key that is scoped to the entire instance, can be used as a valid API key for any API, and cannot be disabled. Prevent this key from being used. As a consequence, the "test" feature in the Azure portal, which relies on this key, is no longer usable. -->
         <choose>
             <when condition="@(context.Subscription != null &amp;&amp; context.Subscription.Id == &quot;master&quot;)">
                 <return-response>

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -43,6 +43,9 @@
         },
         "eventHubName": {
             "type": "String"
+        },
+        "apimPolicyXml": {
+            "type": "String"
         }
     },
     "variables": {
@@ -117,6 +120,18 @@
             "properties": {
                 "displayName": "[variables('matchDisplayName')]",
                 "versioningScheme": "Segment"
+            }
+        },
+        {
+            "type": "Microsoft.ApiManagement/service/policies",
+            "apiVersion": "2021-01-01-preview",
+            "name": "[concat(parameters('apiName'), '/policy')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]"
+            ],
+            "properties": {
+                "value": "[parameters('apimPolicyXml')]",
+                "format": "xml"
             }
         },
         {

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -107,6 +107,9 @@ main () {
   upload_policy_path=$(dirname "$0")/apim-bulkupload-policy.xml
   upload_policy_xml=$(< "$upload_policy_path")
 
+  apim_policy_path=$(dirname "$0")/apim-policy.xml
+  apim_policy_xml=$(< "$apim_policy_path")
+
   local state_abbrs
   state_abbrs=$(get_state_abbrs)
 
@@ -131,7 +134,8 @@ main () {
         location="$LOCATION" \
         resourceTags="$RESOURCE_TAGS" \
         coreResourceGroup="$RESOURCE_GROUP" \
-        eventHubName="$EVENT_HUB_NAME")
+        eventHubName="$EVENT_HUB_NAME" \
+        apimPolicyXml="$apim_policy_xml")
 
   upload_accounts=($(get_resources "$PER_STATE_STORAGE_TAG" "$RESOURCE_GROUP"))
   for account in "${upload_accounts[@]}"


### PR DESCRIPTION
Closes #684 

Adds `apim-policy.xml` prevents the usage of the automatically generated all-access APIM subscription keys. Attempts to use these keys for API calls results in the same `401` response that would be returned with an invalid subscription key.

Updates IaC to apply `apim-policy.xml` to the APIM globally. 