### PR TITLE
Make sign out links work with Azure Front Door

### DIFF
--- a/dashboard/src/Piipan.Dashboard/Pages/BasePageModel.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/BasePageModel.cs
@@ -23,13 +23,7 @@ namespace Piipan.Dashboard.Pages
         }
         public string BaseUrl
         {
-            get 
-            {
-                var url = _requestUrlProvider.GetBaseUrl(Request).ToString();
-                Console.WriteLine(url);
-                return url;
-                
-            }
+            get { return _requestUrlProvider.GetBaseUrl(Request).ToString(); }
         }
     }
 }

--- a/dashboard/src/Piipan.Dashboard/Pages/BasePageModel.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/BasePageModel.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
+using System;
+using System.Linq;
+
+namespace Piipan.Dashboard.Pages
+{
+    public class BasePageModel : PageModel
+    {
+        private readonly IClaimsProvider _claimsProvider;
+        private readonly IRequestUrlProvider _requestUrlProvider;
+
+        public BasePageModel(IClaimsProvider claimsProvider, IRequestUrlProvider requestUrlProvider)
+        {
+            _claimsProvider = claimsProvider;
+            _requestUrlProvider = requestUrlProvider;
+        }
+
+        public string Email 
+        { 
+            get { return _claimsProvider.GetEmail(User); }
+        }
+        public string BaseUrl
+        {
+            get 
+            {
+                var url = _requestUrlProvider.GetBaseUrl(Request).ToString();
+                Console.WriteLine(url);
+                return url;
+                
+            }
+        }
+    }
+}

--- a/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml.cs
@@ -1,25 +1,25 @@
 ﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
