### PR TITLE
Make sign out links work with Azure Front Door

### DIFF
--- a/dashboard/src/Piipan.Dashboard/Pages/BasePageModel.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/BasePageModel.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Piipan.Shared.Claims;
+
+namespace Piipan.Dashboard.Pages
+{
+    public class BasePageModel : PageModel
+    {
+        private readonly IClaimsProvider _claimsProvider;
+
+        public BasePageModel(IClaimsProvider claimsProvider)
+        {
+            _claimsProvider = claimsProvider;
+        }
+
+        public string Email 
+        { 
+            get { return _claimsProvider.GetEmail(User); }
+        }
+        public string BaseUrl
+        {
+            get { return $"{Request.Scheme}://{Request.Host}"; }
+        }
+    }
+} 

--- a/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/Index.cshtml.cs
@@ -4,22 +4,19 @@ using Piipan.Shared.Claims;
 
 namespace Piipan.Dashboard.Pages
 {
-    public class IndexModel : PageModel
+    public class IndexModel : BasePageModel
     {
         private readonly ILogger<IndexModel> _logger;
-        private readonly IClaimsProvider _claimsProvider;
 
         public IndexModel(ILogger<IndexModel> logger,
             IClaimsProvider claimsProvider)
+            : base(claimsProvider)
         {
             _logger = logger;
-            _claimsProvider = claimsProvider;
         }
-        public string Email { get; private set; } = "";
 
         public void OnGet()
         {
-            Email = _claimsProvider.GetEmail(User);
         }
     }
 }

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -13,29 +13,27 @@ using Piipan.Shared.Claims;
 
 namespace Piipan.Dashboard.Pages
 {
-    public class ParticipantUploadsModel : PageModel
+    public class ParticipantUploadsModel : BasePageModel
     {
         private readonly IParticipantUploadRequest _participantUploadRequest;
         private readonly ILogger<ParticipantUploadsModel> _logger;
-        private readonly IClaimsProvider _claimsProvider;
 
         public ParticipantUploadsModel(IParticipantUploadRequest participantUploadRequest, 
             ILogger<ParticipantUploadsModel> logger,
             IClaimsProvider claimsProvider)
+            : base(claimsProvider)
         {
             _participantUploadRequest = participantUploadRequest;
             _logger = logger;
-            _claimsProvider = claimsProvider;
         }
         public string Title = "Participant Uploads";
-        public string Email { get; private set; } = "";
         public List<ParticipantUpload> ParticipantUploadResults { get; private set; } = new List<ParticipantUpload>();
         public string? NextPageParams { get; private set; }
         public string? PrevPageParams { get; private set; }
         public string? StateQuery { get; private set; }
         public static int PerPageDefault = 10;
         public static string ApiUrlKey = "MetricsApiUri";
-        public string? BaseUrl = Environment.GetEnvironmentVariable(ApiUrlKey);
+        public string? MetricsApiBaseUrl = Environment.GetEnvironmentVariable(ApiUrlKey);
 
         private HttpClient httpClient = new HttpClient();
 
@@ -43,8 +41,6 @@ namespace Piipan.Dashboard.Pages
         {
             try
             {
-                Email = _claimsProvider.GetEmail(User);
-
                 _logger.LogInformation("Loading initial results");
                 var url = FormatUrl();
                 var response = await _participantUploadRequest.Get(url);
@@ -60,18 +56,16 @@ namespace Piipan.Dashboard.Pages
         public async Task<IActionResult> OnPostAsync()
         {
             try
-            {
-                Email = _claimsProvider.GetEmail(User);
-                
+            {   
                 _logger.LogInformation("Querying uploads via search form");
 
-                if (BaseUrl == null)
+                if (MetricsApiBaseUrl == null)
                 {
-                    throw new Exception("BaseUrl is null.");
+                    throw new Exception("MetricsApiBaseUrl is null.");
                 }
 
                 StateQuery = Request.Form["state"];
-                var url = QueryHelpers.AddQueryString(BaseUrl, "state", StateQuery);
+                var url = QueryHelpers.AddQueryString(MetricsApiBaseUrl, "state", StateQuery);
                 url = QueryHelpers.AddQueryString(url, "perPage", PerPageDefault.ToString());
                 var response = await _participantUploadRequest.Get(url);
                 ParticipantUploadResults = response.data;
@@ -87,11 +81,11 @@ namespace Piipan.Dashboard.Pages
         // adds default pagination to the api url if none is present from request params
         private string FormatUrl()
         {
-            if (BaseUrl == null)
+            if (MetricsApiBaseUrl == null)
             {
-                throw new Exception("BaseUrl is null.");
+                throw new Exception("MetricsApiBaseUrl is null.");
             }
-            var url = BaseUrl + Request.QueryString;
+            var url = MetricsApiBaseUrl + Request.QueryString;
             StateQuery = Request.Query["state"];
             if (String.IsNullOrEmpty(Request.Query["perPage"]))
                 url = QueryHelpers.AddQueryString(url, "perPage", PerPageDefault.ToString());

--- a/dashboard/src/Piipan.Dashboard/Pages/Shared/_Layout.cshtml
+++ b/dashboard/src/Piipan.Dashboard/Pages/Shared/_Layout.cshtml
@@ -29,7 +29,7 @@
                         </button>
                         <ul id="nav-user" class="usa-nav__submenu" hidden>
                             <li class="usa-nav__submenu-item">
-                                <a href="/.auth/logout">Sign out</a>
+                                <a href="/.auth/logout?post_logout_redirect_uri=@(Model.BaseUrl)/.auth/logout/complete">Sign out</a>
                             </li>
                         </ul>
                     </li>

--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -30,6 +31,12 @@ namespace Piipan.Dashboard
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<ClaimsOptions>(Configuration.GetSection(ClaimsOptions.SectionName));
+
+            services.Configure<ForwardedHeadersOptions>(options => {
+                options.ForwardedHeaders = 
+                    ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
+            });
+
             services.AddRazorPages(options => {
                 options.Conventions.AuthorizeFolder("/");
             });
@@ -85,6 +92,7 @@ namespace Piipan.Dashboard
                 app.UseExceptionHandler("/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
+                app.UseForwardedHeaders();
             }
 
             app.UseHttpsRedirection();

--- a/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Piipan.Shared.Claims;
 using Moq;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 namespace Piipan.Dashboard.Tests
 {
@@ -15,11 +16,13 @@ namespace Piipan.Dashboard.Tests
             // arrange
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
             var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClaimsProvider);
+            pageModel.PageContext.HttpContext = contextMock();
 
             // act
 
             // assert
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
         }
 
         [Fact]
@@ -28,12 +31,14 @@ namespace Piipan.Dashboard.Tests
             // arrange
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
             var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClaimsProvider);
+            pageModel.PageContext.HttpContext = contextMock();
 
             // act
             pageModel.OnGet();
 
             // assert
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
         }
 
         private IClaimsProvider claimsProviderMock(string email)
@@ -43,6 +48,24 @@ namespace Piipan.Dashboard.Tests
                 .Setup(c => c.GetEmail(It.IsAny<ClaimsPrincipal>()))
                 .Returns(email);
             return claimsProviderMock.Object;
+        }
+
+        public static HttpContext contextMock()
+        {
+            var request = new Mock<HttpRequest>();
+
+            request
+                .Setup(m => m.Scheme)
+                .Returns("https");
+
+            request
+                .Setup(m => m.Host)
+                .Returns(new HostString("tts.test"));
+
+            var context = new Mock<HttpContext>();
+            context.Setup(m => m.Request).Returns(request.Object);
+
+            return context.Object;
         }
     }
 }

--- a/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/IndexPageTest.cs
@@ -19,7 +19,7 @@ namespace Piipan.Dashboard.Tests
             // act
 
             // assert
-            Assert.Equal("", pageModel.Email);
+            Assert.Equal("noreply@tts.test", pageModel.Email);
         }
 
         [Fact]

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -30,7 +30,7 @@ namespace Piipan.Dashboard.Tests
                 mockClaimsProvider
             );
             Assert.Equal("Participant Uploads", pageModel.Title);
