### PR TITLE
Add name spaced find_matches endpoint to APIM

### DIFF
--- a/docs/openapi/duplicate-participation-api.yaml
+++ b/docs/openapi/duplicate-participation-api.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: "The API where matching will occur"
 servers:
-  - url: "/v2"
+  - url: "/match/v2"
 paths:
   /find_matches:
     $ref: '../../match/docs/openapi/orchestrator/find.yaml'

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -8,7 +8,7 @@ The API where matching will occur
 
 Base URLs:
 
-* <a href="/v2">/v2</a>
+* <a href="/match/v2">/match/v2</a>
 
 # Authentication
 
@@ -25,7 +25,7 @@ Base URLs:
 
 ```shell
 # You can also use wget
-curl -X POST /v2/find_matches \
+curl -X POST /match/v2/find_matches \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'From: string' \

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: The API where matching will occur
 servers:
-  - url: /v2
+  - url: /match/v2
 paths:
   /find_matches:
     post:

--- a/iac/arm-templates/apim.json
+++ b/iac/arm-templates/apim.json
@@ -148,8 +148,8 @@
                 "protocols": [
                     "https"
                 ],
-                "path": "",
-                "apiVersion": "v1",
+                "path": "[variables('matchSetName')]",
+                "apiVersion": "v2",
                 "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', parameters('apiName'), variables('matchSetName'))]",
                 "serviceUrl": "[parameters('orchestratorUrl')]"
             }
@@ -158,7 +158,7 @@
         {
             "type": "Microsoft.ApiManagement/service/apis/operations",
             "apiVersion": "2020-06-01-preview",
-            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/post-query')]",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/post-find')]",
             "dependsOn": [
                 "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]",
                 "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('matchSetName'))]"
@@ -166,26 +166,15 @@
             "properties": {
                 "displayName": "Search for all matching PII records",
                 "method": "POST",
-                "urlTemplate": "/query",
-                "description": "Queries all state databases for any PII records that are an exact match to the last name, date of birth, and social security number in the request body's `query` property.",
-                "responses": [
-                    {
-                        "statusCode": 200,
-                        "description": "Matching PII records, if any exist"
-                    },
-                    {
-                        "statusCode": 400,
-                        "description": "Bad request. Missing one of the required properties in the request body."
-                    }
-                ]
+                "urlTemplate": "/find_matches"
             }
         },
         {
             "type": "Microsoft.ApiManagement/service/apis/operations/policies",
             "apiVersion": "2020-06-01-preview",
-            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/post-query/policy')]",
+            "name": "[concat(parameters('apiName'), '/', variables('matchSetName'), '/post-find/policy')]",
             "dependsOn": [
-                "[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('apiName'), variables('matchSetName'), 'post-query')]",
+                "[resourceId('Microsoft.ApiManagement/service/apis/operations', parameters('apiName'), variables('matchSetName'), 'post-find')]",
                 "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apiName'), variables('matchSetName'))]",
                 "[resourceId('Microsoft.ApiManagement/service', parameters('apiName'))]"
             ],


### PR DESCRIPTION
- Use "match" as a name space for the duplicate participation API
- Update APIM policy to use new endpoint and remove extraneous properties (description, responses)

Another naming decision.

Closes #1510 and #1215.