### PR TITLE
Add read-only role to participants DB cluster

### DIFF
--- a/ddl/apply-ddl.bash
+++ b/ddl/apply-ddl.bash
@@ -29,10 +29,12 @@ apply_ddl () {
   db=$1
   owner=$2
   admin=$3
+  reader="readonly"
 
   psql "${PSQL_OPTS[@]}" -d "$db" \
     -v owner="$owner" \
     -v admin="$admin" \
+    -v reader="$reader" \
     -v superuser="$SUPERUSER" \
     -f ./per-state.sql
 }

--- a/ddl/per-state.sql
+++ b/ddl/per-state.sql
@@ -3,9 +3,9 @@ BEGIN;
 -- Creates participant records tables and their access controls.
 -- Assumes 4 database roles, to be set via the psql -v option:
 --  * cluster `superuser`
---  * cluster `reader`, which gets read-only access
 --  * database `owner`, which owns the tables, sequences
 --  * database `admin`, which gets read/write access
+--  * database `reader`, which gets read-only access
 
 SET search_path=piipan,public;
 

--- a/ddl/per-state.sql
+++ b/ddl/per-state.sql
@@ -1,8 +1,9 @@
 BEGIN;
 
 -- Creates participant records tables and their access controls.
--- Assumes 3 database roles, to be set via the psql -v option:
+-- Assumes 4 database roles, to be set via the psql -v option:
 --  * cluster `superuser`
+--  * cluster `reader`, which gets read-only access
 --  * database `owner`, which owns the tables, sequences
 --  * database `admin`, which gets read/write access
 
@@ -60,6 +61,9 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON participants TO :admin;
 GRANT SELECT, INSERT, UPDATE, DELETE ON uploads TO :admin;
 GRANT USAGE, SELECT, UPDATE ON participants_id_seq TO :admin;
 GRANT USAGE, SELECT, UPDATE ON uploads_id_seq TO :admin;
+
+GRANT SELECT ON participants TO :reader;
+GRANT SELECT ON uploads TO :reader;
 
 -- restore privileges
 REVOKE :owner FROM :superuser;


### PR DESCRIPTION
- Create `NOLOGIN` role with permission to connect to each state database
- Grant role `SELECT` permission to necessary tables

Intent is for this role to be granted to the forthcoming orchestrator managed identity role (and potentially a future bulk match identity role).

Creating this role/group may be overkill if it's used by only one or two identities, but this approach is intended to avoid making `create-databases.bash` dependent on other resources.

Partially addresses #1339.