### PR TITLE
Initial database schema for match records

### DIFF
--- a/match/ddl/match-record.sql
+++ b/match/ddl/match-record.sql
@@ -21,7 +21,7 @@ COMMENT ON TABLE matches IS 'Match records';
 COMMENT ON COLUMN matches.match_id IS 'Match record''s human-readable unique identifier.';
 COMMENT ON COLUMN matches.created_at IS 'Match record''s creation date/time.';
 COMMENT ON COLUMN matches.initator IS 'Match record''s initiating entity.';
-COMMENT ON COLUMN matches.states IS 'States/territories involved in match.';
+COMMENT ON COLUMN matches.states IS 'State/territory pair involved in match.';
 COMMENT ON COLUMN matches.hash IS 'Value of hash used to identify match.';
 COMMENT ON COLUMN matches.hash_type IS 'Type of hash used to identify match.';
 COMMENT ON COLUMN matches.input IS 'Incoming data from real-time match request.';

--- a/match/ddl/match-record.sql
+++ b/match/ddl/match-record.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+CREATE TYPE hash_type AS ENUM ('ldshash');
+CREATE TYPE status AS ENUM ('open', 'closed');
+
+CREATE TABLE IF NOT EXISTS matches(
+    id serial PRIMARY KEY,
+    match_id text UNIQUE NOT NULL,
+    created_at timestamp NOT NULL,
+    initator text NOT NULL,
+    hash text NOT NULL,
+    hash_type hash_type NOT NULL default 'ldshash';
+    input jsonb,
+    data jsonb NOT NULL,
+    invalid bool NOT NULL default FALSE,
+    status status NOT NULL default 'open'
+);
+
+COMMENT ON TABLE matches IS 'Match records';
+COMMENT ON COLUMN matches.match_id IS 'Match record''s human-readable unique identifier.';
+COMMENT ON COLUMN matches.created_at IS 'Match record''s creation date/time.';
+COMMENT ON COLUMN matches.initator IS 'Match record''s initiating entity.';
+COMMENT ON COLUMN matches.hash IS 'Value of hash used to identify match.';
+COMMENT ON COLUMN matches.hash_type IS 'Type of hash used to identify match.'
+COMMENT ON COLUMN matches.input IS 'Incoming data from real-time match request.';
+COMMENT ON COLUMN matches.data IS 'Response data from match request.';
+COMMENT ON COLUMN matches.invalid IS 'Indicator used for designating match as invalid.';
+COMMENT ON COLUMN matches.status IS 'Match record''s status.';
+
+COMMIT;

--- a/match/ddl/match-record.sql
+++ b/match/ddl/match-record.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS matches(
     match_id text UNIQUE NOT NULL,
     created_at timestamp NOT NULL,
     initator text NOT NULL,
+    states text[2] NOT NULL,
     hash text NOT NULL,
     hash_type hash_type NOT NULL default 'ldshash';
     input jsonb,
@@ -20,8 +21,9 @@ COMMENT ON TABLE matches IS 'Match records';
 COMMENT ON COLUMN matches.match_id IS 'Match record''s human-readable unique identifier.';
 COMMENT ON COLUMN matches.created_at IS 'Match record''s creation date/time.';
 COMMENT ON COLUMN matches.initator IS 'Match record''s initiating entity.';
+COMMENT ON COLUMN matches.states IS 'States/territories involved in match.';
 COMMENT ON COLUMN matches.hash IS 'Value of hash used to identify match.';
-COMMENT ON COLUMN matches.hash_type IS 'Type of hash used to identify match.'
+COMMENT ON COLUMN matches.hash_type IS 'Type of hash used to identify match.';
 COMMENT ON COLUMN matches.input IS 'Incoming data from real-time match request.';
 COMMENT ON COLUMN matches.data IS 'Response data from match request.';
 COMMENT ON COLUMN matches.invalid IS 'Indicator used for designating match as invalid.';


### PR DESCRIPTION
Partially address #1546 — starting with the database schema before getting into implementation.

Trying to keep this as simple as possible for meeting the needs of the ticket, knowing that requirements are still coming into focus and the underlying implementation is likely to change.