### PR TITLE
Update API specs to incorporate PPRL approach

### DIFF
--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -6,7 +6,7 @@ info:
 servers:
   - url: "/v2"
 paths:
-  /find_participants:
+  /find_matches:
     $ref: '../../match/docs/openapi/orchestrator/find.yaml'
 security:
   - ApiKeyAuth: []

--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -4,10 +4,10 @@ info:
   version: 1.0.0
   description: "The API where matching will occur"
 servers:
-  - url: "/v1"
+  - url: "/v2"
 paths:
-  /query:
-    $ref: '../../match/docs/openapi/orchestrator/query.yaml'
+  /find_participants:
+    $ref: '../../match/docs/openapi/orchestrator/find.yaml'
 security:
   - ApiKeyAuth: []
 components:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -25,7 +25,7 @@ Base URLs:
 
 ```shell
 # You can also use wget
-curl -X POST /v2/find_participants \
+curl -X POST /v2/find_matches \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'From: string' \
@@ -33,7 +33,7 @@ curl -X POST /v2/find_participants \
 
 ```
 
-`POST /find_participants`
+`POST /find_matches`
 
 *Search for all matching participant records using de-identified data*
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -8,7 +8,7 @@ The API where matching will occur
 
 Base URLs:
 
-* <a href="/v1">/v1</a>
+* <a href="/v2">/v2</a>
 
 # Authentication
 
@@ -17,15 +17,15 @@ Base URLs:
 
 <h1 id="duplicate-participation-api-match">Match</h1>
 
-## Query for Matches
+## Find matches
 
-<a id="opIdQuery for Matches"></a>
+<a id="opIdFind matches"></a>
 
 > Code samples
 
 ```shell
 # You can also use wget
-curl -X POST /v1/query \
+curl -X POST /v2/find_participants \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'From: string' \
@@ -33,11 +33,11 @@ curl -X POST /v1/query \
 
 ```
 
-`POST /query`
+`POST /find_participants`
 
-*Search for all matching PII records*
+*Search for all matching participant records using de-identified data*
 
-Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number of persons provided in the request.
+Searches all state databases for any participant records that are an exact match to the `lds_hash` of persons provided in the request.
 
 > Body parameter
 
@@ -47,27 +47,19 @@ Queries all state databases for any PII records that are an exact match to the l
 {
   "data": [
     {
-      "first": "string",
-      "middle": "string",
-      "last": "string",
-      "ssn": "000-00-0000",
-      "dob": "1970-01-01"
+      "lds_hash": "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
     }
   ]
 }
 ```
 
-<h3 id="query-for-matches-parameters">Parameters</h3>
+<h3 id="find-matches-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |From|header|string|false|As in the HTTP/1.1 RFC, used for logging purposes as a means for identifying the source of invalid or unwanted requests. The interpretation of this field is that the request is being performed on behalf of the state government-affiliated person whose email address (or username) is specified here. It is not used for authentication or authorization.|
 |data|body|[object]|true|none|
-|» first|body|string|true|PII record's first name|
-|» middle|body|string|false|PII record's middle name|
-|» last|body|string|true|PII record's last name|
-|» ssn|body|string|true|PII record's social security number|
-|» dob|body|string(date)|true|PII record's date of birth|
+|» lds_hash|body|string|true|SHA-512 digest of participant's last name, DoB, and SSN. See docs/pprl.md for details|
 
 > Example responses
 
@@ -81,11 +73,6 @@ Queries all state databases for any PII records that are an exact match to the l
         "index": 0,
         "matches": [
           {
-            "first": "string",
-            "middle": "string",
-            "last": "string",
-            "ssn": "000-00-0000",
-            "dob": "1970-01-01",
             "state": "ea",
             "state_abbr": "ea",
             "case_id": "string",
@@ -132,11 +119,6 @@ Queries all state databases for any PII records that are an exact match to the l
         "index": 0,
         "matches": [
           {
-            "first": "string",
-            "middle": "string",
-            "last": "string",
-            "ssn": "000-00-0000",
-            "dob": "1970-01-01",
             "state": "eb",
             "state_abbr": "eb",
             "case_id": "string",
@@ -150,11 +132,6 @@ Queries all state databases for any PII records that are an exact match to the l
             "protect_location": true
           },
           {
-            "first": null,
-            "middle": null,
-            "last": "string",
-            "ssn": "000-00-0000",
-            "dob": "1970-01-01",
             "state": "ec",
             "state_abbr": "ec",
             "case_id": "string",
@@ -180,11 +157,6 @@ Queries all state databases for any PII records that are an exact match to the l
         "index": 0,
         "matches": [
           {
-            "first": null,
-            "middle": null,
-            "last": "string",
-            "ssn": "000-00-0000",
-            "dob": "1970-01-01",
             "state": "ec",
             "state_abbr": "ec",
             "case_id": "string",
@@ -198,11 +170,6 @@ Queries all state databases for any PII records that are an exact match to the l
         "index": 1,
         "matches": [
           {
-            "first": null,
-            "middle": null,
-            "last": "string",
-            "ssn": "000-00-0000",
-            "dob": "1970-01-01",
             "state": "ec",
             "state_abbr": "ec",
             "case_id": "string",
@@ -232,11 +199,6 @@ Queries all state databases for any PII records that are an exact match to the l
         "index": 1,
         "matches": [
           {
-            "first": null,
-            "middle": null,
-            "last": "string",
-            "ssn": "000-00-0000",
-            "dob": "1970-01-01",
             "state": "ec",
             "state_abbr": "ec",
             "case_id": "string",
@@ -262,11 +224,6 @@ Queries all state databases for any PII records that are an exact match to the l
         "index": 1,
         "matches": [
           {
-            "first": null,
-            "middle": null,
-            "last": "string",
-            "ssn": "000-00-0000",
-            "dob": "1970-01-01",
             "state": "ec",
             "state_abbr": "ec",
             "case_id": "string",
@@ -304,41 +261,38 @@ Queries all state databases for any PII records that are an exact match to the l
 }
 ```
 
