### PR TITLE
Update match API to use de-identified data

### DIFF
--- a/match/src/Piipan.Match.Orchestrator/OrchMatchRequest.cs
+++ b/match/src/Piipan.Match.Orchestrator/OrchMatchRequest.cs
@@ -6,7 +6,7 @@ using Piipan.Match.Shared;
 namespace Piipan.Match.Orchestrator
 {
     /// <summary>
-    /// Represents the full API request from a client
+    /// Represents the full API request from a client when using de-identified data
     /// </summary>
     public class OrchMatchRequest
     {
@@ -15,9 +15,20 @@ namespace Piipan.Match.Orchestrator
     }
 
     /// <summary>
-    /// Represents each person in an API request
+    /// Represents each person in an API request using de-identified data
     /// </summary>
     public class RequestPerson
+    {
+        [JsonProperty("lds_hash",
+            Required = Required.Always,
+            NullValueHandling = NullValueHandling.Ignore)]
+        public string LdsHash { get; set; }
+    }
+
+    /// <summary>
+    /// Represents each person in an API request using PII
+    /// </summary>
+    public class RequestPersonWithPii
     {
         [JsonProperty("last", Required = Required.Always)]
         public string Last { get; set; }

--- a/match/src/Piipan.Match.Orchestrator/OrchMatchRequestValidator.cs
+++ b/match/src/Piipan.Match.Orchestrator/OrchMatchRequestValidator.cs
@@ -25,6 +25,19 @@ namespace Piipan.Match.Orchestrator
     {
         public PersonValidator()
         {
+            const string HashRegex = "^[a-z0-9]{128}$";
+
+            RuleFor(q => q.LdsHash).Matches(HashRegex);
+        }
+    }
+
+    /// <summary>
+    /// Validates each person in an API request
+    /// </summary>
+    public class PersonWithPiiValidator : AbstractValidator<RequestPersonWithPii>
+    {
+        public PersonWithPiiValidator()
+        {
             RuleFor(q => q.First).NotEmpty();
             RuleFor(q => q.Last).NotEmpty();
             RuleFor(q => q.Ssn).Matches(@"^[0-9]{3}-[0-9]{2}-[0-9]{4}$");

--- a/match/src/Piipan.Match.Orchestrator/OrchMatchResponse.cs
+++ b/match/src/Piipan.Match.Orchestrator/OrchMatchResponse.cs
@@ -9,10 +9,5 @@ namespace Piipan.Match.Orchestrator
     {
         [JsonProperty("data")]
         public OrchMatchResponseData Data { get; set; } = new OrchMatchResponseData();
-
-        public string ToJson()
-        {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-        }
     }
 }

--- a/match/src/Piipan.Match.Orchestrator/ParticipantRecord.cs
+++ b/match/src/Piipan.Match.Orchestrator/ParticipantRecord.cs
@@ -7,21 +7,9 @@ namespace Piipan.Match.Orchestrator
 {
     public class ParticipantRecord
     {
-        [JsonProperty("last")]
-        public string Last { get; set; }
-
-        [JsonProperty("first")]
-        public string First { get; set; }
-
-        [JsonProperty("middle")]
-        public string Middle { get; set; }
-
-        [JsonProperty("ssn")]
-        public string Ssn { get; set; }
-
-        [JsonProperty("dob")]
-        [JsonConverter(typeof(JsonConverters.DateTimeConverter))]
-        public DateTime Dob { get; set; }
+        [JsonProperty("lds_hash",
+            NullValueHandling = NullValueHandling.Ignore)]
+        public string LdsHash { get; set; }
 
         [JsonProperty("state")]
         public string State { get; set; }

--- a/match/tests/Piipan.Match.Orchestrator.IntegrationTests/ApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.IntegrationTests/ApiIntegrationTests.cs
@@ -19,6 +19,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
         {
             return new ParticipantRecord
             {
+                // farrington,1931-10-13,000-12-3456
                 LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458",
                 CaseId = "CaseIdExample",
                 ParticipantId = "ParticipantIdExample",
@@ -150,6 +151,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             // Arrange
             var recordA = FullRecord();
             var recordB = FullRecord();
+            // lynn,1940-08-01,000-12-3457
             recordB.LdsHash = "97719c32bb3c6a5e08c1241a7435d6d7047e75f40d8b3880744c07fef9d586954f77dc93279044c662d5d379e9c8a447ce03d9619ce384a7467d322e647e5d95";
             recordB.ParticipantId = "ParticipantB";
             var logger = Mock.Of<ILogger>();

--- a/match/tests/Piipan.Match.Orchestrator.IntegrationTests/ApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.IntegrationTests/ApiIntegrationTests.cs
@@ -19,11 +19,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
         {
             return new ParticipantRecord
             {
-                First = "First",
-                Middle = "Middle",
-                Last = "Last",
-                Dob = new DateTime(1970, 1, 1),
-                Ssn = "000-00-0000",
+                LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458",
                 CaseId = "CaseIdExample",
                 ParticipantId = "ParticipantIdExample",
                 BenefitsEndMonth = new DateTime(1970, 1, 31),
@@ -86,7 +82,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             Insert(record);
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
             var result = response as JsonResult;
             var resultObject = result.Value as OrchMatchResponse;
 
@@ -94,11 +90,6 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             Assert.Single(resultObject.Data.Results);
 
             var person = resultObject.Data.Results[0];
-            Assert.Equal(record.First, person.Matches[0].First);
-            Assert.Equal(record.Middle, person.Matches[0].Middle);
-            Assert.Equal(record.Last, person.Matches[0].Last);
-            Assert.Equal(record.Dob, person.Matches[0].Dob);
-            Assert.Equal(record.Ssn, person.Matches[0].Ssn);
             Assert.Equal(record.CaseId, person.Matches[0].CaseId);
             Assert.Equal(record.ParticipantId, person.Matches[0].ParticipantId);
             Assert.Equal(state[0], person.Matches[0].State);
@@ -120,7 +111,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             ClearParticipants();
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
             var result = response as JsonResult;
             var resultObject = result.Value as OrchMatchResponse;
 
@@ -134,7 +125,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             // Arrange
             var recordA = FullRecord();
             var recordB = FullRecord();
-            recordB.Ssn = "00-00-00";
+            recordB.LdsHash = "foo";
             var logger = Mock.Of<ILogger>();
             var body = new object[] { recordA, recordB };
             var mockRequest = MockRequest(JsonBody(body));
@@ -144,7 +135,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             Insert(recordA);
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
             var result = response as JsonResult;
             var resultObject = result.Value as OrchMatchResponse;
 
@@ -154,37 +145,13 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
         }
 
         [Fact]
-        public async void ApiReturnsMultipleValidationErrors()
-        {
-            // Arrange
-            var recordA = FullRecord();
-            var logger = Mock.Of<ILogger>();
-
-            ClearParticipants();
-            Insert(recordA);
-
-            recordA.Ssn = "00-00-0000";
-            recordA.First = "";
-            var body = new object[] { recordA };
-            var mockRequest = MockRequest(JsonBody(body));
-            var api = Construct();
-
-            // Act
-            var response = await api.Query(mockRequest.Object, logger);
-            var result = response as JsonResult;
-            var resultObject = result.Value as OrchMatchResponse;
-
-            // Assert
-            Assert.Equal(2, resultObject.Data.Errors.Count);
-        }
-
-        [Fact]
         public async void ApiReturnsExpectedIndices()
         {
             // Arrange
             var recordA = FullRecord();
             var recordB = FullRecord();
-            recordB.Last = "LastB";
+            recordB.LdsHash = "97719c32bb3c6a5e08c1241a7435d6d7047e75f40d8b3880744c07fef9d586954f77dc93279044c662d5d379e9c8a447ce03d9619ce384a7467d322e647e5d95";
+            recordB.ParticipantId = "ParticipantB";
             var logger = Mock.Of<ILogger>();
             var body = new object[] { recordA, recordB };
             var mockRequest = MockRequest(JsonBody(body));
@@ -195,7 +162,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             Insert(recordB);
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
             var result = response as JsonResult;
             var resultObject = result.Value as OrchMatchResponse;
 
@@ -203,8 +170,8 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
             var resultA = resultObject.Data.Results.Find(p => p.Index == 0);
             var resultB = resultObject.Data.Results.Find(p => p.Index == 1);
 
-            Assert.Equal(resultA.Matches[0].Last, recordA.Last);
-            Assert.Equal(resultB.Matches[0].Last, recordB.Last);
+            Assert.Equal(resultA.Matches[0].ParticipantId, recordA.ParticipantId);
+            Assert.Equal(resultB.Matches[0].ParticipantId, recordB.ParticipantId);
         }
     }
 }

--- a/match/tests/Piipan.Match.Orchestrator.IntegrationTests/DbFixture.cs
+++ b/match/tests/Piipan.Match.Orchestrator.IntegrationTests/DbFixture.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Data;
-using System.Data.Common;
 using System.Threading;
-using System.Threading.Tasks;
+using Dapper;
 using Npgsql;
-using Piipan.Shared.Helpers;
 
 namespace Piipan.Match.Orchestrator.IntegrationTests
 {
@@ -64,16 +61,8 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
 
-                using (var cmd = Factory.CreateCommand())
-                {
-                    cmd.Connection = conn;
-
-                    cmd.CommandText = "DROP TABLE IF EXISTS participants;";
-                    cmd.ExecuteNonQuery();
-
-                    cmd.CommandText = "DROP TABLE IF EXISTS uploads;";
-                    cmd.ExecuteNonQuery();
-                }
+                conn.Execute("DROP TABLE IF EXISTS participants");
+                conn.Execute("DROP TABLE IF EXISTS uploads");
 
                 conn.Close();
             }
@@ -83,46 +72,17 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
         // xxx Apply schema directly from ddl/per-state.sql
         private void ApplySchema()
         {
+            string sqltext = System.IO.File.ReadAllText("per-state.sql", System.Text.Encoding.UTF8);
+
             using (var conn = Factory.CreateConnection())
             {
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
 
-                using (var cmd = Factory.CreateCommand())
-                {
-                    cmd.Connection = conn;
-
-                    cmd.CommandText = "DROP TABLE IF EXISTS participants;";
-                    cmd.ExecuteNonQuery();
-
-                    cmd.CommandText = "DROP TABLE IF EXISTS uploads;";
-                    cmd.ExecuteNonQuery();
-
-                    cmd.CommandText = @"CREATE TABLE uploads(
-                        id serial PRIMARY KEY,
-                        created_at timestamp NOT NULL,
-                        publisher text NOT NULL);";
-                    cmd.ExecuteNonQuery();
-
-                    cmd.CommandText = "INSERT INTO uploads (created_at, publisher) VALUES(now(), current_user)";
-                    cmd.ExecuteNonQuery();
-
-                    cmd.CommandText = @"CREATE TABLE IF NOT EXISTS participants(
-                        id serial PRIMARY KEY,
-                        last text NOT NULL,
-                        first text,
-                        middle text,
-                        dob date NOT NULL,
-                        ssn text NOT NULL,
-                        upload_id integer REFERENCES uploads(id),
-                        case_id text NOT NULL,
-                        participant_id text,
-                        benefits_end_date date,
-                        recent_benefit_months date[],
-                        protect_location boolean
-                      );";
-                    cmd.ExecuteNonQuery();
-                }
+                conn.Execute("DROP TABLE IF EXISTS participants");
+                conn.Execute("DROP TABLE IF EXISTS uploads");
+                conn.Execute(sqltext);
+                conn.Execute("INSERT INTO uploads(created_at, publisher) VALUES(now(), current_user)");
 
                 conn.Close();
             }
@@ -135,12 +95,7 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
 
-                using (var cmd = Factory.CreateCommand())
-                {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "DELETE FROM participants";
-                    cmd.ExecuteNonQuery();
-                }
+                conn.Execute("DELETE FROM participants");
 
                 conn.Close();
             }
@@ -155,45 +110,17 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
 
-                Int64 lastval = 0;
-                using (var cmd = factory.CreateCommand())
-                {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "SELECT MAX(id) from uploads";
-                    lastval = (Int32)cmd.ExecuteScalar();
-                }
+                Int64 lastval = conn.ExecuteScalar<Int64>("SELECT MAX(id) FROM uploads");
+                DynamicParameters parameters = new DynamicParameters(record);
+                parameters.Add("UploadId", lastval);
 
-                using (var cmd = factory.CreateCommand())
-                {
-                    cmd.Connection = conn;
-                    cmd.CommandText = "INSERT INTO participants (last, first, middle, dob, ssn, upload_id, case_id, participant_id, benefits_end_date, recent_benefit_months, protect_location) " +
-                            "VALUES (@last, @first, @middle, @dob, @ssn, @upload_id, @case_id, @participant_id, @benefits_end_date, @recent_benefit_months::date[], @protect_location)";
-
-                    AddWithValue(cmd, DbType.String, "last", record.Last);
-                    AddWithValue(cmd, DbType.String, "first", (object)record.First ?? DBNull.Value);
-                    AddWithValue(cmd, DbType.String, "middle", (object)record.Middle ?? DBNull.Value);
-                    AddWithValue(cmd, DbType.DateTime, "dob", record.Dob);
-                    AddWithValue(cmd, DbType.String, "ssn", record.Ssn);
-                    AddWithValue(cmd, DbType.Int64, "upload_id", lastval);
-                    AddWithValue(cmd, DbType.String, "case_id", record.CaseId);
-                    AddWithValue(cmd, DbType.String, "participant_id", (object)record.ParticipantId ?? DBNull.Value);
-                    AddWithValue(cmd, DbType.DateTime, "benefits_end_date", (object)record.BenefitsEndMonth ?? DBNull.Value);
-                    AddWithValue(cmd, DbType.Object, "recent_benefit_months", (object)DateFormatters.FormatDatesAsPgArray(record.RecentBenefitMonths));
-                    AddWithValue(cmd, DbType.Boolean, "protect_location", (object)record.ProtectLocation ?? DBNull.Value);
-
-                    cmd.ExecuteNonQuery();
-                }
+                conn.Execute(@"
+                    INSERT INTO participants(lds_hash, upload_id, case_id, participant_id, benefits_end_date, recent_benefit_months, protect_location)
+                    VALUES (@LdsHash, @UploadId, @CaseId, @ParticipantId, @BenefitsEndMonth, @RecentBenefitMonths::date[], @ProtectLocation)",
+                    parameters);
 
                 conn.Close();
             }
-        }
-        static void AddWithValue(DbCommand cmd, DbType type, String name, object value)
-        {
-            var p = cmd.CreateParameter();
-            p.DbType = type;
-            p.ParameterName = name;
-            p.Value = value;
-            cmd.Parameters.Add(p);
         }
     }
 }

