### PR TITLE
Drop state_abbr property from DupPart API

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -74,7 +74,6 @@ Searches all state databases for any participant records that are an exact match
         "matches": [
           {
             "state": "ea",
-            "state_abbr": "ea",
             "case_id": "string",
             "participant_id": "string",
             "benefits_end_month": "2021-01",
@@ -120,7 +119,6 @@ Searches all state databases for any participant records that are an exact match
         "matches": [
           {
             "state": "eb",
-            "state_abbr": "eb",
             "case_id": "string",
             "participant_id": "string",
             "benefits_end_month": "2021-01",
@@ -133,7 +131,6 @@ Searches all state databases for any participant records that are an exact match
           },
           {
             "state": "ec",
-            "state_abbr": "ec",
             "case_id": "string",
             "participant_id": "string",
             "benefits_end_month": null,
@@ -158,7 +155,6 @@ Searches all state databases for any participant records that are an exact match
         "matches": [
           {
             "state": "ec",
-            "state_abbr": "ec",
             "case_id": "string",
             "participant_id": "string",
             "benefits_end_month": null,
@@ -171,7 +167,6 @@ Searches all state databases for any participant records that are an exact match
         "matches": [
           {
             "state": "ec",
-            "state_abbr": "ec",
             "case_id": "string",
             "participant_id": "string",
             "benefits_end_month": null,
@@ -200,7 +195,6 @@ Searches all state databases for any participant records that are an exact match
         "matches": [
           {
             "state": "ec",
-            "state_abbr": "ec",
             "case_id": "string",
             "participant_id": "string",
             "benefits_end_month": null,
@@ -225,7 +219,6 @@ Searches all state databases for any participant records that are an exact match
         "matches": [
           {
             "state": "ec",
-            "state_abbr": "ec",
             "case_id": "string",
             "participant_id": "string",
             "benefits_end_month": null,
@@ -281,7 +274,6 @@ Status Code **200**
 |»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
 |»»» matches|[object]|true|none|none|
 |»»»» state|string|true|none|State/territory two-letter postal abbreviation|
-|»»»» state_abbr|string|false|none|State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.|
 |»»»» case_id|string|true|none|Participant's state-specific case identifier. Can be the same for multiple participants.|
 |»»»» participant_id|string|true|none|Participant's state-specific identifier. Is unique to the participant. Must not be social security number or any PII.|
 |»»»» benefits_end_month|string|false|none|Participant's ending benefits month|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -94,10 +94,6 @@ paths:
                                   state:
                                     type: string
                                     description: State/territory two-letter postal abbreviation
-                                  state_abbr:
-                                    type: string
-                                    description: 'State/territory two-letter postal abbreviation. Deprecated, superseded by `state`.'
-                                    deprecated: true
                                   case_id:
                                     type: string
                                     description: Participant's state-specific case identifier. Can be the same for multiple participants.
@@ -173,7 +169,6 @@ paths:
                         - index: 0
                           matches:
                             - state: ea
-                              state_abbr: ea
                               case_id: string
                               participant_id: string
                               benefits_end_month: 2021-01
@@ -199,7 +194,6 @@ paths:
                         - index: 0
                           matches:
                             - state: eb
-                              state_abbr: eb
                               case_id: string
                               participant_id: string
                               benefits_end_month: 2021-01
@@ -209,7 +203,6 @@ paths:
                                 - 2021-03
                               protect_location: true
                             - state: ec
-                              state_abbr: ec
                               case_id: string
                               participant_id: string
                               benefits_end_month: null

--- a/match/docs/openapi/schemas/participant-record.yaml
+++ b/match/docs/openapi/schemas/participant-record.yaml
@@ -9,10 +9,6 @@ ParticipantRecord:
     state:
       type: string
       description: "State/territory two-letter postal abbreviation"
-    state_abbr:
-      type: string
-      description: "State/territory two-letter postal abbreviation. Deprecated, superseded by `state`."
-      deprecated: true
     case_id:
       type: string
       description: "Participant's state-specific case identifier. Can be the same for multiple participants."
@@ -42,7 +38,6 @@ ParticipantRecord:
 ParticipantRecordExamples:
   All:
     state: "ea"
-    state_abbr: "ea"
     case_id: "string"
     participant_id: "string"
     benefits_end_month: "2021-01"
@@ -53,7 +48,6 @@ ParticipantRecordExamples:
     protect_location: true
   AllEB:
     state: "eb"
-    state_abbr: "eb"
     case_id: "string"
     participant_id: "string"
     benefits_end_month: "2021-01"
@@ -64,7 +58,6 @@ ParticipantRecordExamples:
     protect_location: true
   Required:
     state: "ec"
-    state_abbr: "ec"
     case_id: "string"
     participant_id: "string"
     benefits_end_month: null

--- a/match/src/Piipan.Match.Orchestrator/ParticipantRecord.cs
+++ b/match/src/Piipan.Match.Orchestrator/ParticipantRecord.cs
@@ -14,17 +14,6 @@ namespace Piipan.Match.Orchestrator
         [JsonProperty("state")]
         public string State { get; set; }
 
-        // Read-only
-        // Deprecated
-        [JsonProperty("state_abbr")]
-        public string StateAbbr
-        {
-            get
-            {
-                return State;
-            }
-        }
-
         [JsonProperty("case_id")]
         public string CaseId { get; set; }
 

--- a/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
+++ b/match/tests/Piipan.Match.Orchestrator.Tests/ApiTests.cs
@@ -204,9 +204,6 @@ namespace Piipan.Match.Orchestrator.Tests
             Assert.Contains("\"2019-11\",", jsonRecord);
             Assert.Contains("\"2019-10\"", jsonRecord);
             Assert.Contains("\"protect_location\": true", jsonRecord);
-
-            // Deprecated
-            Assert.Contains("\"state_abbr\": null", record.ToJson());
         }
 
         // Malformed request results in BadRequest


### PR DESCRIPTION
With the recent API churn, it seems like it's time to drop the deprecated property completely. 

Closes #1550 