-<h3 id="query-for-matches-responses">Responses</h3>
+<h3 id="find-matches-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Successful response. Returns match response items.|Inline|
-|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Missing one of the required properties in the request body.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. Request body does not match the required format.|None|
 
-<h3 id="query-for-matches-responseschema">Response Schema</h3>
+<h3 id="find-matches-responseschema">Response Schema</h3>
 
 Status Code **200**
+
+*Match response*
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |» data|object¦null|false|none|The response payload. Either an errors or data property will be present in the response, but not both.|
-|»» results|array|true|none|Array of query results. For every person provided in the request, a result is returned, even if no matches are found. If a query fails, the failure data will be in the errors array.|
+|»» results|[object]|true|none|Array of query results. For every person provided in the request, a result is returned, even if no matches are found. If a query fails, the failure data will be in the errors array.|
 |»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
 |»»» matches|[object]|true|none|none|
-|»»»» first|string|false|none|First name|
-|»»»» middle|string|false|none|Middle name|
-|»»»» last|string|true|none|Last name|
-|»»»» ssn|string|true|none|Social Security number|
-|»»»» dob|string(date)|true|none|Date of birth|
-|»»»» state|string|false|none|State/territory two-letter postal abbreviation|
+|»»»» state|string|true|none|State/territory two-letter postal abbreviation|
 |»»»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
-|»»»» case_id|string|false|none|Participant's state-specific case identifier. Can be the same for multiple participants.|
-|»»»» participant_id|string|false|none|Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.|
+|»»»» case_id|string|true|none|Participant's state-specific case identifier. Can be the same for multiple participants.|
+|»»»» participant_id|string|true|none|Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.|
 |»»»» benefits_end_month|string|false|none|Participant's ending benefits month|
 |»»»» recent_benefit_months|[string]|false|none|List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.|
 |»»»» protect_location|boolean¦null|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
-|»» errors|array|true|none|Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items.|
+|»» errors|[object]|true|none|Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items.|
 |»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
 |»»» code|string|false|none|The application-specific error code|
 |»»» title|string|false|none|The short, human-readable summary of the error, consistent across all occurrences of the error|
 |»»» detail|string|false|none|The human-readable explanation specific to this occurrence of the error|
