### PR TITLE
With Easy Auth at web app, drop FD firewall rules

### DIFF
--- a/iac/arm-templates/front-door-app-service.json
+++ b/iac/arm-templates/front-door-app-service.json
@@ -80,47 +80,7 @@
                     "enabledState": "Enabled"
                 },
                 "customRules": {
-                    "rules": [
-                        /* Allow GSA IP's */
-                        {
-                            "name": "IPAllowListRule",
-                            "enabledState": "Enabled",
-                            "priority": 300, /* Lower number denotes higher priority. This Allow Rule must be a highger priority than the Deny rule below. */
-                            "ruleType": "MatchRule",
-                            "rateLimitDurationInMinutes": 1,
-                            "rateLimitThreshold": 100,
-                            "matchConditions": [
-                                {
-                                    "matchVariable": "RemoteAddr",
-                                    "operator": "IPMatch",
-                                    "negateCondition": false,
-                                    "matchValue": [
-                                        "159.142.0.0/16" /* GSA IP range */
-                                    ],
-                                    "transforms": []
-                                }
-                            ],
-                            "action": "Allow"
-                        },
-                        /* Deny all IP's */
-                        {
-                            "name": "IPDenyListRule",
-                            "enabledState": "Enabled",
-                            "priority": 301,
-                            "ruleType": "MatchRule",
-                            "rateLimitDurationInMinutes": 1,
-                            "rateLimitThreshold": 100,
-                            "matchConditions": [
-                                {
-                                    "matchVariable": "RemoteAddr",
-                                    "operator": "Any",
-                                    "matchValue": [], /* The matchValue key is required, but can be empty for the "Any" operator */
-                                    "transforms": []
-                                }
-                            ],
-                            "action": "Block"
-                        }
-                    ]
+                    "rules": []
                 },
                 "managedRules": {
                     "managedRuleSets": [


### PR DESCRIPTION
Now that Easy Auth is enabled at App Service Level, we can drop the Front Door firewall rules that restricted access to the GSA network.

- [X] Applied to tts/dev on the dashboard and query tool Front Doors