### PR TITLE
Update query tool to handle household match requests/responses

### DIFF
--- a/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
+++ b/query-tool/src/Piipan.QueryTool/OrchestratorApiRequest.cs
@@ -26,7 +26,7 @@ namespace Piipan.QueryTool
         {
             const string Endpoint = "query";
 
-            var request = new MatchRequest { Query = query };
+            var request = new MatchRequest { Data = new List<PiiRecord> { query } };
             var json = JsonSerializer.Serialize(request);
             var response = await _apiClient.PostAsync(
                 new Uri(_baseUri, Endpoint),
@@ -59,9 +59,44 @@ namespace Piipan.QueryTool
 
     public class MatchResponse
     {
+        [JsonPropertyName("data")]
+        public MatchResponseData Data { get; set; } = new MatchResponseData();
+    }
+
+    public class MatchResponseData
+    {
+        [JsonPropertyName("results")]
+        public List<MatchResult> Results { get; set; } = new List<MatchResult>();
+
+        [JsonPropertyName("errors")]
+        public List<MatchError> Errors { get; set; } = new List<MatchError>();
+    }
+
+    public class MatchResult
+    {
+        [JsonPropertyName("index")]
+        public int Index { get; set; }
+
         [JsonPropertyName("lookup_id")]
-        public virtual string lookupId { get; set; }
-        public virtual List<PiiRecord> matches { get; set; }
+        public virtual string LookupId { get; set; }
+
+        [JsonPropertyName("matches")]
+        public virtual List<PiiRecord> Matches { get; set; }
+    }
+
+    public class MatchError
+    {
+        [JsonPropertyName("index")]
+        public int Index { get; set; }
+
+        [JsonPropertyName("code")]
+        public string Code { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("detail")]
+        public string Detail { get; set; }
     }
 
     public class LookupResponse

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -39,7 +39,8 @@ namespace Piipan.QueryTool.Pages
                     MatchResponse result = await _apiRequest.Match(Query);
 
                     QueryResult = result;
-                    NoResults = QueryResult.matches.Count == 0;
+                    NoResults = QueryResult.Data.Results.Count == 0 ||
+                        QueryResult.Data.Results[0].Matches.Count == 0;
                     Title = "NAC Query Results";
                 }
                 catch (Exception exception)

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_ResultsTable.cshtml
@@ -1,37 +1,47 @@
 @model MatchResponse
-@if (Model != null && Model.matches.Any())
+@if (@Model != null && @Model.Data != null && @Model.Data.Results.Any())
 {
     <h2>Results</h2>
-    <table class="usa-table">
-    <caption>Lookup ID: @Model.lookupId</caption>
-    <thead>
-        <tr>
-            <th scope="col">Name</th>
-            <th scope="col">DOB</th>
-            <th scope="col">SSN</th>
-            <th scope="col">State</th>
-            <th scope="col">Case ID</th>
-            <th scope="col">Participant ID</th>
-            <th scope="col">Benefits end month</th>
-            <th scope="col">Recent benefits months</th>
-            <th scope="col">Protected location for vulnerable individuals</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var record in @Model.matches)
-            {
+    @foreach (var result in @Model.Data.Results)
+    {
+        @if (result.Matches.Any())
+        {
+            <table class="usa-table">
+            <caption>Lookup ID: @result.LookupId</caption>
+            <thead>
                 <tr>
-                    <td>@record.FirstName @record.MiddleName @record.LastName</td>
-                    <td>@Html.DisplayFor(m => record.DateOfBirth)</td>
-                    <td>@record.SocialSecurityNum</td>
-                    <td>@record.State</td>
-                    <td>@record.CaseId</td>
-                    <td>@record.ParticipantId</td>
-                    <td>@record.BenefitsEndMonth</td>
-                    <td>@record.RecentBenefitMonthsDisplay</td>
-                    <td>@record.ProtectLocationDisplay</td>
+                    <th scope="col">Name</th>
+                    <th scope="col">DOB</th>
+                    <th scope="col">SSN</th>
+                    <th scope="col">State</th>
+                    <th scope="col">Case ID</th>
+                    <th scope="col">Participant ID</th>
+                    <th scope="col">Benefits end month</th>
+                    <th scope="col">Recent benefits months</th>
+                    <th scope="col">Protected location for vulnerable individuals</th>
                 </tr>
-            }
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+                @foreach (var record in result.Matches)
+                    {
+                        <tr>
+                            <td>@record.FirstName @record.MiddleName @record.LastName</td>
+                            <td>@Html.DisplayFor(m => record.DateOfBirth)</td>
+                            <td>@record.SocialSecurityNum</td>
+                            <td>@record.State</td>
+                            <td>@record.CaseId</td>
+                            <td>@record.ParticipantId</td>
+                            <td>@record.BenefitsEndMonth</td>
+                            <td>@record.RecentBenefitMonthsDisplay</td>
+                            <td>@record.ProtectLocationDisplay</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        } else
+        {
+            <h3>No matches found</h3>
+        }
+    }
 }
+

--- a/query-tool/src/Piipan.QueryTool/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool/PiiRecord.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -6,8 +7,8 @@ namespace Piipan.QueryTool
 {
     public class MatchRequest
     {
-        [JsonPropertyName("query")]
-        public PiiRecord Query { get; set; }
+        [JsonPropertyName("data")]
+        public List<PiiRecord> Data { get; set; }
     }
 
     public class PiiRecord : IQueryable

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -67,16 +67,23 @@ namespace Piipan.QueryTool.Tests
         {
             // arrange
             var returnValue = @"{
-                ""lookup_id"": ""BBB2222"",
-                ""matches"": [{
-                    ""first"": ""Theodore"",
-                    ""middle"": ""Carri"",
-                    ""last"": ""Farrington"",
-                    ""ssn"": ""000-00-0000"",
-                    ""dob"": ""2021-01-01"",
-                    ""state"": ""ea"",
-                    ""state_abbr"": ""ea""
-                }]
+                ""data"": {
+                    ""results"": [
+                        {
+                            ""lookup_id"": ""BBB2222"",
+                            ""matches"": [{
+                                ""first"": ""Theodore"",
+                                ""middle"": ""Carri"",
+                                ""last"": ""Farrington"",
+                                ""ssn"": ""000-00-0000"",
+                                ""dob"": ""2021-01-01"",
+                                ""state"": ""ea"",
+                                ""state_abbr"": ""ea""
+                            }]
+                        }
+                    ],
+                    ""errors"": []
+                }
             }";
             var requestPii = new PiiRecord
             {
@@ -95,7 +102,7 @@ namespace Piipan.QueryTool.Tests
             // assert
             Assert.IsType<MatchResponse>(pageModel.QueryResult);
             Assert.NotNull(pageModel.QueryResult);
-            Assert.NotNull(pageModel.QueryResult.matches);
+            Assert.NotNull(pageModel.QueryResult.Data.Results[0].Matches);
             Assert.False(pageModel.NoResults);
         }
 
@@ -104,8 +111,15 @@ namespace Piipan.QueryTool.Tests
         {
             // arrange
             var returnValue = @"{
-                ""lookup_id"": null,
-                ""matches"": []
+                ""data"": {
+                    ""results"": [
+                        {
+                            ""lookup_id"": null,
+                            ""matches"": []
+                        }
+                    ],
+                    ""errors"": []
+                }
             }";
             var requestPii = new PiiRecord
             {
@@ -123,8 +137,8 @@ namespace Piipan.QueryTool.Tests
 
             // assert
             Assert.IsType<MatchResponse>(pageModel.QueryResult);
-            Assert.Null(pageModel.QueryResult.lookupId);
-            Assert.Empty(pageModel.QueryResult.matches);
+            Assert.Null(pageModel.QueryResult.Data.Results[0].LookupId);
+            Assert.Empty(pageModel.QueryResult.Data.Results[0].Matches);
             Assert.True(pageModel.NoResults);
         }
 

--- a/query-tool/tests/Piipan.QueryTool.Tests/OrchestratorApiRequestTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/OrchestratorApiRequestTest.cs
@@ -16,18 +16,25 @@ namespace Piipan.QueryTool.Tests
         {
             // arrange
             var mockResponse = @"{
-                ""lookup_id"": ""BBB2222"",
-                ""matches"": [
-                    {
-                        ""first"": ""Theodore"",
-                        ""middle"": ""Carri"",
-                        ""last"": ""Farrington"",
-                        ""ssn"": ""000-00-0000"",
-                        ""dob"": ""2021-01-01"",
-                        ""state"": ""ea"",
-                        ""state_abbr"": ""ea""
-                    }
-                ]
+                ""data"": {
+                    ""results"": [
+                        {
+                            ""lookup_id"": ""BBB2222"",
+                            ""matches"": [
+                                {
+                                    ""first"": ""Theodore"",
+                                    ""middle"": ""Carri"",
+                                    ""last"": ""Farrington"",
+                                    ""ssn"": ""000-00-0000"",
+                                    ""dob"": ""2021-01-01"",
+                                    ""state"": ""ea"",
+                                    ""state_abbr"": ""ea""
+                                }
+                            ]
+                        }
+                    ],
+                    ""errors"": []
+                }
             }";
             var query = new PiiRecord
             {
@@ -50,17 +57,18 @@ namespace Piipan.QueryTool.Tests
 
             // act
             var result = await api.Match(query);
+            var match = result.Data.Results[0].Matches[0];
 
             // assert
             Assert.IsType<MatchResponse>(result);
-            Assert.Single(result.matches);
-            Assert.Equal("BBB2222", result.lookupId);
-            Assert.Equal("Theodore", result.matches[0].FirstName);
-            Assert.Equal("Carri", result.matches[0].MiddleName);
-            Assert.Equal("Farrington", result.matches[0].LastName);
-            Assert.Equal("000-00-0000", result.matches[0].SocialSecurityNum);
-            Assert.Equal(new DateTime(2021, 1, 1), result.matches[0].DateOfBirth);
-            Assert.Equal("ea", result.matches[0].State);
+            Assert.Single(result.Data.Results[0].Matches);
+            Assert.Equal("BBB2222", result.Data.Results[0].LookupId);
+            Assert.Equal("Theodore", match.FirstName);
+            Assert.Equal("Carri", match.MiddleName);
+            Assert.Equal("Farrington", match.LastName);
+            Assert.Equal("000-00-0000", match.SocialSecurityNum);
+            Assert.Equal(new DateTime(2021, 1, 1), match.DateOfBirth);
+            Assert.Equal("ea", match.State);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #1121 
Relies on #1098

This is a quick fix to ensure there are no breaking changes from the API switch to households.
No new UI was added.
Validation and other data-level errors aren't being shown in the UI.