-|» errors|array¦null|false|none|Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both.|
+|» errors|[object]¦null|false|none|Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both.|
 |»» status|string|true|none|The HTTP status code|
 |»» code|string|false|none|The application-specific error code|
 |»» title|string|false|none|The short, human-readable summary of the error, consistent across all occurrences of the error|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -4,15 +4,15 @@ info:
   version: 1.0.0
   description: The API where matching will occur
 servers:
-  - url: /v1
+  - url: /v2
 paths:
-  /query:
+  /find_participants:
     post:
-      operationId: Query for Matches
+      operationId: Find matches
       tags:
         - Match
-      summary: Search for all matching PII records
-      description: 'Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number of persons provided in the request.'
+      summary: Search for all matching participant records using de-identified data
+      description: Searches all state databases for any participant records that are an exact match to the `lds_hash` of persons provided in the request.
       parameters:
         - in: header
           name: From
@@ -35,64 +35,31 @@ paths:
                   items:
                     type: object
                     required:
-                      - first
-                      - last
-                      - dob
-                      - ssn
+                      - lds_hash
                     properties:
-                      first:
+                      lds_hash:
                         type: string
-                        description: PII record's first name
-                      middle:
-                        type: string
-                        description: PII record's middle name
-                      last:
-                        type: string
-                        description: PII record's last name
-                      ssn:
-                        type: string
-                        description: PII record's social security number
-                        pattern: '^\d{3}-\d{2}-\d{4}$'
-                      dob:
-                        type: string
-                        format: date
-                        description: PII record's date of birth
+                        description: 'SHA-512 digest of participant''s last name, DoB, and SSN. See docs/pprl.md for details'
+                        pattern: '^[0-9a-f]{128}$'
             examples:
-              All fields:
+              Single person:
                 description: 'An example request to query a single person, with values for all fields'
                 value:
                   data:
-                    - first: string
-                      middle: string
-                      last: string
-                      ssn: 000-00-0000
-                      dob: '1970-01-01'
-              Only requried fields:
-                description: A request to query a single person with values only for required fields
-                value:
-                  data:
-                    - first: string
-                      last: string
-                      ssn: 000-00-0000
-                      dob: '1970-01-01'
-              Multiple Persons:
+                    - lds_hash: eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458
+              Multiple persons:
                 description: A request with multiple persons
                 value:
                   data:
-                    - first: string
-                      last: string
-                      ssn: 000-00-0000
-                      dob: '1970-01-01'
-                    - first: string
-                      last: string
-                      ssn: 000-00-0001
-                      dob: '1970-01-02'
+                    - lds_hash: eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458
+                    - lds_hash: 97719c32bb3c6a5e08c1241a7435d6d7047e75f40d8b3880744c07fef9d586954f77dc93279044c662d5d379e9c8a447ce03d9619ce384a7467d322e647e5d95
       responses:
         '200':
           description: Successful response. Returns match response items.
           content:
             application/json:
               schema:
+                title: Match response
                 type: object
                 properties:
                   data:
@@ -106,122 +73,106 @@ paths:
                       results:
                         type: array
                         description: 'Array of query results. For every person provided in the request, a result is returned, even if no matches are found. If a query fails, the failure data will be in the errors array.'