-            Assert.Equal("", pageModel.Email);
+            Assert.Equal("noreply@tts.test", pageModel.Email);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Piipan.Dashboard.Tests
                 new NullLogger<ParticipantUploadsModel>(),
                 mockClaimsProvider
             );
-            Assert.Matches("http://example.com", pageModel.BaseUrl);
+            Assert.Matches("http://example.com", pageModel.MetricsApiBaseUrl);
             Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
 

--- a/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/ParticipantUploadsModelTests.cs
@@ -29,8 +29,11 @@ namespace Piipan.Dashboard.Tests
                 new NullLogger<ParticipantUploadsModel>(),
                 mockClaimsProvider
             );
+            pageModel.PageContext.HttpContext = contextMock();
+
             Assert.Equal("Participant Uploads", pageModel.Title);
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
         }
 
         [Fact]
@@ -56,7 +59,11 @@ namespace Piipan.Dashboard.Tests
                 new NullLogger<ParticipantUploadsModel>(),
                 mockClaimsProvider
             );
+            pageModel.PageContext.HttpContext = contextMock();
+
             Assert.Matches("http://example.com", pageModel.MetricsApiBaseUrl);
+            Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
             Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
 
@@ -86,7 +93,10 @@ namespace Piipan.Dashboard.Tests
             var meta = new ParticipantUploadResponseMeta();
             var mockApi = mockApiWithResponse(data, meta);
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
-            var pageContext = MockPageContext(new DefaultHttpContext());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("tts.test");
+            var pageContext = MockPageContext(httpContext);
             // setup page model with mocks
             var pageModel = new ParticipantUploadsModel(
                 mockApi.Object,
@@ -96,14 +106,19 @@ namespace Piipan.Dashboard.Tests
             {
                 PageContext = pageContext
             };
+
             // run
             await pageModel.OnGetAsync();
+
             // assert
             Assert.Equal(participantUpload, pageModel.ParticipantUploadResults[0]);
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
+
             // teardown
             Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
+
         // sets participant uploads after Post request
         [Fact]
         public async void AfterOnPostAsync_setsParticipantUploadResults()
@@ -125,6 +140,8 @@ namespace Piipan.Dashboard.Tests
                 { "state", "foo" }
             });
             httpContext.Request.Form = form;
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("tts.test");
             var pageContext = MockPageContext(httpContext);
             // setup page model with mocks
             var pageModel = new ParticipantUploadsModel(
@@ -135,11 +152,15 @@ namespace Piipan.Dashboard.Tests
             {
                 PageContext = pageContext
             };
+
             // run
             await pageModel.OnPostAsync();
+
             // assert
             Assert.Equal(participantUpload, pageModel.ParticipantUploadResults[0]);
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
+
             // teardown
             Environment.SetEnvironmentVariable(ParticipantUploadsModel.ApiUrlKey, null);
         }
