### PR TITLE
Limit network egress for function apps

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -2,8 +2,7 @@
 
 ## Prerequisites
 
-- [Azure Command Line Interface (CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) >= 2.23.0 but <= 2.26.1
-    - A [defect was introduced in Azure CLI version 2.27.0](https://github.com/Azure/azure-cli/issues/19719#issuecomment-932617639). As of October 2021, the latest release (2.29.0) continues to have this problem.
+- [Azure Command Line Interface (CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) >= 2.30.0
 - [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 - [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download)
 - `bash` shell >= 4.1, `/dev/urandom` – included in macOS, Linux, Git for Windows, Azure Cloud Shell

--- a/iac/arm-templates/function-orch-match.json
+++ b/iac/arm-templates/function-orch-match.json
@@ -77,6 +77,7 @@
             "properties": {
                 "serverFarmId": "[resourceId(parameters('coreResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
                 "httpsOnly": true,
+                "vnetRouteAllEnabled": true,
                 "siteConfig": {
                     "ftpsState": "Disabled",
                     "alwaysOn": true,

--- a/iac/arm-templates/virtual-network.json
+++ b/iac/arm-templates/virtual-network.json
@@ -30,7 +30,13 @@
         "appServicePlanSubnetName": {
             "type": "string",
             "metadata": {
-                "description": "The name of the subnet etl apps will use."
+                "description": "The name of the subnet function apps will use."
+            }
+        },
+        "appServicePlanNsgName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the network security group associated with the function apps subnet."
             }
         }
     },
@@ -95,6 +101,9 @@
                         },
                         "appServicePlanSubnetName": {
                             "type": "string"
+                        },
+                        "appServicePlanNsgName": {
+                            "type": "string"
                         }
                     },
                     "variables": {},
@@ -106,6 +115,9 @@
                             "tags": "[parameters('resourceTags')]",
                             "name": "[parameters('vnetName')]",
                             "location": "[parameters('location')]",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('appServicePlanNsgName'))]"
+                            ],
                             "properties": {
                                 "addressSpace": {
                                     "addressPrefixes": [
@@ -139,7 +151,90 @@
                                                         "serviceName": "Microsoft.Web/serverfarms"
                                                     }
                                                 }
-                                            ]
+                                            ],
+                                            "networkSecurityGroup": {
+                                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('appServicePlanNsgName'))]"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        // Network security groups
+                        {
+                            "type": "Microsoft.Network/networkSecurityGroups",
+                            "apiVersion": "2020-11-01",
+                            "name": "[parameters('appServicePlanNsgName')]",
+                            "location": "[parameters('location')]",
+                            "tags": "[parameters('resourceTags')]",
+                            "properties": {
+                                "securityRules": [
+                                    {
+                                        "name": "AllowAAD",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "AzureActiveDirectory",
+                                            "access": "Allow",
+                                            "priority": 100,
+                                            "direction": "Outbound",
+                                            "sourcePortRanges": [],
+                                            "destinationPortRanges": [],
+                                            "sourceAddressPrefixes": [],
+                                            "destinationAddressPrefixes": []
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowStorage",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "Storage",
+                                            "access": "Allow",
+                                            "priority": 110,
+                                            "direction": "Outbound",
+                                            "sourcePortRanges": [],
+                                            "destinationPortRanges": [],
+                                            "sourceAddressPrefixes": [],
+                                            "destinationAddressPrefixes": []
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowAppService",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "AppService",
+                                            "access": "Allow",
+                                            "priority": 120,
+                                            "direction": "Outbound",
+                                            "sourcePortRanges": [],
+                                            "destinationPortRanges": [],
+                                            "sourceAddressPrefixes": [],
+                                            "destinationAddressPrefixes": []
+                                        }
+                                    },
+                                    {
+                                        "name": "DenyInternet",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "Internet",
+                                            "access": "Deny",
+                                            "priority": 130,
+                                            "direction": "Outbound",
+                                            "sourcePortRanges": [],
+                                            "destinationPortRanges": [],
+                                            "sourceAddressPrefixes": [],
+                                            "destinationAddressPrefixes": []
                                         }
                                     }
                                 ]
@@ -165,6 +260,9 @@
                     },
                     "appServicePlanSubnetName": {
                         "value": "[parameters('appServicePlanSubnetName')]"
+                    },
+                    "appServicePlanNsgName": {
+                        "value": "[parameters('appServicePlanNsgName')]"
                     }
                 }
             }

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -69,6 +69,10 @@ main () {
     --resource-group "$RESOURCE_GROUP" \
     --subnet "$FUNC_SUBNET_NAME" \
     --vnet "$VNET_NAME"
+  az webapp config set \
+    --name "$METRICS_COLLECT_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --vnet-route-all-enabled true
 
   # Allow only incoming traffic from Event Grid
   # Only set rule if it does not exist, to avoid error
@@ -183,6 +187,10 @@ main () {
     --resource-group "$RESOURCE_GROUP" \
     --subnet "$FUNC_SUBNET_NAME" \
     --vnet "$VNET_NAME"
+  az webapp config set \
+    --name "$METRICS_API_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --vnet-route-all-enabled true
 
   db_conn_str=$(pg_connection_string "$DB_SERVER_NAME" "$DB_NAME" "${METRICS_API_APP_NAME//-/_}")
   az functionapp config appsettings set \

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -93,7 +93,8 @@ main () {
         vnetName="$VNET_NAME" \
         peParticipantsSubnetName="$DB_SUBNET_NAME" \
         peCoreSubnetName="$DB_2_SUBNET_NAME" \
-        appServicePlanSubnetName="$FUNC_SUBNET_NAME"
+        appServicePlanSubnetName="$FUNC_SUBNET_NAME" \
+        appServicePlanNsgName="$FUNC_NSG_NAME"
 
   # Many CLI commands use a URI to identify nested resources; pre-compute the URI's prefix
   # for our default resource group
@@ -406,6 +407,10 @@ main () {
       --resource-group "$RESOURCE_GROUP" \
       --subnet "$FUNC_SUBNET_NAME" \
       --vnet "$VNET_NAME"
+    az webapp config set \
+      --name "$func_app" \
+      --resource-group "$RESOURCE_GROUP" \
+      --vnet-route-all-enabled true
 
     # Stream logs to Event Hub
     func_id=$(\

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -52,6 +52,7 @@ VNET_NAME=vnet-core-$ENV
 DB_SUBNET_NAME=snet-participants-$ENV # Subnet that participants database private endpoint uses
 DB_2_SUBNET_NAME=snet-core-$ENV # Subnet that core database private endpoint uses
 FUNC_SUBNET_NAME=snet-apps1-$ENV # Subnet function apps use
+FUNC_NSG_NAME=nsg-apps1-$ENV # Network security groups for function apps subnet
 PRIVATE_ENDPOINT_NAME=pe-participants-$ENV
 CORE_DB_PRIVATE_ENDPOINT_NAME=pe-core-$ENV
 


### PR DESCRIPTION
- Adds NSG to virtual network with necessary outbound rules for allowing deployment and execution
- Associates NSG with subnet used by function apps
- Enables setting on function apps to route all traffic through vnet
- Updates IaC docs to reflect new Azure CLI version requirement (setting `vnet-route-all-enabled` via the CLI is only possible with versions >=2.27.0 and only versions >=2.30.0 fix the previous issue with AAD administration for our PostgreSQL clusters)

Closes #1164