### PR TITLE
Make IDbConnectionFactory generic and update implementations

### DIFF
--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
@@ -1,8 +1,10 @@
+using System;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using Piipan.Etl.Func.BulkUpload.Parsers;
+using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Extensions;
 using Piipan.Shared.Database;
 
@@ -12,15 +14,17 @@ namespace Piipan.Etl.Func.BulkUpload
 {
     public class Startup : FunctionsStartup
     {
+        public const string DatabaseConnectionString = "DatabaseConnectionString";
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder.Services.AddLogging();
 
-            builder.Services.AddTransient<IDbConnectionFactory>(s =>
+            builder.Services.AddTransient<IDbConnectionFactory<ParticipantsDb>>(s =>
             {
-                return new AzurePgConnectionFactory(
+                return new AzurePgConnectionFactory<ParticipantsDb>(
                     new AzureServiceTokenProvider(),
-                    NpgsqlFactory.Instance
+                    NpgsqlFactory.Instance,
+                    Environment.GetEnvironmentVariable(DatabaseConnectionString)
                 );
             });
             builder.Services.AddTransient<IParticipantStreamParser, ParticipantCsvStreamParser>();

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.IntegrationTests/BulkUploadIntegrationTests.cs
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.IntegrationTests/BulkUploadIntegrationTests.cs
@@ -1,16 +1,17 @@
 using System;
+using System.Data;
 using System.IO;
 using System.Linq;
 using Microsoft.Azure.EventGrid.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Piipan.Participants.Core.Extensions;
 using Moq;
-using Xunit;
-using System.Data;
-using Piipan.Participants.Api;
 using Piipan.Etl.Func.BulkUpload.Parsers;
+using Piipan.Participants.Api;
+using Piipan.Participants.Core.DataAccessObjects;
+using Piipan.Participants.Core.Extensions;
 using Piipan.Shared.Database;
+using Xunit;
 
 namespace Piipan.Etl.Func.BulkUpload.IntegrationTests
 {
@@ -24,18 +25,18 @@ namespace Piipan.Etl.Func.BulkUpload.IntegrationTests
             var services = new ServiceCollection();
 
             services.AddLogging();
-            services.AddTransient<IDbConnectionFactory>(c =>
+            services.AddTransient<IDbConnectionFactory<ParticipantsDb>>(c =>
             {
-                var factory = new Mock<IDbConnectionFactory>();
+                var factory = new Mock<IDbConnectionFactory<ParticipantsDb>>();
                 factory
                     .Setup(m => m.Build(It.IsAny<string>()))
                     .ReturnsAsync(() =>
-                {
-                    var connection = Factory.CreateConnection();
-                    connection.ConnectionString = ConnectionString;
-                    connection.Open();
-                    return connection;
-                });
+                    {
+                        var connection = Factory.CreateConnection();
+                        connection.ConnectionString = ConnectionString;
+                        connection.Open();
+                        return connection;
+                    });
                 return factory.Object;
             });
 
@@ -78,8 +79,8 @@ namespace Piipan.Etl.Func.BulkUpload.IntegrationTests
             // assert
             for (int i = 0; i < records.Count(); i++)
             {
-                Assert.Equal($"caseid{i+1}", records.ElementAt(i).CaseId);
-                Assert.Equal($"participantid{i+1}", records.ElementAt(i).ParticipantId);
+                Assert.Equal($"caseid{i + 1}", records.ElementAt(i).CaseId);
+                Assert.Equal($"participantid{i + 1}", records.ElementAt(i).ParticipantId);
             }
             Assert.Equal("a3cab51dd68da2ac3e5508c8b0ee514ada03b9f166f7035b4ac26d9c56aa7bf9d6271e44c0064337a01b558ff63fd282de14eead7e8d5a613898b700589bcdec", records.First().LdsHash);
             Assert.Equal(new DateTime(2021, 05, 31), records.First().BenefitsEndDate);

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/StartupTests.cs
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/StartupTests.cs
@@ -1,12 +1,12 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Npgsql;
+using Piipan.Etl.Func.BulkUpload;
 using Piipan.Etl.Func.BulkUpload.Parsers;
 using Piipan.Participants.Api;
+using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Shared.Database;
 using Xunit;
 
@@ -27,11 +27,13 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
             var target = new Startup();
 
             // Act
+            Environment.SetEnvironmentVariable(Startup.DatabaseConnectionString,
+                "Server=server;Database=db;Port=5432;User Id=postgres;Password={password};");
             target.Configure(builder.Object);
             var provider = services.BuildServiceProvider();
 
             // Assert
-            Assert.NotNull(provider.GetService<IDbConnectionFactory>());
+            Assert.NotNull(provider.GetService<IDbConnectionFactory<ParticipantsDb>>());
             Assert.NotNull(provider.GetService<IParticipantApi>());
             Assert.NotNull(provider.GetService<IParticipantStreamParser>());
         }

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/CollaborationDb.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/CollaborationDb.cs
@@ -1,0 +1,4 @@
+namespace Piipan.Match.Core.DataAccessObjects
+{
+    public struct CollaborationDb { }
+}

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/CollaborationDb.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/CollaborationDb.cs
@@ -1,4 +1,8 @@
 namespace Piipan.Match.Core.DataAccessObjects
 {
+    /// <summary>
+    /// Establishes a placeholder type for use when instantiating typed
+    /// instances of Piipan.Shared.IDbConnectionFactory
+    /// </summary>
     public struct CollaborationDb { }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
@@ -13,14 +13,14 @@ namespace Piipan.Match.Core.DataAccessObjects
     /// </summary>
     public class MatchRecordDao : IMatchRecordDao
     {
-        private readonly IDbConnectionFactory _dbConnectionFactory;
+        private readonly IDbConnectionFactory<CollaborationDb> _dbConnectionFactory;
         private readonly ILogger<MatchRecordDao> _logger;
 
         /// <summary>
         /// Initializes a new instance of MatchRecordDao
         /// </summary>
         public MatchRecordDao(
-            IDbConnectionFactory dbConnectionFactory,
+            IDbConnectionFactory<CollaborationDb> dbConnectionFactory,
             ILogger<MatchRecordDao> logger)
         {
             _dbConnectionFactory = dbConnectionFactory;

--- a/match/tests/Piipan.Match.Core.IntegrationTests/MatchRecordDaoTests.cs
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/MatchRecordDaoTests.cs
@@ -14,9 +14,9 @@ namespace Piipan.Match.Core.IntegrationTests
     [Collection("Core.IntegrationTests")]
     public class MatchRecordDaoTests : DbFixture
     {
-        private IDbConnectionFactory DbConnFactory()
+        private IDbConnectionFactory<CollaborationDb> DbConnFactory()
         {
-            var factory = new Mock<IDbConnectionFactory>();
+            var factory = new Mock<IDbConnectionFactory<CollaborationDb>>();
             factory
                 .Setup(m => m.Build(It.IsAny<string>()))
                 .ReturnsAsync(() =>

--- a/match/tests/Piipan.Match.Func.Api.IntegrationTests/ApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.Api.IntegrationTests/ApiIntegrationTests.cs
@@ -2,28 +2,24 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using Moq;
+using Newtonsoft.Json;
+using Npgsql;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Models;
 using Piipan.Match.Core.Parsers;
 using Piipan.Match.Core.Services;
 using Piipan.Match.Core.Validators;
-using Piipan.Participants.Api;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Extensions;
-using Piipan.Participants.Core.Services;
-using Piipan.Shared;
-using Piipan.Shared.Authentication;
 using Piipan.Shared.Database;
-using FluentValidation;
-using Moq;
-using Newtonsoft.Json;
-using Npgsql;
 using Xunit;
 
 
@@ -95,9 +91,11 @@ namespace Piipan.Match.Func.Api.IntegrationTests
 
             services.AddTransient<IStreamParser<OrchMatchRequest>, OrchMatchRequestParser>();
 
-            services.AddTransient<IDbConnectionFactory>(s =>
+            services.AddTransient<IDbConnectionFactory<ParticipantsDb>>(s =>
             {
-                return new BasicPgConnectionFactory(NpgsqlFactory.Instance);
+                return new BasicPgConnectionFactory<ParticipantsDb>(
+                    NpgsqlFactory.Instance,
+                    Environment.GetEnvironmentVariable(Startup.DatabaseConnectionString));
             });
             services.RegisterParticipantsServices();
 

--- a/match/tests/Piipan.Match.Func.Api.Tests/StartupTests.cs
+++ b/match/tests/Piipan.Match.Func.Api.Tests/StartupTests.cs
@@ -1,13 +1,13 @@
+using System;
+using FluentValidation;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Parsers;
-using Piipan.Shared;
-using Piipan.Shared.Authentication;
+using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Shared.Database;
-using FluentValidation;
-using Moq;
 using Xunit;
 
 namespace Piipan.Match.Func.Api.Tests
@@ -29,13 +29,15 @@ namespace Piipan.Match.Func.Api.Tests
             // Act
             target.Configure(builder.Object);
             var provider = services.BuildServiceProvider();
+            Environment.SetEnvironmentVariable(Startup.DatabaseConnectionString,
+                "Server=server;Database=db;Port=5432;User Id=postgres;Password={password};");
 
             // Assert
             Assert.NotNull(provider.GetService<IMatchApi>());
             Assert.NotNull(provider.GetService<IValidator<OrchMatchRequest>>());
             Assert.NotNull(provider.GetService<IValidator<RequestPerson>>());
             Assert.NotNull(provider.GetService<IStreamParser<OrchMatchRequest>>());
-            Assert.NotNull(provider.GetService<IDbConnectionFactory>());
+            Assert.NotNull(provider.GetService<IDbConnectionFactory<ParticipantsDb>>());
         }
     }
 }

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDao.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDao.cs
@@ -1,20 +1,20 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Dapper;
 using Microsoft.Extensions.Logging;
 using Piipan.Participants.Core.Models;
 using Piipan.Shared.Database;
-using Dapper;
 
 namespace Piipan.Participants.Core.DataAccessObjects
 {
     public class ParticipantDao : IParticipantDao
     {
-        private readonly IDbConnectionFactory _dbConnectionFactory;
+        private readonly IDbConnectionFactory<ParticipantsDb> _dbConnectionFactory;
         private readonly ILogger<ParticipantDao> _logger;
 
         public ParticipantDao(
-            IDbConnectionFactory dbConnectionFactory,
+            IDbConnectionFactory<ParticipantsDb> dbConnectionFactory,
             ILogger<ParticipantDao> logger)
         {
             _dbConnectionFactory = dbConnectionFactory;

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDb.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDb.cs
@@ -1,0 +1,8 @@
+namespace Piipan.Participants.Core.DataAccessObjects
+{
+    /// <summary>
+    /// Establishes a placeholder type for use when instantiating typed
+    /// instances of Piipan.Shared.IDbConnectionFactory
+    /// </summary>
+    public struct ParticipantsDb { }
+}

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/UploadDao.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/UploadDao.cs
@@ -1,16 +1,16 @@
 using System.Threading.Tasks;
+using Dapper;
 using Piipan.Participants.Api.Models;
 using Piipan.Participants.Core.Models;
-using Dapper;
 using Piipan.Shared.Database;
 
 namespace Piipan.Participants.Core.DataAccessObjects
 {
     public class UploadDao : IUploadDao
     {
-        private readonly IDbConnectionFactory _dbConnectionFactory;
+        private readonly IDbConnectionFactory<ParticipantsDb> _dbConnectionFactory;
 
-        public UploadDao(IDbConnectionFactory dbConnectionFactory)
+        public UploadDao(IDbConnectionFactory<ParticipantsDb> dbConnectionFactory)
         {
             _dbConnectionFactory = dbConnectionFactory;
         }

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantDaoTests.cs
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantDaoTests.cs
@@ -1,19 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using Microsoft.Extensions.Logging;
-using Piipan.Participants.Api.Models;
+using Moq;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Models;
-using Piipan.Participants.Core.Services;
-using Dapper;
-using Npgsql;
-using Xunit;
-using Moq;
 using Piipan.Shared.Database;
+using Xunit;
 
 namespace Piipan.Participants.Core.IntegrationTests
 {
@@ -58,12 +53,12 @@ namespace Piipan.Participants.Core.IntegrationTests
             return result;
         }
 
-        private IDbConnectionFactory DbConnFactory()
+        private IDbConnectionFactory<ParticipantsDb> DbConnFactory()
         {
-            var factory = new Mock<IDbConnectionFactory>();
+            var factory = new Mock<IDbConnectionFactory<ParticipantsDb>>();
             factory
                 .Setup(m => m.Build(It.IsAny<string>()))
-                .ReturnsAsync(() => 
+                .ReturnsAsync(() =>
                 {
                     var conn = Factory.CreateConnection();
                     conn.ConnectionString = ConnectionString;

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/UploadDaoTests.cs
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/UploadDaoTests.cs
@@ -1,22 +1,22 @@
 using System;
+using Dapper;
+using Moq;
+using Npgsql;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Shared.Database;
-using Dapper;
-using Npgsql;
 using Xunit;
-using Moq;
 
 namespace Piipan.Participants.Core.IntegrationTests
 {
     [Collection("Core.IntegrationTests")]
     public class UploadDaoTests : DbFixture
     {
-        private IDbConnectionFactory DbConnFactory()
+        private IDbConnectionFactory<ParticipantsDb> DbConnFactory()
         {
-            var factory = new Mock<IDbConnectionFactory>();
+            var factory = new Mock<IDbConnectionFactory<ParticipantsDb>>();
             factory
                 .Setup(m => m.Build(It.IsAny<string>()))
-                .ReturnsAsync(() => 
+                .ReturnsAsync(() =>
                 {
                     var conn = Factory.CreateConnection();
                     conn.ConnectionString = ConnectionString;
@@ -39,7 +39,7 @@ namespace Piipan.Participants.Core.IntegrationTests
                 InsertUpload();
 
                 var expected = GetLastUploadId();
-            
+
                 var dao = new UploadDao(DbConnFactory());
 
                 // Act
@@ -60,7 +60,7 @@ namespace Piipan.Participants.Core.IntegrationTests
                 conn.Open();
 
                 ClearUploads();
-            
+
                 var dao = new UploadDao(DbConnFactory());
 
                 // Act / Assert

--- a/participants/tests/Piipan.Participants.Core.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/participants/tests/Piipan.Participants.Core.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,11 +1,11 @@
 using System.Data;
 using Microsoft.Extensions.DependencyInjection;
-using Piipan.Participants.Core.Extensions;
 using Moq;
-using Xunit;
-using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Api;
+using Piipan.Participants.Core.DataAccessObjects;
+using Piipan.Participants.Core.Extensions;
 using Piipan.Shared.Database;
+using Xunit;
 
 namespace Piipan.Participants.Core.Tests.Extensions
 {
@@ -17,7 +17,7 @@ namespace Piipan.Participants.Core.Tests.Extensions
             // Arrange
             var services = new ServiceCollection();
             services.AddLogging();
-            services.AddTransient<IDbConnectionFactory>(c => Mock.Of<IDbConnectionFactory>());
+            services.AddTransient<IDbConnectionFactory<ParticipantsDb>>(c => Mock.Of<IDbConnectionFactory<ParticipantsDb>>());
 
             // Act
             services.RegisterParticipantsServices();

--- a/shared/src/Piipan.Shared/Database/BasicPgConnectionFactory.cs
+++ b/shared/src/Piipan.Shared/Database/BasicPgConnectionFactory.cs
@@ -6,25 +6,25 @@ using Npgsql;
 
 namespace Piipan.Shared.Database
 {
-    public class BasicPgConnectionFactory : IDbConnectionFactory
+    public class BasicPgConnectionFactory<T> : IDbConnectionFactory<T>
     {
         public readonly DbProviderFactory _dbProviderFactory;
-        public const string DatabaseConnectionString = "DatabaseConnectionString";
+        public readonly string _connectionString;
 
-        public BasicPgConnectionFactory(DbProviderFactory dbProviderFactory)
+        public BasicPgConnectionFactory(DbProviderFactory dbProviderFactory, string connectionString)
         {
+            if (String.IsNullOrEmpty(connectionString))
+            {
+                throw new ArgumentException($"Connection string must be set to a value.");
+            }
+
             _dbProviderFactory = dbProviderFactory;
+            _connectionString = connectionString;
         }
 
         public async Task<IDbConnection> Build(string database = null)
         {
-            if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable(DatabaseConnectionString)))
-            {
-                throw new ArgumentException($"{DatabaseConnectionString} env variable must be set!");
-            }
-
-            var builder = new NpgsqlConnectionStringBuilder(
-                Environment.GetEnvironmentVariable(DatabaseConnectionString));
+            var builder = new NpgsqlConnectionStringBuilder(_connectionString);
 
             if (!String.IsNullOrEmpty(database))
             {

--- a/shared/src/Piipan.Shared/Database/IDbConnectionFactory.cs
+++ b/shared/src/Piipan.Shared/Database/IDbConnectionFactory.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Piipan.Shared.Database
 {
-    public interface IDbConnectionFactory
+    public interface IDbConnectionFactory<T>
     {
         Task<IDbConnection> Build(string database = null);
     }


### PR DESCRIPTION
- Adds DAO-specific placeholder types (e.g., `struct ParticipantsDb`)
- Updates implementations and tests across all subsystems

Note: OmniSharp caught some whitespace and import ordering. Toggling off whitespace changes might make review a little simpler.

Closes #1795 