@@ -178,6 +199,24 @@ namespace Piipan.Dashboard.Tests
                 .Setup(c => c.GetEmail(It.IsAny<ClaimsPrincipal>()))
                 .Returns(email);
             return claimsProviderMock.Object;
+        }
+
+        public static HttpContext contextMock()
+        {
+            var request = new Mock<HttpRequest>();
+
+            request
+                .Setup(m => m.Scheme)
+                .Returns("https");
+
+            request
+                .Setup(m => m.Host)
+                .Returns(new HostString("tts.test"));
+
+            var context = new Mock<HttpContext>();
+            context.Setup(m => m.Request).Returns(request.Object);
+
+            return context.Object;
         }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Piipan.Shared.Claims;
+
+namespace Piipan.QueryTool.Pages
+{
+    public class BasePageModel : PageModel
+    {
+        private readonly IClaimsProvider _claimsProvider;
+
+        public BasePageModel(IClaimsProvider claimsProvider)
+        {
+            _claimsProvider = claimsProvider;
+        }
+
+        public string Email 
+        { 
+            get { return _claimsProvider.GetEmail(User); }
+        }
+        public string BaseUrl
+        {
+            get { return $"{Request.Scheme}://{Request.Host}"; }
+        }
+    }
+} 

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -1,29 +1,25 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using Piipan.Shared.Authentication;
 using Piipan.Shared.Claims;
 
 namespace Piipan.QueryTool.Pages
 {
-    public class IndexModel : PageModel
+    public class IndexModel : BasePageModel
     {
         private readonly ILogger<IndexModel> _logger;
         private readonly IAuthorizedApiClient _apiClient;
-        private readonly IClaimsProvider _claimsProvider;
         private readonly OrchestratorApiRequest _apiRequest;
 
         public IndexModel(ILogger<IndexModel> logger,
                           IAuthorizedApiClient apiClient,
                           IClaimsProvider claimsProvider)
+                          : base(claimsProvider)
         {
             _logger = logger;
             _apiClient = apiClient;
-            _claimsProvider = claimsProvider;
 
             var apiBaseUri = new Uri(Environment.GetEnvironmentVariable("OrchApiUri"));
             _apiRequest = new OrchestratorApiRequest(_apiClient, apiBaseUri, _logger);
@@ -37,8 +33,6 @@ namespace Piipan.QueryTool.Pages
 
         public async Task<IActionResult> OnPostAsync()
         {
-            Email = _claimsProvider.GetEmail(User);
-
             if (ModelState.IsValid)
             {
                 try
@@ -63,12 +57,10 @@ namespace Piipan.QueryTool.Pages
         }
 
         public string Title { get; private set; } = "";
-        public string Email { get; private set; } = "";
 
         public void OnGet()
         {
             Title = "NAC Query Tool";
-            Email = _claimsProvider.GetEmail(User);
         }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
@@ -44,7 +44,7 @@
                                     </button>
                                     <ul id="nav-user" class="usa-nav__submenu" hidden>
                                         <li class="usa-nav__submenu-item">
-                                            <a href="/.auth/logout">Sign out</a>
+                                            <a href="/.auth/logout?post_logout_redirect_uri=@(Model.BaseUrl)/.auth/logout/complete">Sign out</a>
                                         </li>
                                     </ul>
                                 </li>

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -30,6 +31,11 @@ namespace Piipan.QueryTool
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<ClaimsOptions>(Configuration.GetSection(ClaimsOptions.SectionName));
+
+            services.Configure<ForwardedHeadersOptions>(options => {
+                options.ForwardedHeaders = 
+                    ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
+            });
 
             services.AddRazorPages(options => 
             {
@@ -87,6 +93,7 @@ namespace Piipan.QueryTool
                 app.UseExceptionHandler("/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
+                app.UseForwardedHeaders();
             }
 
             app.UseHttpsRedirection();

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Piipan.QueryTool.Pages;
@@ -45,6 +46,24 @@ namespace Piipan.QueryTool.Tests
             return claimsProviderMock.Object;
         }
 
+        public static HttpContext contextMock()
+        {
+            var request = new Mock<HttpRequest>();
+
+            request
+                .Setup(m => m.Scheme)
+                .Returns("https");
+
+            request
+                .Setup(m => m.Host)
+                .Returns(new HostString("tts.test"));
+
+            var context = new Mock<HttpContext>();
+            context.Setup(m => m.Request).Returns(request.Object);
+
+            return context.Object;
+        }
+
         [Fact]
         public void TestBeforeOnGet()
         {
@@ -69,6 +88,7 @@ namespace Piipan.QueryTool.Tests
             var mockApiClient = Mock.Of<IAuthorizedApiClient>();
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
             var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockApiClient, mockClaimsProvider);
+            pageModel.PageContext.HttpContext = contextMock();
 
             // act
             pageModel.OnGet();
@@ -76,6 +96,7 @@ namespace Piipan.QueryTool.Tests
             // assert
             Assert.Equal("NAC Query Tool", pageModel.Title);
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
         }
 
         [Fact]
@@ -111,6 +132,7 @@ namespace Piipan.QueryTool.Tests
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
             var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider);
             pageModel.Query = requestPii;
+            pageModel.PageContext.HttpContext = contextMock();
 
             // act
             await pageModel.OnPostAsync();
@@ -121,6 +143,7 @@ namespace Piipan.QueryTool.Tests
             Assert.NotNull(pageModel.QueryResult.Data.Results[0].Matches);
             Assert.False(pageModel.NoResults);
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
         }
 
         [Fact]
@@ -148,6 +171,7 @@ namespace Piipan.QueryTool.Tests
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
             var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider);
             pageModel.Query = requestPii;
+            pageModel.PageContext.HttpContext = contextMock();
 
             // act
             await pageModel.OnPostAsync();
@@ -157,6 +181,7 @@ namespace Piipan.QueryTool.Tests
             Assert.Empty(pageModel.QueryResult.Data.Results[0].Matches);
             Assert.True(pageModel.NoResults);
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
         }
 
         [Fact]
