### PR TITLE
Add OIDC claim-based authorization policy to Query Tool

### DIFF
--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using NEasyAuthMiddleware;
 using Piipan.QueryTool.Binders;
 using Piipan.Shared.Authentication;
+using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
 using Piipan.Shared.Logging;
 
@@ -30,7 +31,10 @@ namespace Piipan.QueryTool
         {
             services.Configure<ClaimsOptions>(Configuration.GetSection(ClaimsOptions.SectionName));
 
-            services.AddRazorPages().AddMvcOptions(options =>
+            services.AddRazorPages(options => 
+            {
+                options.Conventions.AuthorizeFolder("/");
+            }).AddMvcOptions(options =>
             {
                 options.ModelBinderProviders.Insert(0, new TrimModelBinderProvider());
             });
@@ -57,6 +61,12 @@ namespace Piipan.QueryTool
 
             services.AddDistributedMemoryCache();
             services.AddSession();
+
+            services.AddAuthorizationCore(options => {
+                options.DefaultPolicy = AuthorizationPolicyBuilder.Build(Configuration
+                    .GetSection(AuthorizationPolicyOptions.SectionName)
+                    .Get<AuthorizationPolicyOptions>());
+            });
 
             if (_env.IsDevelopment())
             {

--- a/query-tool/src/Piipan.QueryTool/appsettings.Development.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.Development.json
@@ -5,5 +5,13 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "AuthorizationPolicy": {
+    "RequiredClaims": [
+      {
+        "Type": "email",
+        "Values": ["*"]
+      }
+    ]
   }
 }

--- a/query-tool/src/Piipan.QueryTool/appsettings.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.json
@@ -9,6 +9,9 @@
   "Claims": {
     "Email": "email"
   },
+  "AuthorizationPolicy": {
+    "RequiredClaims": []
+  },
   "AllowedHosts": "*",
   "AzureFunctionURL": "https://eafuncw5wltopux5z7i.azurewebsites.net/api/v1/query"
 }

--- a/query-tool/src/Piipan.QueryTool/appsettings.tts.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.tts.json
@@ -1,5 +1,13 @@
 {
-    "Claims": {
-        "Email": "extension_EmailAddress"
-    }
+  "Claims": {
+    "Email": "extension_EmailAddress"
+  },
+  "AuthorizationPolicy": {
+    "RequiredClaims": [
+      {
+        "Type": "extension_EmailAddress",
+        "Values": ["*"]
+      }
+    ]
+  }
 }

--- a/query-tool/src/Piipan.QueryTool/mock_user.json
+++ b/query-tool/src/Piipan.QueryTool/mock_user.json
@@ -19,7 +19,7 @@
         "val": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
       },
       {
-        "typ": "emailasdf",
+        "typ": "email",
         "val": "johndoe@test.test"
       },
       {

--- a/query-tool/src/Piipan.QueryTool/mock_user.json
+++ b/query-tool/src/Piipan.QueryTool/mock_user.json
@@ -19,7 +19,7 @@
         "val": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
       },
       {
-        "typ": "email",
+        "typ": "emailasdf",
         "val": "johndoe@test.test"
       },
       {


### PR DESCRIPTION
Closes #1129

Adds a default authorization policy to the Dashboard that requires the user to have particular claims in order to access the application. The required claims are configurable via appsettings. If no authorization policy is configured in appsettings, all requests are rejected with 403 - Forbidden.

Reuses much of #1128 via `Piipan.Shared`