-                        required:
-                          - index
-                          - matches
-                        properties:
-                          index:
-                            type: integer
-                            description: 'The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.'
-                          matches:
-                            type: array
-                            items:
-                              type: object
-                              required:
-                                - last
-                                - ssn
-                                - dob
-                              properties:
-                                first:
-                                  type: string
-                                  description: First name
-                                middle:
-                                  type: string
-                                  description: Middle name
-                                last:
-                                  type: string
-                                  description: Last name
-                                ssn:
-                                  type: string
-                                  description: Social Security number
-                                  pattern: '^\d{3}-\d{2}-\d{4}$'
-                                dob:
-                                  type: string
-                                  format: date
-                                  description: Date of birth
-                                state:
-                                  type: string
-                                  description: State/territory two-letter postal abbreviation
-                                state_abbr:
-                                  type: string
-                                  description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
-                                  deprecated: true
-                                case_id:
-                                  type: string
-                                  description: Participant's state-specific case identifier. Can be the same for multiple participants.
-                                participant_id:
-                                  type: string
-                                  description: Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.
-                                benefits_end_month:
-                                  type: string
-                                  pattern: '^\d{4}-\d{2}$'
-                                  example: 2021-01
-                                  description: Participant's ending benefits month
-                                recent_benefit_months:
-                                  type: array
-                                  items:
+                        items:
+                          type: object
+                          required:
+                            - index
+                            - matches
+                          properties:
+                            index:
+                              type: integer
+                              description: 'The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.'
+                            matches:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                  - state
+                                  - participant_id
+                                  - case_id
+                                properties:
+                                  state:
+                                    type: string
+                                    description: State/territory two-letter postal abbreviation
+                                  state_abbr:
+                                    type: string
+                                    description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
+                                    deprecated: true
+                                  case_id:
+                                    type: string
+                                    description: Participant's state-specific case identifier. Can be the same for multiple participants.
+                                  participant_id:
+                                    type: string
+                                    description: Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.
+                                  benefits_end_month:
                                     type: string
                                     pattern: '^\d{4}-\d{2}$'
                                     example: 2021-01
-                                  minItems: 0
-                                  maxItems: 3
-                                  description: 'List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.'
-                                protect_location:
-                                  type: boolean
-                                  nullable: true
-                                  example: true
-                                  description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
+                                    description: Participant's ending benefits month
+                                  recent_benefit_months:
+                                    type: array
+                                    items:
+                                      type: string
+                                      pattern: '^\d{4}-\d{2}$'
+                                      example: 2021-01
+                                    minItems: 0
+                                    maxItems: 3
+                                    description: 'List of up to the last 3 months that participant received benefits, in descending order. Each month is formatted as ISO 8601 year and month. Does not include current benefit month.'
+                                  protect_location:
+                                    type: boolean
+                                    nullable: true
+                                    example: true
+                                    description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
                       errors:
                         type: array
                         description: 'Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items.'
-                        required:
-                          - index
-                        properties:
-                          index:
-                            type: integer
-                            description: 'The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.'
-                          code:
-                            type: string
-                            description: The application-specific error code
-                          title:
-                            type: string
-                            description: 'The short, human-readable summary of the error, consistent across all occurrences of the error'
-                          detail:
-                            type: string
-                            description: The human-readable explanation specific to this occurrence of the error
+                        items:
+                          type: object
+                          required:
+                            - index
+                          properties:
+                            index:
+                              type: integer
+                              description: 'The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.'
+                            code:
+                              type: string
+                              description: The application-specific error code
+                            title:
+                              type: string
+                              description: 'The short, human-readable summary of the error, consistent across all occurrences of the error'
+                            detail:
+                              type: string
+                              description: The human-readable explanation specific to this occurrence of the error
                   errors:
                     type: array
                     nullable: true
                     description: 'Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both.'
-                    required:
-                      - status
-                    properties:
-                      status:
-                        type: string
-                        description: The HTTP status code
-                      code:
-                        type: string
-                        description: The application-specific error code
-                      title:
-                        type: string
-                        description: 'The short, human-readable summary of the error, consistent across all occurrences of the error'
-                      detail:
-                        type: string
-                        description: The human-readable explanation specific to this occurrence of the error
+                    items:
+                      type: object
+                      required:
+                        - status
+                      properties:
+                        status:
+                          type: string
+                          description: The HTTP status code
+                        code:
+                          type: string
+                          description: The application-specific error code
+                        title:
+                          type: string
+                          description: 'The short, human-readable summary of the error, consistent across all occurrences of the error'
+                        detail:
+                          type: string
+                          description: The human-readable explanation specific to this occurrence of the error
               examples:
-                Single:
+                Single match:
                   description: A query for a single person returning a single match
                   value:
                     data:
                       results:
                         - index: 0
                           matches:
-                            - first: string
-                              middle: string
-                              last: string
-                              ssn: 000-00-0000
-                              dob: '1970-01-01'
-                              state: ea
+                            - state: ea
                               state_abbr: ea
                               case_id: string
                               participant_id: string
@@ -232,7 +183,7 @@ paths:
                                 - 2021-03
                               protect_location: true
                       errors: []
-                None:
+                No matches:
                   description: A query for a single person returning no matches
                   value:
                     data:
