### PR TITLE
Explicitly disable token store and document

### DIFF
--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -194,6 +194,13 @@
                             }
                         }
                     }
+                },
+                "login": {
+                    "tokenStore": {
+                        // If enabled, /.auth/me URL is exposed to the authenticated user,
+                        // which is useful for debugging OIDC claims
+                        "enabled": false
+                    }
                 }
             }
         }

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -194,6 +194,13 @@
                             }
                         }
                     }
+                },
+                "login": {
+                    "tokenStore": {
+                        // If enabled, /.auth/me URL is exposed to the authenticated user,
+                        // which is useful for debugging OIDC claims
+                        "enabled": false
+                    }
                 }
             }
         }


### PR DESCRIPTION
Normally we would not explicitly disable a feature that was already turned off by default, but as it was very useful for debugging OIDC claim issues, it seems appropriate to leave a "bread crumb".

[Enabling the token store enables the /.auth/me URL that prints the current user's OIDC claims.](https://docs.microsoft.com/en-us/azure/app-service/configure-authentication-user-identities#access-user-claims-using-the-api)