### PR TITLE
Update B2C docs for creating, updating user claims

### DIFF
--- a/docs/create-ad-b2c-idp.md
+++ b/docs/create-ad-b2c-idp.md
@@ -72,3 +72,16 @@ We use an [Azure AD B2C](https://docs.microsoft.com/en-us/azure/active-directory
    4. Under `Reply URL`, select `https://jwt.ms`
    5. Click `Run user flow`
    6. The profile editor will open in a new tab. Once you sign in, you will be able to update the attributes for the user, and the associated claims will reflect those updates on the next sign in.
+
+#### Add a new user attribute (claim)
+1. From within the B2C tenant, search for and select `Azure AD B2C`
+2. Open the `User attributes` blade
+   1. Click `Add`
+   2. Enter the name and data type of the attribute, and click `Create`
+3. Click the `User flows` blade
+   1. Select `B2C_1_si` (`si` in this case stands for sign in)
+   2. Click `Application claims`
+   3. Find the attribute you just added in the list and check the box next to it
+   4. Click save
+4. Repeat step 3 for the `B2C_1_pe` user flow
+5. Follow the [instructions for updating user attribute values](#set-or-update-existing-user-attributes-claims)

--- a/docs/create-ad-b2c-idp.md
+++ b/docs/create-ad-b2c-idp.md
@@ -1,4 +1,4 @@
-# Create Azure AD B2C IDP
+# Create & Manage Azure AD B2C IDP
 
 ## Background
 We use an [Azure AD B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/overview) tenant as our Open ID Connect identity provider in the TTS sandbox environment.

--- a/docs/create-ad-b2c-idp.md
+++ b/docs/create-ad-b2c-idp.md
@@ -62,3 +62,13 @@ We use an [Azure AD B2C](https://docs.microsoft.com/en-us/azure/active-directory
    6. Click `Create`
    7. [Open the profile editing user flow and sign in as the new user](https://ttsb2cdev.b2clogin.com/ttsb2cdev.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_pe&client_id=e7e769ad-e9bc-4c5f-8c3e-ebaf6cf9cacb&nonce=defaultNonce&redirect_uri=https%3A%2F%2Fjwt.ms&scope=openid&response_type=id_token&prompt=login). Under email, enter the same email address that was used for sign in and click continue.
       - You should be redirected to [jwt.ms](jwt.ms) where, under `Decoded Token`, you should see a claim with a type of `extension_EmailAddress`.
+
+#### Set or update existing user attributes (claims)
+1. From within the B2C tenant, search for and select `Azure AD B2C`
+2. Open the `User flows` blade
+   1. From the list of user flows, select `B2C_1_pe` (`pe` in this case stands for profile edit)
+   2. Click `Run user flow`
+   3. Under `Application`, select either `tts-app-dashboard-dev` or `tts-app-querytool-dev`
+   4. Under `Reply URL`, select `https://jwt.ms`
+   5. Click `Run user flow`
+   6. The profile editor will open in a new tab. Once you sign in, you will be able to update the attributes for the user, and the associated claims will reflect those updates on the next sign in.


### PR DESCRIPTION
Closes #1336

Updates the Azure B2C IDP documentation to include instructions for creating new user attribute types (claim types) as well as updating attributes for specific users (claim values).