--- a/match/tests/Piipan.Match.Orchestrator.IntegrationTests/DbFixture.cs
+++ b/match/tests/Piipan.Match.Orchestrator.IntegrationTests/DbFixture.cs
@@ -69,7 +69,6 @@ namespace Piipan.Match.Orchestrator.IntegrationTests
 
         }
 
-        // xxx Apply schema directly from ddl/per-state.sql
         private void ApplySchema()
         {
             string sqltext = System.IO.File.ReadAllText("per-state.sql", System.Text.Encoding.UTF8);

--- a/match/tests/Piipan.Match.Orchestrator.IntegrationTests/Piipan.Match.Orchestrator.IntegrationTests.csproj
+++ b/match/tests/Piipan.Match.Orchestrator.IntegrationTests/Piipan.Match.Orchestrator.IntegrationTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.90" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -23,6 +24,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Piipan.Match.Orchestrator\Piipan.Match.Orchestrator.csproj" />
     <ProjectReference Include="..\..\..\shared\src\Piipan.Shared\Piipan.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\..\ddl\per-state.sql" Link="per-state.sql" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
@@ -47,6 +47,7 @@ namespace Piipan.Match.Orchestrator.Tests
                 Data = new List<RequestPerson>() {
                     new RequestPerson
                     {
+                        // farrington,1931-10-13,000-12-3456
                         LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
                     }
                 }
@@ -60,10 +61,12 @@ namespace Piipan.Match.Orchestrator.Tests
                 Data = new List<RequestPerson>() {
                     new RequestPerson
                     {
+                        // farrington,1931-10-13,000-12-3456
                         LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
                     },
                     new RequestPerson
                     {
+                        // lynn,1940-08-01,000-12-3457
                         LdsHash = "97719c32bb3c6a5e08c1241a7435d6d7047e75f40d8b3880744c07fef9d586954f77dc93279044c662d5d379e9c8a447ce03d9619ce384a7467d322e647e5d95"
                     }
                 }
@@ -77,6 +80,7 @@ namespace Piipan.Match.Orchestrator.Tests
             {
                 list.Add(new RequestPerson
                 {
+                    // farrington,1931-10-13,000-12-3456
                     LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
                 });
             }

--- a/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
@@ -2,12 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.Http;
 using Azure.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -31,11 +29,6 @@ namespace Piipan.Match.Orchestrator.Tests
         {
             return new ParticipantRecord
             {
-                First = "First",
-                Middle = "Middle",
-                Last = "Last",
-                Dob = new DateTime(1970, 1, 1),
-                Ssn = "000-00-0000",
                 CaseId = "CaseIdExample",
                 BenefitsEndMonth = new DateTime(1970, 1, 31),
                 RecentBenefitMonths = new List<DateTime>() {
@@ -54,11 +47,7 @@ namespace Piipan.Match.Orchestrator.Tests
                 Data = new List<RequestPerson>() {
                     new RequestPerson
                     {
-                        First = "First",
-                        Middle = "Middle",
-                        Last = "Last",
-                        Dob = new DateTime(1970, 1, 1),
-                        Ssn = "000-00-0000"
+                        LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
                     }
                 }
             };
@@ -71,19 +60,11 @@ namespace Piipan.Match.Orchestrator.Tests
                 Data = new List<RequestPerson>() {
                     new RequestPerson
                     {
-                        First = "First",
-                        Middle = "Middle",
-                        Last = "Last",
-                        Dob = new DateTime(1970, 1, 1),
-                        Ssn = "000-00-0000"
+                        LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
                     },
                     new RequestPerson
                     {
-                        First = "FirstTwo",
-                        Middle = "MiddleTwo",
-                        Last = "LastTwo",
-                        Dob = new DateTime(1970, 1, 2),
-                        Ssn = "000-00-0001"
+                        LdsHash = "97719c32bb3c6a5e08c1241a7435d6d7047e75f40d8b3880744c07fef9d586954f77dc93279044c662d5d379e9c8a447ce03d9619ce384a7467d322e647e5d95"
                     }
                 }
             };
@@ -96,11 +77,7 @@ namespace Piipan.Match.Orchestrator.Tests
             {
                 list.Add(new RequestPerson
                 {
-                    First = "First",
-                    Middle = "Middle",
-                    Last = "Last",
-                    Dob = new DateTime(1970, 1, 1),
-                    Ssn = "000-00-0000"
+                    LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
                 });
             }
             return new OrchMatchRequest { Data = list };
@@ -209,17 +186,13 @@ namespace Piipan.Match.Orchestrator.Tests
         [Fact]
         public void ParticipantRecordJson()
         {
-            var json = @"{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '000000000', case_id: 'foo', benefits_end_month: '2020-01', recent_benefit_months: ['2019-12', '2019-11', '2019-10'], protect_location: true}";
+            var json = @"{participant_id: 'baz', case_id: 'foo', benefits_end_month: '2020-01', recent_benefit_months: ['2019-12', '2019-11', '2019-10'], protect_location: true}";
             var record = JsonConvert.DeserializeObject<ParticipantRecord>(json);
 
             string jsonRecord = record.ToJson();
 
-            Assert.Contains("\"last\": \"Last\"", jsonRecord);
-            Assert.Contains("\"dob\": \"2020-01-01\"", jsonRecord);
-            Assert.Contains("\"ssn\": \"000000000\"", jsonRecord);
-            Assert.Contains("\"first\": \"First\"", jsonRecord);
-            Assert.Contains("\"middle\": null", jsonRecord);
             Assert.Contains("\"state\": null", jsonRecord);
+            Assert.Contains("\"participant_id\": \"baz\"", jsonRecord);
             Assert.Contains("\"case_id\": \"foo\"", jsonRecord);
             Assert.Contains("\"benefits_end_month\": \"2020-01\"", jsonRecord);
             Assert.Contains("\"recent_benefit_months\": [", jsonRecord);
@@ -245,7 +218,7 @@ namespace Piipan.Match.Orchestrator.Tests
             var logger = Mock.Of<ILogger>();
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
 
             // Assert
             var result = response as BadRequestObjectResult;
@@ -269,7 +242,7 @@ namespace Piipan.Match.Orchestrator.Tests
             var logger = Mock.Of<ILogger>();
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
 
             // Assert
             var result = response as BadRequestObjectResult;
@@ -284,11 +257,8 @@ namespace Piipan.Match.Orchestrator.Tests
 
         // Invalid person-level results in item-level validation errors
         [Theory]
-        [InlineData(@"[{last: 'Last', first: 'First', dob: '2020-01-01', ssn: '0000000000'}]")] // Invalid Ssn format
-        [InlineData(@"[{last: '', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}]")] // Empty last
-        [InlineData(@"[{last: '        ', first: 'First', dob: '2020-01-01', ssn: '000-00-0000'}]")] // Whitespace last
-        [InlineData(@"[{last: 'Last', first: '', dob: '2020-01-01', ssn: '000-00-0000'}]")] // Empty first
-        [InlineData(@"[{last: 'Last', first: '       ', dob: '2020-01-01', ssn: '000-00-0000'}]")] // Whitespace first
+        [InlineData(@"[{lds_hash: 'abc'}]")] // Invalid hash
+        [InlineData(@"[{lds_hash: ''}]")] // Empty hash
         public async void ExpectBadResultFromInvalidPersonData(string query)
         {
             // Arrange
@@ -297,7 +267,7 @@ namespace Piipan.Match.Orchestrator.Tests
             var logger = Mock.Of<ILogger>();
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
 
             // Assert
             var result = response as JsonResult;
@@ -312,12 +282,8 @@ namespace Piipan.Match.Orchestrator.Tests
 
         // Incomplete person-level results in top-level bad request response
         [Theory]
-        [InlineData(@"[{first: 'First'}]")] // Missing Last, Dob, and Ssn
-        [InlineData(@"[{last: 'Last'}]")] // Missing Dob and Ssn
-        [InlineData(@"[{last: 'Last', dob: '2020-01-01'}]")] // Missing Ssn
-        [InlineData(@"[{last: 'Last', dob: '2020-01-1', ssn: '000-00-000'}]")] // Invalid Dob DateTime
-        [InlineData(@"[{last: 'Last', dob: '', ssn: '000-00-000'}]")] // Empty Dob DateTime
-        [InlineData(@"[{last: 'Last', dob: '2020-01-01', ssn: '000-00-000'}]")] // Missing First
+        [InlineData(@"[{ssn: '000-00-0000'}]")] // Missing hash
+        [InlineData(@"[{}]")] // Empty record
         public async void ExpectBadResultFromIncompleteData(string query)
         {
             // Arrange
@@ -326,7 +292,7 @@ namespace Piipan.Match.Orchestrator.Tests
             var logger = Mock.Of<ILogger>();
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger);
+            var response = await api.Find(mockRequest.Object, logger);
 
             // Assert
             var result = response as BadRequestObjectResult;
@@ -373,7 +339,7 @@ namespace Piipan.Match.Orchestrator.Tests
             .Throws(new Exception("example message"));
 
             // Act
-            var response = await api.Query(mockRequest.Object, logger.Object);
+            var response = await api.Find(mockRequest.Object, logger.Object);
             var result = response as JsonResult;
             var resBody = result.Value as ApiErrorResponse;
             var error = resBody.Errors[0];

--- a/match/tests/Piipan.Match.Orchestrator.Tests/OrchMatchRequestValidatorTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/OrchMatchRequestValidatorTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using FluentValidation.TestHelper;
 using Piipan.Match.Orchestrator;
@@ -34,11 +33,7 @@ public class OrchMatchRequestValidatorTests
         {
             list.Add(new RequestPerson
             {
-                First = "First",
-                Middle = "Middle",
-                Last = "Last",
-                Dob = new DateTime(1970, 1, 1),
-                Ssn = "000-00-0000"
+                LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
             });
         }
         var model = new OrchMatchRequest { Data = list };
@@ -57,41 +52,24 @@ public class PersonValidatorTests
     }
 
     [Fact]
-    public void ReturnsErrorWhenLastNameEmpty()
+    public void ReturnsErrorWhenHashEmpty()
     {
         var model = new RequestPerson()
         {
-            Last = "",
-            First = "Foo",
-            Ssn = "123-45-6789"
+            LdsHash = ""
         };
         var result = Validator().TestValidate(model);
-        result.ShouldHaveValidationErrorFor(person => person.Last);
+        result.ShouldHaveValidationErrorFor(person => person.LdsHash);
     }
 
     [Fact]
-    public void ReturnsErrorWhenFirstNameEmpty()
+    public void ReturnsErrorWhenHashMalformed()
     {
         var model = new RequestPerson()
         {
-            First = "",
-            Last = "Foo",
-            Ssn = "123-45-6789"
+            LdsHash = "Foo"
         };
         var result = Validator().TestValidate(model);
-        result.ShouldHaveValidationErrorFor(person => person.First);
-    }
-
-    [Fact]
-    public void ReturnsErrorWhenSsnMalformed()
-    {
-        var model = new RequestPerson()
-        {
-            Last = "Foo",
-            First = "Bar",
-            Ssn = "baz"
-        };
-        var result = Validator().TestValidate(model);
-        result.ShouldHaveValidationErrorFor(person => person.Ssn);
+        result.ShouldHaveValidationErrorFor(person => person.LdsHash);
     }
 }


### PR DESCRIPTION
- Replace PII properties with hash property
- Update SQL query/matching algorithm
- Align integration tests database fixture with recent work in `Piipan.Etl`
- Use Dapper in database fixture

Partially addresses #1215.

Note: the PII-based endpoint `/find_matches_by_pii` is stubbed in and currently returns just a 204 response.