+using System.Linq;
 
 namespace Piipan.Dashboard.Pages
 {
-    public class IndexModel : PageModel
+    public class IndexModel : BasePageModel
     {
         private readonly ILogger<IndexModel> _logger;
-        private readonly IClaimsProvider _claimsProvider;
 
         public IndexModel(ILogger<IndexModel> logger,
-            IClaimsProvider claimsProvider)
+            IClaimsProvider claimsProvider,
+            IRequestUrlProvider requestUrlProvider) 
+            : base(claimsProvider, requestUrlProvider)
         {
             _logger = logger;
-            _claimsProvider = claimsProvider;
         }
-        public string Email { get; private set; } = "";
 
         public void OnGet()
         {
-            Email = _claimsProvider.GetEmail(User);
         }
     }
 }

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -3,39 +3,38 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Piipan.Dashboard.Api;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
 
 #nullable enable
 
 namespace Piipan.Dashboard.Pages
 {
-    public class ParticipantUploadsModel : PageModel
+    public class ParticipantUploadsModel : BasePageModel
     {
         private readonly IParticipantUploadRequest _participantUploadRequest;
         private readonly ILogger<ParticipantUploadsModel> _logger;
-        private readonly IClaimsProvider _claimsProvider;
 
         public ParticipantUploadsModel(IParticipantUploadRequest participantUploadRequest, 
             ILogger<ParticipantUploadsModel> logger,
-            IClaimsProvider claimsProvider)
+            IClaimsProvider claimsProvider,
+            IRequestUrlProvider requestUrlProvider)
+            : base(claimsProvider, requestUrlProvider)
         {
             _participantUploadRequest = participantUploadRequest;
             _logger = logger;
-            _claimsProvider = claimsProvider;
         }
         public string Title = "Participant Uploads";
-        public string Email { get; private set; } = "";
         public List<ParticipantUpload> ParticipantUploadResults { get; private set; } = new List<ParticipantUpload>();
         public string? NextPageParams { get; private set; }
         public string? PrevPageParams { get; private set; }
         public string? StateQuery { get; private set; }
         public static int PerPageDefault = 10;
         public static string ApiUrlKey = "MetricsApiUri";
-        public string? BaseUrl = Environment.GetEnvironmentVariable(ApiUrlKey);
+        public string? MetricsApiBaseUrl = Environment.GetEnvironmentVariable(ApiUrlKey);
 
         private HttpClient httpClient = new HttpClient();
 
@@ -43,8 +42,6 @@ namespace Piipan.Dashboard.Pages
         {
             try
             {
-                Email = _claimsProvider.GetEmail(User);
-
                 _logger.LogInformation("Loading initial results");
                 var url = FormatUrl();
                 var response = await _participantUploadRequest.Get(url);
@@ -60,18 +57,16 @@ namespace Piipan.Dashboard.Pages
         public async Task<IActionResult> OnPostAsync()
         {
             try
-            {
-                Email = _claimsProvider.GetEmail(User);
-                
+            {   
                 _logger.LogInformation("Querying uploads via search form");
 
-                if (BaseUrl == null)
+                if (MetricsApiBaseUrl == null)
                 {
-                    throw new Exception("BaseUrl is null.");
+                    throw new Exception("MetricsApiBaseUrl is null.");
                 }
 
                 StateQuery = Request.Form["state"];
-                var url = QueryHelpers.AddQueryString(BaseUrl, "state", StateQuery);
+                var url = QueryHelpers.AddQueryString(MetricsApiBaseUrl, "state", StateQuery);
                 url = QueryHelpers.AddQueryString(url, "perPage", PerPageDefault.ToString());
                 var response = await _participantUploadRequest.Get(url);
                 ParticipantUploadResults = response.data;
@@ -87,11 +82,11 @@ namespace Piipan.Dashboard.Pages
         // adds default pagination to the api url if none is present from request params
         private string FormatUrl()
         {
-            if (BaseUrl == null)
+            if (MetricsApiBaseUrl == null)
             {
-                throw new Exception("BaseUrl is null.");
+                throw new Exception("MetricsApiBaseUrl is null.");
             }
-            var url = BaseUrl + Request.QueryString;
+            var url = MetricsApiBaseUrl + Request.QueryString;
             StateQuery = Request.Query["state"];
             if (String.IsNullOrEmpty(Request.Query["perPage"]))
                 url = QueryHelpers.AddQueryString(url, "perPage", PerPageDefault.ToString());

--- a/dashboard/src/Piipan.Dashboard/Pages/Shared/_Layout.cshtml
+++ b/dashboard/src/Piipan.Dashboard/Pages/Shared/_Layout.cshtml
@@ -29,7 +29,7 @@
                         </button>
                         <ul id="nav-user" class="usa-nav__submenu" hidden>
                             <li class="usa-nav__submenu-item">
-                                <a href="/.auth/logout?post_logout_redirect_uri=@(Model.BaseUrl)/.auth/logout/complete">Sign out</a>
+                                <a href="/.auth/logout?post_logout_redirect_uri=@(Model.BaseUrl).auth/logout/complete">Sign out</a>
                             </li>
                         </ul>
                     </li>

--- a/dashboard/src/Piipan.Dashboard/Pages/Shared/_Layout.cshtml
+++ b/dashboard/src/Piipan.Dashboard/Pages/Shared/_Layout.cshtml
@@ -29,7 +29,7 @@
                         </button>
                         <ul id="nav-user" class="usa-nav__submenu" hidden>
                             <li class="usa-nav__submenu-item">
-                                <a href="/.auth/logout">Sign out</a>
+                                <a href="/.auth/logout?post_logout_redirect_uri=@(Model.BaseUrl)/.auth/logout/complete">Sign out</a>
                             </li>
                         </ul>
                     </li>

--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -10,6 +10,7 @@ using Piipan.Dashboard.Api;
 using Piipan.Shared.Authentication;
 using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
 using Piipan.Shared.Logging;
 
 namespace Piipan.Dashboard
@@ -68,8 +69,14 @@ namespace Piipan.Dashboard
 
             if (_env.IsDevelopment())
             {
+                services.AddTransient<IRequestUrlProvider, RequestUrlProvider>();
+                
                 var mockFile = $"{_env.ContentRootPath}/mock_user.json";
                 services.UseJsonFileToMockEasyAuth(mockFile);
+            }
+            else
+            {
+                services.AddTransient<IRequestUrlProvider, ProxiedRequestUrlProvider>();
             }
         }
 

--- a/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
@@ -2,6 +2,7 @@ using Xunit;
 using Piipan.Dashboard.Pages;
 using Microsoft.Extensions.Logging.Abstractions;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
 using Moq;
 using System.Security.Claims;
 
@@ -14,12 +15,13 @@ namespace Piipan.Dashboard.Tests
         {
             // arrange
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
-            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClaimsProvider);
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>();
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClaimsProvider, mockRequestUrlProvider.Object);
 
             // act
 
             // assert
-            Assert.Equal("", pageModel.Email);
+            Assert.Equal("noreply@tts.test", pageModel.Email);
         }
 
         [Fact]
@@ -27,7 +29,8 @@ namespace Piipan.Dashboard.Tests
         {
             // arrange
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
-            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClaimsProvider);
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>();
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClaimsProvider, mockRequestUrlProvider.Object);
 
             // act
             pageModel.OnGet();

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using Piipan.Dashboard.Api;
 using Piipan.Dashboard.Pages;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
 using Xunit;
 
 namespace Piipan.Dashboard.Tests
@@ -24,13 +25,15 @@ namespace Piipan.Dashboard.Tests
         {
             var mockApi = new Mock<IParticipantUploadRequest>();
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>().Object;
             var pageModel = new ParticipantUploadsModel(
                 mockApi.Object,
                 new NullLogger<ParticipantUploadsModel>(),
-                mockClaimsProvider
+                mockClaimsProvider,
+                mockRequestUrlProvider
             );
             Assert.Equal("Participant Uploads", pageModel.Title);
-            Assert.Equal("", pageModel.Email);
+            Assert.Equal("noreply@tts.test", pageModel.Email);
         }
 
         [Fact]
@@ -51,12 +54,14 @@ namespace Piipan.Dashboard.Tests
             Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, "http://example.com");
             var mockApi = new Mock<IParticipantUploadRequest>();
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>().Object;
             var pageModel = new ParticipantUploadsModel(
                 mockApi.Object,
                 new NullLogger<ParticipantUploadsModel>(),
-                mockClaimsProvider
+                mockClaimsProvider,
+                mockRequestUrlProvider
             );
-            Assert.Matches("http://example.com", pageModel.BaseUrl);
+            Assert.Matches("http://example.com", pageModel.MetricsApiBaseUrl);
             Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
 
@@ -65,10 +70,12 @@ namespace Piipan.Dashboard.Tests
         {
             var mockApi = new Mock<IParticipantUploadRequest>();
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>().Object;
             var pageModel = new ParticipantUploadsModel(
                 mockApi.Object,
                 new NullLogger<ParticipantUploadsModel>(),
-                mockClaimsProvider
+                mockClaimsProvider,
+                mockRequestUrlProvider
             );
             Assert.IsType<List<ParticipantUpload>>(pageModel.ParticipantUploadResults);
         }
@@ -86,12 +93,14 @@ namespace Piipan.Dashboard.Tests
             var meta = new ParticipantUploadResponseMeta();
             var mockApi = mockApiWithResponse(data, meta);
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>().Object;
             var pageContext = MockPageContext(new DefaultHttpContext());
             // setup page model with mocks
             var pageModel = new ParticipantUploadsModel(
                 mockApi.Object,
                 new NullLogger<ParticipantUploadsModel>(),
-                mockClaimsProvider
+                mockClaimsProvider,
+                mockRequestUrlProvider
             )
             {
                 PageContext = pageContext
@@ -117,6 +126,7 @@ namespace Piipan.Dashboard.Tests
             var meta = new ParticipantUploadResponseMeta();
             var mockApi = mockApiWithResponse(data, meta);
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>().Object;
             // setup mock page context with form data
             var httpContext = new DefaultHttpContext();
             var form = new FormCollection(new Dictionary<string,
@@ -130,7 +140,8 @@ namespace Piipan.Dashboard.Tests
             var pageModel = new ParticipantUploadsModel(
                 mockApi.Object,
                 new NullLogger<ParticipantUploadsModel>(),
-                mockClaimsProvider
+                mockClaimsProvider,
+                mockRequestUrlProvider
             )
             {
                 PageContext = pageContext

--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
+
+namespace Piipan.QueryTool.Pages
+{
+    public class BasePageModel : PageModel
+    {
+        private readonly IClaimsProvider _claimsProvider;
+        private readonly IRequestUrlProvider _requestUrlProvider;
+
+        public BasePageModel(IClaimsProvider claimsProvider, IRequestUrlProvider requestUrlProvider)
+        {
+            _claimsProvider = claimsProvider;
+            _requestUrlProvider = requestUrlProvider;
+        }
+
+        public string Email 
+        { 
+            get { return _claimsProvider.GetEmail(User); }
+        }
+        public string BaseUrl
+        {
+            get { return _requestUrlProvider.GetBaseUrl(Request).ToString(); }
+        }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -7,10 +7,11 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using Piipan.Shared.Authentication;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
 
 namespace Piipan.QueryTool.Pages
 {
-    public class IndexModel : PageModel
+    public class IndexModel : BasePageModel
     {
         private readonly ILogger<IndexModel> _logger;
         private readonly IAuthorizedApiClient _apiClient;
@@ -19,7 +20,9 @@ namespace Piipan.QueryTool.Pages
 
         public IndexModel(ILogger<IndexModel> logger,
                           IAuthorizedApiClient apiClient,
-                          IClaimsProvider claimsProvider)
+                          IClaimsProvider claimsProvider,
+                          IRequestUrlProvider requestUrlProvider)
+                          : base(claimsProvider, requestUrlProvider)
         {
             _logger = logger;
             _apiClient = apiClient;
@@ -37,8 +40,6 @@ namespace Piipan.QueryTool.Pages
 
         public async Task<IActionResult> OnPostAsync()
         {
-            Email = _claimsProvider.GetEmail(User);
-
             if (ModelState.IsValid)
             {
                 try
@@ -63,12 +64,10 @@ namespace Piipan.QueryTool.Pages
         }
 
         public string Title { get; private set; } = "";
-        public string Email { get; private set; } = "";
 
         public void OnGet()
         {
             Title = "NAC Query Tool";
-            Email = _claimsProvider.GetEmail(User);
         }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
@@ -35,7 +35,7 @@
                                     </button>
                                     <ul id="nav-user" class="usa-nav__submenu" hidden>
                                         <li class="usa-nav__submenu-item">
-                                            <a href="/.auth/logout">Sign out</a>
+                                            <a href="/.auth/logout?post_logout_redirect_uri=@(Model.BaseUrl).auth/logout/complete">Sign out</a>
                                         </li>
                                     </ul>
                                 </li>

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -10,6 +10,7 @@ using Piipan.QueryTool.Binders;
 using Piipan.Shared.Authentication;
 using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
 using Piipan.Shared.Logging;
 
 namespace Piipan.QueryTool
@@ -70,8 +71,14 @@ namespace Piipan.QueryTool
 
             if (_env.IsDevelopment())
             {
+                services.AddTransient<IRequestUrlProvider, RequestUrlProvider>();
+
                 var mockFile = $"{_env.ContentRootPath}/mock_user.json";
                 services.UseJsonFileToMockEasyAuth(mockFile);
+            }
+            else
+            {
+                services.AddTransient<IRequestUrlProvider, ProxiedRequestUrlProvider>();
             }
         }
 

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -8,6 +8,7 @@ using Moq;
 using Piipan.QueryTool.Pages;
 using Piipan.Shared.Authentication;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Http;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests
@@ -52,15 +53,17 @@ namespace Piipan.QueryTool.Tests
 
             var mockApiClient = Mock.Of<IAuthorizedApiClient>();
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>();
             var pageModel = new IndexModel(
                 new NullLogger<IndexModel>(),
                 mockApiClient,
-                mockClaimsProvider
+                mockClaimsProvider,
+                mockRequestUrlProvider.Object
                 );
             // act
             // assert
             Assert.Equal("", pageModel.Title);
-            Assert.Equal("", pageModel.Email);
+            Assert.Equal("noreply@tts.test", pageModel.Email);
         }
         [Fact]
         public void TestAfterOnGet()
@@ -68,7 +71,8 @@ namespace Piipan.QueryTool.Tests
             // arrange
             var mockApiClient = Mock.Of<IAuthorizedApiClient>();
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
-            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockApiClient, mockClaimsProvider);
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>();
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockApiClient, mockClaimsProvider, mockRequestUrlProvider.Object);
 
             // act
             pageModel.OnGet();
@@ -109,7 +113,8 @@ namespace Piipan.QueryTool.Tests
             };
             var mockClient = clientMock(HttpStatusCode.OK, returnValue);
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
-            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider);
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>();
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider, mockRequestUrlProvider.Object);
             pageModel.Query = requestPii;
 
             // act
@@ -146,7 +151,8 @@ namespace Piipan.QueryTool.Tests
             };
             var mockClient = clientMock(HttpStatusCode.OK, returnValue);
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
-            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider);
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>();
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider, mockRequestUrlProvider.Object);
             pageModel.Query = requestPii;
 
             // act
