### PR TITLE
Enable always on setting for match function apps

### DIFF
--- a/iac/arm-templates/function-orch-match.json
+++ b/iac/arm-templates/function-orch-match.json
@@ -110,6 +110,7 @@
                 "httpsOnly": true,
                 "siteConfig": {
                     "ftpsState": "Disabled",
+                    "alwaysOn": true,
                     "appSettings": [
                         /*
                             The following settings are required for Function apps per the MS documentation:

--- a/iac/arm-templates/function-state-match.json
+++ b/iac/arm-templates/function-state-match.json
@@ -89,6 +89,7 @@
                 "httpsOnly": true,
                 "siteConfig": {
                     "ftpsState": "Disabled",
+                    "alwaysOn": true,
                     "appSettings": [
                         /*
                             The following settings are required for Function apps per the MS documentation:


### PR DESCRIPTION
Enables `alwaysOn` configuration property to avoid cold starts when calling the duplicate participation API.

Closes #1163.