@@ -240,19 +191,14 @@ paths:
                         - index: 0
                           matches: []
                       errors: []
-                Multiple:
+                Multiple matches:
                   description: A query for one person returning multiple matches
                   value:
                     data:
                       results:
                         - index: 0
                           matches:
-                            - first: string
-                              middle: string
-                              last: string
-                              ssn: 000-00-0000
-                              dob: '1970-01-01'
-                              state: eb
+                            - state: eb
                               state_abbr: eb
                               case_id: string
                               participant_id: string
@@ -262,31 +208,26 @@ paths:
                                 - 2021-04
                                 - 2021-03
                               protect_location: true
-                            - first: null
-                              middle: null
-                              last: string
-                              ssn: 000-00-0000
-                              dob: '1970-01-01'
-                              state: ec
+                            - state: ec
                               state_abbr: ec
                               case_id: string
                               participant_id: null
                               benefits_end_month: null
                               protect_location: null
                       errors: []
-                MultipleRecords:
+                Multiple persons with matches:
                   description: A query for two persons returning one match for each person
                   value:
                     data:
                       results:
                         - index: 0
                           matches:
-                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                         - index: 1
                           matches:
-                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                       errors: []
-                MultipleRecordsOneMatch:
+                Multiple persons with one match:
                   description: A query for two persons returning no matches for one person and a match for the other
                   value:
                     data:
@@ -295,22 +236,22 @@ paths:
                           matches: []
                         - index: 1
                           matches:
-                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                       errors: []
-                MultipleRecordsOneError:
+                Multiple persons with errors:
                   description: A query for two persons returning a successful result for one person and an error for the other person
                   value:
                     data:
                       results:
                         - index: 1
                           matches:
-                            - $ref: '#/paths/~1query/post/responses/200/content/application~1json/examples/Multiple/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                       errors:
                         - index: 0
                           code: XYZ
                           title: Internal Server Exception
                           detail: Unexpected Server Error. Please try again.
-                TopLevelError:
+                Top-level error:
                   description: An example response for an invalid request
                   value:
                     errors:
@@ -319,7 +260,7 @@ paths:
                         title: Bad Request
                         detail: Request payload exceeds maxiumum count
         '400':
-          description: Bad request. Missing one of the required properties in the request body.
+          description: Bad request. Request body does not match the required format.
 security:
   - ApiKeyAuth: []
 components:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -6,7 +6,7 @@ info:
 servers:
   - url: /v2
 paths:
-  /find_participants:
+  /find_matches:
     post:
       operationId: Find matches
       tags:
@@ -222,10 +222,10 @@ paths:
                       results:
                         - index: 0
                           matches:
-                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_matches/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                         - index: 1
                           matches:
-                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_matches/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                       errors: []
                 Multiple persons with one match:
                   description: A query for two persons returning no matches for one person and a match for the other
@@ -236,7 +236,7 @@ paths:
                           matches: []
                         - index: 1
                           matches:
-                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_matches/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                       errors: []
                 Multiple persons with errors:
                   description: A query for two persons returning a successful result for one person and an error for the other person
@@ -245,7 +245,7 @@ paths:
                       results:
                         - index: 1
                           matches:
-                            - $ref: '#/paths/~1find_participants/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
+                            - $ref: '#/paths/~1find_matches/post/responses/200/content/application~1json/examples/Multiple%20matches/value/data/results/0/matches/1'
                       errors:
                         - index: 0
                           code: XYZ

--- a/match/docs/openapi/orchestrator/find-pii.yaml
+++ b/match/docs/openapi/orchestrator/find-pii.yaml
@@ -1,9 +1,9 @@
 post:
-  operationId: "Query for Matches"
+  operationId: "Find matches using PII"
   tags:
     - "Match"
-  summary: "Search for all matching PII records"
-  description: "Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number of persons provided in the request."
+  summary: "Search for all matching participant records using PII"
+  description: "Searches all state databases for any participant records that are an exact match to the last name, date of birth, and social security number of persons provided in the request."
   parameters:
     - in: header
       name: From