@@ -172,7 +178,8 @@ namespace Piipan.QueryTool.Tests
             };
             var mockClient = clientMock(HttpStatusCode.BadRequest, "");
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
-            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider);
+            var mockRequestUrlProvider = new Mock<RequestUrlProvider>();
+            var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider, mockRequestUrlProvider.Object);
             pageModel.Query = requestPii;
 
             // act

--- a/shared/src/Piipan.Shared/IRequestUrlProvider.cs
+++ b/shared/src/Piipan.Shared/IRequestUrlProvider.cs
@@ -1,0 +1,10 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Piipan.Shared.Http
+{
+    public interface IRequestUrlProvider
+    {
+        Uri GetBaseUrl(HttpRequest request);
+    }
+}

--- a/shared/src/Piipan.Shared/ProxiedRequestUrlProvider.cs
+++ b/shared/src/Piipan.Shared/ProxiedRequestUrlProvider.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace Piipan.Shared.Http
+{
+    public class ProxiedRequestUrlProvider : IRequestUrlProvider
+    {
+        public Uri GetBaseUrl(HttpRequest request)
+        {
+            var proto = request.Headers.Single(h => h.Key == "X-Forwarded-Proto").Value;
+            var host = request.Headers.Single(h => h.Key == "X-Forwarded-Host").Value;
+            return new Uri($"{proto}://{host}");
+        }
+    }
+}

