### PR TITLE
Create match records database in IaC

### DIFF
--- a/iac/create-core-databases.bash
+++ b/iac/create-core-databases.bash
@@ -9,7 +9,7 @@ set_constants () {
   SUPERUSER=$DB_ADMIN_NAME
 
   METRICS_DB_NAME=metrics
-  MATCH_RECORDS_DB_NAME=matches
+  COLLAB_DB_NAME=collaboration
 
   VAULT_NAME=$PREFIX-kv-core-$ENV
   PG_SECRET_NAME=core-pg-admin
@@ -68,9 +68,9 @@ main () {
   db_init "$METRICS_DB_NAME" "$SUPERUSER"
   db_apply_ddl "$METRICS_DB_NAME" ../metrics/ddl/metrics.sql
 
-  echo "Creating $MATCH_RECORDS_DB_NAME database and applying DDL"
-  db_init "$MATCH_RECORDS_DB_NAME" "$SUPERUSER"
-  db_apply_ddl "$MATCH_RECORDS_DB_NAME" ../match/ddl/match-record.sql
+  echo "Creating $COLLAB_DB_NAME database and applying DDL"
+  db_init "$COLLAB_DB_NAME" "$SUPERUSER"
+  db_apply_ddl "$COLLAB_DB_NAME" ../match/ddl/match-record.sql
 
   db_config_aad "$RESOURCE_GROUP" "$DB_SERVER_NAME" "$PG_AAD_ADMIN"
   db_use_aad "$DB_SERVER_NAME" "$PG_AAD_ADMIN"
@@ -87,10 +87,10 @@ main () {
 
   local orchestrator
   orchestrator=$(get_resources "$ORCHESTRATOR_API_TAG" "$MATCH_RESOURCE_GROUP")
-  echo "Configuring $MATCH_RECORDS_DB_NAME access for $orchestrator"
-  db_create_managed_role "$MATCH_RECORDS_DB_NAME" "$orchestrator" "$MATCH_RESOURCE_GROUP"
-  db_config_managed_role "$MATCH_RECORDS_DB_NAME" "$orchestrator"
-  db_grant_readwrite "$MATCH_RECORDS_DB_NAME" "$orchestrator"
+  echo "Configuring $COLLAB_DB_NAME access for $orchestrator"
+  db_create_managed_role "$COLLAB_DB_NAME" "$orchestrator" "$MATCH_RESOURCE_GROUP"
+  db_config_managed_role "$COLLAB_DB_NAME" "$orchestrator"
+  db_grant_readwrite "$COLLAB_DB_NAME" "$orchestrator"
 
   db_leave_aad $PG_AAD_ADMIN
 

--- a/iac/db-common.bash
+++ b/iac/db-common.bash
@@ -109,12 +109,13 @@ EOF
 db_create_managed_role () {
   local db=$1
   local func=$2
+  local group=$3
   local role=${func//-/_}
 
   principal_id=$(\
     az webapp identity show \
       -n "$func" \
-      -g "$RESOURCE_GROUP" \
+      -g "$group" \
       --query principalId \
       -o tsv)
   app_id=$(\

--- a/match/ddl/match-record.sql
+++ b/match/ddl/match-record.sql
@@ -1,7 +1,18 @@
 BEGIN;
 
-CREATE TYPE hash_type AS ENUM ('ldshash');
-CREATE TYPE status AS ENUM ('open', 'closed');
+DO $$ BEGIN
+    CREATE TYPE hash_type AS ENUM ('ldshash');
+EXCEPTION
+    WHEN duplicate_object THEN
+        RAISE NOTICE 'hash_type ENUM already exists, skipping';
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE status AS ENUM ('open', 'closed');
+EXCEPTION
+    WHEN duplicate_object THEN
+        RAISE NOTICE 'status ENUM already exists, skipping';
+END $$;
 
 CREATE TABLE IF NOT EXISTS matches(
     id serial PRIMARY KEY,
@@ -10,7 +21,7 @@ CREATE TABLE IF NOT EXISTS matches(
     initator text NOT NULL,
     states text[2] NOT NULL,
     hash text NOT NULL,
-    hash_type hash_type NOT NULL default 'ldshash';
+    hash_type hash_type NOT NULL default 'ldshash',
     input jsonb,
     data jsonb NOT NULL,
     invalid bool NOT NULL default FALSE,


### PR DESCRIPTION
- Update `db_create_managed_role` to allow other resource groups when creating managed identities
- Make DDL re-runnable by handling case where ENUMs already exist
- Fix typo in schema

Partially addresses #1546 