@@ -11,7 +11,7 @@ post:
         type: string
       description: "As in the HTTP/1.1 RFC, used for logging purposes as a means for identifying the source of invalid or unwanted requests. The interpretation of this field is that the request is being performed on behalf of the state government-affiliated person whose email address (or username) is specified here. It is not used for authentication or authorization."
   requestBody:
-    $ref: '../schemas/match-query.yaml#/MatchRequest'
+    $ref: '../schemas/match-query.yaml#/MatchRequestWithPii'
   responses:
     '200':
       description: "Successful response. Returns match response items."
@@ -19,7 +19,5 @@ post:
         application/json:
           schema:
             $ref: '../schemas/match-query.yaml#/MatchResponse'
-          examples:
-            $ref: '../schemas/match-query.yaml#/MatchResponseExamples'
     '400':
-      description: "Bad request. Missing one of the required properties in the request body."
+      description: "Bad request. Request body does not match the required format."

--- a/match/docs/openapi/orchestrator/find.yaml
+++ b/match/docs/openapi/orchestrator/find.yaml
@@ -1,0 +1,38 @@
+post:
+  operationId: "Find matches"
+  tags:
+    - "Match"
+  summary: "Search for all matching participant records using de-identified data"
+  description: "Searches all state databases for any participant records that are an exact match to the `lds_hash` of persons provided in the request."
+  parameters:
+    - in: header
+      name: From
+      schema:
+        type: string
+      description: "As in the HTTP/1.1 RFC, used for logging purposes as a means for identifying the source of invalid or unwanted requests. The interpretation of this field is that the request is being performed on behalf of the state government-affiliated person whose email address (or username) is specified here. It is not used for authentication or authorization."
+  requestBody:
+    $ref: '../schemas/match-query.yaml#/MatchRequest'
+  responses:
+    '200':
+      description: "Successful response. Returns match response items."
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/match-query.yaml#/MatchResponse'
+          examples:
+            Single match:
+              $ref: '../schemas/match-query.yaml#/MatchResponseExamples/Single'
+            No matches:
+              $ref: '../schemas/match-query.yaml#/MatchResponseExamples/None'
+            Multiple matches:
+              $ref: '../schemas/match-query.yaml#/MatchResponseExamples/Multiple'
+            Multiple persons with matches:
+              $ref: '../schemas/match-query.yaml#/MatchResponseExamples/MultipleRecords'
+            Multiple persons with one match:
+              $ref: '../schemas/match-query.yaml#/MatchResponseExamples/MultipleRecordsOneMatch'
+            Multiple persons with errors:
+              $ref: '../schemas/match-query.yaml#/MatchResponseExamples/MultipleRecordsOneError'
+            Top-level error:
+              $ref: '../schemas/match-query.yaml#/MatchResponseExamples/TopLevelError'
+    '400':
+      description: "Bad request. Request body does not match the required format."

--- a/match/docs/openapi/orchestrator/index.yaml
+++ b/match/docs/openapi/orchestrator/index.yaml
@@ -3,11 +3,20 @@ openapi: 3.0.0
 info:
   title: "Active Matching API"
   version: 1.0.0
-  description: "API for detecting matching PII records across all participating states."
+  description: "API for finding matching participant records across all participating states."
 tags:
   - name: "Match"
 servers:
-  - url: "/v1"
+  - url: "/v2"
 paths:
-  /query:
-    $ref: './query.yaml'
+  /find_participants:
+    $ref: './find.yaml'
+  /find_participants_by_pii:
+    $ref: './find-pii.yaml'
+security:
+  - BearerAuth: []
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer

--- a/match/docs/openapi/orchestrator/index.yaml
+++ b/match/docs/openapi/orchestrator/index.yaml
@@ -9,9 +9,9 @@ tags:
 servers:
   - url: "/v2"
 paths:
-  /find_participants:
+  /find_matches:
     $ref: './find.yaml'
-  /find_participants_by_pii:
+  /find_matches_by_pii:
     $ref: './find-pii.yaml'
 security:
   - BearerAuth: []

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -1,4 +1,3 @@
-#/components/requestBodies/MatchRequest
 MatchRequest:
   required: true
   content:
@@ -15,8 +14,35 @@ MatchRequest:
             items:
               $ref: '#/Person'
       examples:
