### PR TITLE
Configure Easy Auth and Front Door for dashboard

### DIFF
--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -28,6 +28,12 @@
         },
         "aspNetCoreEnvironment": {
             "type": "string"
+        },
+        "frontDoorId": {
+            "type": "string"
+        },
+        "frontDoorUri": {
+            "type": "string"
         }
     },
     "variables": {
@@ -45,7 +51,21 @@
             ],
             // Use 64-bit runtime on Windows for consistency with local Linux and macOS dev environments
             "use32BitWorkerProcess": false,
-            "ipSecurityRestrictions": [],
+            "ipSecurityRestrictions": [
+                // Restricts access to Front Door
+                {
+                    "ipAddress": "AzureFrontDoor.Backend",
+                    "tag": "ServiceTag",
+                    "action": "Allow",
+                    "priority": 100,
+                    "name": "Allow Azure Front Door access",
+                    "headers": {
+                        "x-azure-fdid": [
+                            "[parameters('frontDoorId')]"
+                        ]
+                    }
+                }
+            ],
             "ftpsState": "Disabled",
             "appSettings": [
                 // Environment Variables
@@ -171,6 +191,13 @@
                     "redirectToProvider": "oidcProvider",
                     "excludedPaths": ["/health-probe.html"]
                 },
+                "httpSettings": {
+                    "requireHttps": true,
+                    // Required for Easy Auth and Front Door to work together
+                    "forwardProxy": {
+                        "convention": "Standard"
+                    }
+                },
                 "identityProviders": {
                     "customOpenIdConnectProviders": {
                         "oidcProvider": {
@@ -200,7 +227,12 @@
                         // If enabled, /.auth/me URL is exposed to the authenticated user,
                         // which is useful for debugging OIDC claims
                         "enabled": false
-                    }
+                    },
+                    "preserveUrlFragmentsForLogins": true,
+                    "allowedExternalRedirectUrls": [
+                        // Required for Easy Auth and Front Door to work together
+                        "[parameters('frontDoorUri')]"
+                    ]
                 }
             }
         }

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -253,6 +253,8 @@ main () {
     --output tsv)
   echo "Front Door iD: ${front_door_id}"
 
+  front_door_uri="https://$DASHBOARD_FRONTDOOR_NAME"$(front_door_host_suffix)
+
   metrics_api_uri=$(\
     az functionapp function show \
       -g "$RESOURCE_GROUP" \
@@ -276,7 +278,9 @@ main () {
       eventHubName="$EVENT_HUB_NAME" \
       idpOidcConfigUri="$DASHBOARD_APP_IDP_OIDC_CONFIG_URI" \
       idpClientId="$DASHBOARD_APP_IDP_CLIENT_ID" \
-      aspNetCoreEnvironment="$PREFIX"
+      aspNetCoreEnvironment="$PREFIX" \
+      frontDoorId="$front_door_id" \
+      frontDoorUri="$front_door_uri"
 
   ./configure-oidc.bash "$azure_env" "$DASHBOARD_APP_NAME"
 


### PR DESCRIPTION
Partially addresses #1029; similar to work done for query tool in #1380

The sign-out link however is now broken; wants to redirect to App Service URL for ../complete rather than the Front Door URL. Will address in separate PR.

**Deploy notes**
- Updated B2C app registration to allow Front Door callback URL, deleted App Service callback URL