### PR TITLE
Bump coverlet.collector to 3.1.0

### DIFF
--- a/match/tests/Piipan.Match.Orchestrator.IntegrationTests/Piipan.Match.Orchestrator.IntegrationTests.csproj
+++ b/match/tests/Piipan.Match.Orchestrator.IntegrationTests/Piipan.Match.Orchestrator.IntegrationTests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Reference: [Updating .NET dependencies](https://github.com/18F/piipan/blob/main/docs/update-deps.md)

(Dependabot caught this once `dependabot.yaml` was updated).