-        $ref: '#/MatchRequestExamples'
+        Single person:
+          $ref: '#/MatchRequestExamples/Single'
+        Multiple persons:
+          $ref: '#/MatchRequestExamples/Multiple'
+MatchRequestWithPii:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: object
+        required:
+            - data
+        properties:
+          data:
+            type: array
+            minItems: 1
+            maxItems: 50
+            items:
+              $ref: '#/PersonWithPii'
 Person:
+  type: object
+  required:
+    - lds_hash
+  properties:
+    lds_hash:
+      type: string
+      description: "SHA-512 digest of participant's last name, DoB, and SSN. See docs/pprl.md for details"
+      pattern: "^[0-9a-f]{128}$"
+PersonWithPii:
   type: object
   required:
     - first
@@ -26,54 +52,37 @@ Person:
   properties:
     first:
       type: string
-      description: "PII record's first name"
+      description: "Person's first name"
     middle:
       type: string
-      description: "PII record's middle name"
+      description: "Person's middle name"
     last:
       type: string
-      description: "PII record's last name"
+      description: "Person's last name"
     ssn:
       type: string
-      description: "PII record's social security number"
+      description: "Person's social security number"
       pattern: '^\d{3}-\d{2}-\d{4}$'
     dob:
       type: string
       format: "date"
-      description: "PII record's date of birth"
+      description: "Person's date of birth"
 MatchRequestExamples:
-  "All fields":
+  Single:
     description: "An example request to query a single person, with values for all fields"
     value:
       data:
-        - first: "string"
-          middle: "string"
-          last: "string"
-          ssn: "000-00-0000"
-          dob: "1970-01-01"
-  "Only requried fields":
-    description: "A request to query a single person with values only for required fields"
-    value:
-      data:
-        - first: "string"
-          last: "string"
-          ssn: "000-00-0000"
-          dob: "1970-01-01"
-  "Multiple Persons":
+        - lds_hash: "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
+  Multiple:
     description: "A request with multiple persons"
     value:
       data:
-        - first: "string"
-          last: "string"
-          ssn: "000-00-0000"
-          dob: "1970-01-01"
-        - first: "string"
-          last: "string"
-          ssn: "000-00-0001"
-          dob: "1970-01-02"
+        - lds_hash: "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
+        - lds_hash: "97719c32bb3c6a5e08c1241a7435d6d7047e75f40d8b3880744c07fef9d586954f77dc93279044c662d5d379e9c8a447ce03d9619ce384a7467d322e647e5d95"
 
 #/components/schemas/MatchResponse
 MatchResponse:
+  title: Match response
   type: object
   properties:
     data:
@@ -86,17 +95,20 @@ MatchResponse:
       properties:
         results:
           type: array
-          $ref: '#/Result'
           description: "Array of query results. For every person provided in the request, a result is returned, even if no matches are found. If a query fails, the failure data will be in the errors array."
+          items:
+            $ref: '#/Result'
         errors:
           type: array
           description: "Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items."
-          $ref: '#/DataError'
+          items:
+            $ref: '#/DataError'
     errors:
       type: array
       nullable: true
       description: "Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both."
-      $ref: '#/ResponseError'
+      items:
+        $ref: '#/ResponseError'
 
 Result:
   type: object
@@ -110,7 +122,7 @@ Result:
     matches:
       type: array
       items:
-        $ref: './pii-record.yaml#/PiiRecord'
+        $ref: './participant-record.yaml#/ParticipantRecord'
 
 MatchResponseExamples:
   Single:
@@ -120,7 +132,7 @@ MatchResponseExamples:
         results:
           - index: 0
             matches:
-              - $ref: './pii-record.yaml#/PiiRecordExamples/All'
+              - $ref: './participant-record.yaml#/ParticipantRecordExamples/All'
         errors: []
   None:
     description: "A query for a single person returning no matches"
@@ -137,8 +149,8 @@ MatchResponseExamples:
         results:
           - index: 0
             matches:
-              - $ref: './pii-record.yaml#/PiiRecordExamples/AllEB'
-              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+              - $ref: './participant-record.yaml#/ParticipantRecordExamples/AllEB'
+              - $ref: './participant-record.yaml#/ParticipantRecordExamples/Required'
         errors: []
   MultipleRecords:
     description: "A query for two persons returning one match for each person"