--- a/shared/src/Piipan.Shared/ProxiedRequestUrlProvider.cs
+++ b/shared/src/Piipan.Shared/ProxiedRequestUrlProvider.cs
@@ -1,16 +1,32 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Piipan.Shared.Http
 {
     public class ProxiedRequestUrlProvider : IRequestUrlProvider
     {
+        private readonly ILogger<ProxiedRequestUrlProvider> _logger;
+
+        public ProxiedRequestUrlProvider(ILogger<ProxiedRequestUrlProvider> logger)
+        {
+            _logger = logger;
+        }
+
         public Uri GetBaseUrl(HttpRequest request)
         {
-            var proto = request.Headers.Single(h => h.Key == "X-Forwarded-Proto").Value;
-            var host = request.Headers.Single(h => h.Key == "X-Forwarded-Host").Value;
-            return new Uri($"{proto}://{host}");
+            try
+            {
+                var proto = request.Headers.Single(h => h.Key == "X-Forwarded-Proto").Value;
+                var host = request.Headers.Single(h => h.Key == "X-Forwarded-Host").Value;
+                return new Uri($"{proto}://{host}");
+            }
+            catch (InvalidOperationException)
+            {
+                _logger.LogError($"Unable to extract X-Forwarded-Proto and/or X-Forwarded-Host from request headers!");
+                throw;
+            }
         }
     }
 }