@@ -174,6 +199,7 @@ namespace Piipan.QueryTool.Tests
             var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
             var pageModel = new IndexModel(new NullLogger<IndexModel>(), mockClient, mockClaimsProvider);
             pageModel.Query = requestPii;
+            pageModel.PageContext.HttpContext = contextMock();
 
             // act
             await pageModel.OnPostAsync();
@@ -181,6 +207,7 @@ namespace Piipan.QueryTool.Tests
             // assert
             Assert.NotNull(pageModel.RequestError);
             Assert.Equal("noreply@tts.test", pageModel.Email);
+            Assert.Equal("https://tts.test", pageModel.BaseUrl);
         }
     }
 }

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -60,7 +60,7 @@ namespace Piipan.QueryTool.Tests
             // act
             // assert
             Assert.Equal("", pageModel.Title);
-            Assert.Equal("", pageModel.Email);
+            Assert.Equal("noreply@tts.test", pageModel.Email);
         }
         [Fact]
         public void TestAfterOnGet()


### PR DESCRIPTION
Closes #1383 

- Configures [forwarded headers middleware](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-3.1) so that the `post_logout_redirect_uri` points back to Azure FD rather than the App Service. 
- Pulls properties that are references in shared Razor pages (e.g. `_Layout.cshtml`) up into `BasePageModel` rather than having them duplicated across `PageModels`