@@ -147,10 +159,10 @@ MatchResponseExamples:
         results:
           - index: 0
             matches:
-              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+              - $ref: './participant-record.yaml#/ParticipantRecordExamples/Required'
           - index: 1
             matches:
-              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+              - $ref: './participant-record.yaml#/ParticipantRecordExamples/Required'
         errors: []
   MultipleRecordsOneMatch:
     description: "A query for two persons returning no matches for one person and a match for the other"
@@ -161,7 +173,7 @@ MatchResponseExamples:
             matches: []
           - index: 1
             matches:
-              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+              - $ref: './participant-record.yaml#/ParticipantRecordExamples/Required'
         errors: []
   MultipleRecordsOneError:
     description: "A query for two persons returning a successful result for one person and an error for the other person"
@@ -170,7 +182,7 @@ MatchResponseExamples:
         results:
           - index: 1
             matches:
-              - $ref: './pii-record.yaml#/PiiRecordExamples/Required'
+              - $ref: './participant-record.yaml#/ParticipantRecordExamples/Required'
         errors:
           - index: 0
             code: "XYZ"

--- a/match/docs/openapi/schemas/participant-record.yaml
+++ b/match/docs/openapi/schemas/participant-record.yaml
@@ -1,28 +1,11 @@
-#/components/schemas/PiiRecord
-PiiRecord:
+# Schema for participant records in response objects
+ParticipantRecord:
   type: "object"
   required:
-    - last
-    - ssn
-    - dob
+    - state
+    - participant_id
+    - case_id
   properties:
-    first:
-      type: string
-      description: "First name"
-    middle:
-      type: string
-      description: "Middle name"
-    last:
-      type: string
-      description: "Last name"
-    ssn:
-      type: string
-      description: "Social Security number"
-      pattern: '^\d{3}-\d{2}-\d{4}$'
-    dob:
-      type: string
-      format: "date"
-      description: "Date of birth"
     state:
       type: string
       description: "State/territory two-letter postal abbreviation"
@@ -56,13 +39,8 @@ PiiRecord:
       example: true
       description: "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values."
 
-PiiRecordExamples:
+ParticipantRecordExamples:
   All:
-    first: "string"
-    middle: "string"
-    last: "string"
-    ssn: "000-00-0000"
-    dob: "1970-01-01"
     state: "ea"
     state_abbr: "ea"
     case_id: "string"
@@ -74,11 +52,6 @@ PiiRecordExamples:
       - "2021-03"
     protect_location: true
   AllEB:
-    first: "string"
-    middle: "string"
-    last: "string"
-    ssn: "000-00-0000"
-    dob: "1970-01-01"
     state: "eb"
     state_abbr: "eb"
     case_id: "string"
@@ -90,11 +63,6 @@ PiiRecordExamples:
       - "2021-03"
     protect_location: true
   Required:
-    first: null
-    middle: null
-    last: "string"
-    ssn: "000-00-0000"
-    dob: "1970-01-01"
     state: "ec"
     state_abbr: "ec"
     case_id: "string"


### PR DESCRIPTION
- Update both internal-facing and state-facing specs, keeping internal-facing PII-based endpoint
- Bump all endpoints from `v1` to `v2`
- Rename endpoints from `/query` to `/find_participants`
- Remove PII fields (name, dob, ssn) from response

As usual, it may be easiest to review the state-facing changes by looking at `docs/openapi/generated/duplicate-participation-api/openapi.md`. Internal-facing changes might be easiest to review by pulling down this branch, running `match/tools/generate-specs.bash` and reviewing at the output in `match/docs/openapi/orchestrator/generated`.

@cjhskippy @ryanhofdotgov Should the internal-facing PII endpoint still require match requests include first name?

@ryanhofdotgov @echappen @timoballard tagging all of you since I'm using this change as an opportunity to rename the endpoint to be less ambiguous. I'm opening the bidding with `find_participants` (in the spirit of [Google's RPC naming conventions](https://cloud.google.com/apis/design/naming_convention#method_names)), but open to all suggestions.

Closes #1452