--- a/shared/src/Piipan.Shared/RequestUrlProvider.cs
+++ b/shared/src/Piipan.Shared/RequestUrlProvider.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Piipan.Shared.Http
+{
+    public class RequestUrlProvider : IRequestUrlProvider
+    {
+        public Uri GetBaseUrl(HttpRequest request)
+        {
+            return new Uri( $"{request.Scheme}://{request.Host.ToString()}");
+        }
+    }
+}

--- a/shared/tests/Piipan.Shared.Tests/ProxiedRequestUrlProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/ProxiedRequestUrlProviderTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using Moq;
+using Xunit;
+
+namespace Piipan.Shared.Http.Tests
+{
+    public class ProxiedRequestUrlProviderTests
+    {
+        [Fact]
+        public void GetBaseUrl()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ProxiedRequestUrlProvider>>();
+            var provider = new ProxiedRequestUrlProvider(logger.Object);
+            var request = new Mock<HttpRequest>();
+            var headers = new HeaderDictionary();
+            headers.Add("X-Forwarded-Proto", "https");
+            headers.Add("X-Forwarded-Host", "tts.test");
+
+            request
+                .Setup(m => m.Headers)
+                .Returns(headers);
+            
+            // Act
+            var baseUrl = provider.GetBaseUrl(request.Object);
+
+            // Assert
+            Assert.Equal("https://tts.test/", baseUrl.ToString());
+        }
+
+        [Fact]
+        public void GetBaseUrl_ThrowsWhenProtoHeaderMissing()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ProxiedRequestUrlProvider>>();
+            var provider = new ProxiedRequestUrlProvider(logger.Object);
+            var request = new Mock<HttpRequest>();
+            var headers = new HeaderDictionary();
+            // no proto header
+            headers.Add("X-Forwarded-Host", "tts.test");
+
+            request
+                .Setup(m => m.Headers)
+                .Returns(headers);
+            
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => provider.GetBaseUrl(request.Object));
+
+            // Assert
+            logger.Verify(m => m.Log(
+                It.Is<LogLevel>(l => l == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((object v, Type _) => v.ToString().Contains("Unable to extract")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once());
+        }
+
+        [Fact]
+        public void GetBaseUrl_ThrowsWhenHostHeaderMissing()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ProxiedRequestUrlProvider>>();
+            var provider = new ProxiedRequestUrlProvider(logger.Object);
+            var request = new Mock<HttpRequest>();
+            var headers = new HeaderDictionary();
+            headers.Add("X-Forwarded-Proto", "https");
+            // no host header
+
+            request
+                .Setup(m => m.Headers)
+                .Returns(headers);
+            
+            // Act / Assert
+            Assert.Throws<InvalidOperationException>(() => provider.GetBaseUrl(request.Object));
+
+            // Assert
+            logger.Verify(m => m.Log(
+                It.Is<LogLevel>(l => l == LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((object v, Type _) => v.ToString().Contains("Unable to extract")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once());
+        }
+    }
+}

--- a/shared/tests/Piipan.Shared.Tests/RequestUrlProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/RequestUrlProviderTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Piipan.Shared.Http.Tests
+{
+    public class RequestUrlProviderTests
+    {
+        [Fact]
+        public void GetBaseUrl()
+        {
+            // Arrange
+            var provider = new RequestUrlProvider();
+            var request = new Mock<HttpRequest>();
+            request
+                .Setup(m => m.Scheme)
+                .Returns("https");
+            request
+                .Setup(m => m.Host)
+                .Returns(new HostString("tts.test"));
+            
+            // Act
+            var baseUrl = provider.GetBaseUrl(request.Object);
+
+            // Assert
+            Assert.Equal("https://tts.test/", baseUrl.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Closes #1383 

- Adds `IRequestUrlProvider` with two implementations:
  - `RequestUrlProvider`: for non-proxied environments (local development)
  - `ProxiedRequestUrlProvider`: for proxied environments (FNS & TTS sandbox, where apps sit behind Azure Front Door) 
- Pulls properties that are references in shared Razor pages (e.g. `_Layout.cshtml`) up into `BasePageModel` rather than having them duplicated across `PageModels`