### PR TITLE
Bump coverlet.collector to 3.1.0

### DIFF
--- a/match/tests/Piipan.Match.Core.Tests/Piipan.Match.Core.Tests.csproj
+++ b/match/tests/Piipan.Match.Core.Tests/Piipan.Match.Core.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/match/tests/Piipan.Match.Core.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Core.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[1.3.0, )",
-        "resolved": "1.3.0",
-        "contentHash": "t8pnf5SX2ya0RX4vjoxsbhDMQCZJcpPun2neHKJ4FouMmObylo25FvoOydvf3Bl+l+IzWw7u2vjEeCBHnleB9g=="
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "YzYqSRrjoP5lULBhTDcTOjuM4IDPPi6PhFsl4w8EI4WdZhE6llt7E38Tg4CHyrS+QKwyu1+9OwkdDgluOdoBTw=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/match/tests/Piipan.Match.Func.Api.Tests/Piipan.Match.Func.Api.Tests.csproj
+++ b/match/tests/Piipan.Match.Func.Api.Tests/Piipan.Match.Func.Api.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[1.3.0, )",
-        "resolved": "1.3.0",
-        "contentHash": "t8pnf5SX2ya0RX4vjoxsbhDMQCZJcpPun2neHKJ4FouMmObylo25FvoOydvf3Bl+l+IzWw7u2vjEeCBHnleB9g=="
+        "requested": "[3.1.0, )",
+        "resolved": "3.1.0",
+        "contentHash": "YzYqSRrjoP5lULBhTDcTOjuM4IDPPi6PhFsl4w8EI4WdZhE6llt7E38Tg4CHyrS+QKwyu1+9OwkdDgluOdoBTw=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",


### PR DESCRIPTION
Reference: [Updating .NET dependencies](https://github.com/18F/piipan/blob/main/docs/update-deps.md)

This major version bump was missed with the last round of dependency updates.