### PR TITLE
Use TimeZoneConverter for retrieving TimeZoneInfo objects

### DIFF
--- a/dashboard/src/Piipan.Dashboard/ParticipantUpload.cs
+++ b/dashboard/src/Piipan.Dashboard/ParticipantUpload.cs
@@ -1,5 +1,6 @@
 using System;
 using Piipan.Shared.Helpers;
+using TimeZoneConverter;
 
 namespace Piipan.Dashboard
 {
@@ -7,7 +8,7 @@ namespace Piipan.Dashboard
     {
         public string State { get; set; }
         public DateTime UploadedAt { get; set; }
-        public TimeZoneInfo TZ = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        public TimeZoneInfo TZ = TZConvert.GetTimeZoneInfo("America/New_York");
 
         public ParticipantUpload(string state, DateTime uploaded_at)
         {

--- a/dashboard/src/Piipan.Dashboard/Piipan.Dashboard.csproj
+++ b/dashboard/src/Piipan.Dashboard/Piipan.Dashboard.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.18" />
     <PackageReference Include="NEasyAuthMiddleware" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dashboard/src/Piipan.Dashboard/packages.lock.json
+++ b/dashboard/src/Piipan.Dashboard/packages.lock.json
@@ -28,6 +28,12 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
+      "TimeZoneConverter": {
+        "type": "Direct",
+        "requested": "[3.5.0, )",
+        "resolved": "3.5.0",
+        "contentHash": "ziTcQ5rVxRdtWJEnEqhKBukZGuUQregbf5G7QRrFKj6CwBLss5tSz0dlSHy9gzi5M5ES0PNQ0K2ACP/0XVT5Ow=="
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.19.0",

--- a/dashboard/tests/Piipan.Dashboard.Tests/Api/ParticipantUploadTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/Api/ParticipantUploadTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Xunit;
+
+namespace Piipan.Dashboard.Tests
+{
+    public class ParticipantUploadTests
+    {
+        [Fact]
+        public void FormattedUploadAt_ReturnsResult()
+        {
+            const string state = "ea";
+            DateTime uploaded_at = new DateTime(1970, 1, 1, 0, 0, 0);
+
+            var upload = new ParticipantUpload(state, uploaded_at);
+
+            Assert.IsType<string>(upload.FormattedUploadedAt());
+            Assert.NotEmpty(upload.FormattedUploadedAt());
+        }
+
+        // Tests the method only
+        // Formatting is tested in `shared/tests`
+        [Fact]
+        public void RelativeUploadAt_ReturnsResult()
+        {
+            const string state = "ea";
+            DateTime uploaded_at = new DateTime(1970, 1, 1, 0, 0, 0);
+
+            var upload = new ParticipantUpload(state, uploaded_at);
+
+            Assert.IsType<string>(upload.RelativeUploadedAt());
+            Assert.NotEmpty(upload.RelativeUploadedAt());
+        }
+    }
+}

--- a/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
+++ b/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
@@ -1419,6 +1419,11 @@
           "System.Xml.ReaderWriter": "4.3.0"
         }
       },
+      "TimeZoneConverter": {
+        "type": "Transitive",
+        "resolved": "3.5.0",
+        "contentHash": "ziTcQ5rVxRdtWJEnEqhKBukZGuUQregbf5G7QRrFKj6CwBLss5tSz0dlSHy9gzi5M5ES0PNQ0K2ACP/0XVT5Ow=="
+      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -1470,7 +1475,8 @@
           "Microsoft.Extensions.Logging.AzureAppServices": "3.1.18",
           "NEasyAuthMiddleware": "2.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Piipan.Shared": "1.0.0"
+          "Piipan.Shared": "1.0.0",
+          "TimeZoneConverter": "3.5.0"
         }
       },
       "piipan.shared": {


### PR DESCRIPTION
- Update application
- Add tests for `ParticipantUpload` methods

Closes #1562. Fixes issue where Dashboard would not display any participant upload results.

Note: [Requires runtime environment has access to timezone data](https://github.com/mattjohnsonpint/TimeZoneConverter#note-on-os-data-dependencies).