### PR TITLE
Limit egress traffic for dashboard and query tool

### DIFF
--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -80,7 +80,8 @@
                     "name": "ASPNETCORE_ENVIRONMENT",
                     "value": "[parameters('aspNetCoreEnvironment')]"
                 }
-            ]
+            ],
+            "vnetRouteAllEnabled": true
         },
         "systemTypeTag": {
             "SysType": "DashboardApp"

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -80,7 +80,8 @@
                     "name": "ASPNETCORE_ENVIRONMENT",
                     "value": "[parameters('aspNetCoreEnvironment')]"
                 }
-            ]
+            ],
+            "vnetRouteAllEnabled": true
         },
         "systemTypeTag": {
             "SysType": "QueryApp"

--- a/iac/arm-templates/virtual-network.json
+++ b/iac/arm-templates/virtual-network.json
@@ -27,16 +27,28 @@
                 "description": "The name of the subnet the second database will use."
             }
         },
-        "appServicePlanSubnetName": {
+        "funcAppServicePlanSubnetName": {
             "type": "string",
             "metadata": {
                 "description": "The name of the subnet function apps will use."
             }
         },
-        "appServicePlanNsgName": {
+        "funcAppServicePlanNsgName": {
             "type": "string",
             "metadata": {
                 "description": "The name of the network security group associated with the function apps subnet."
+            }
+        },
+        "webAppServicePlanSubnetName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the subnet web apps will use."
+            }
+        },
+        "webAppServicePlanNsgName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the network security group associated with the web apps subnet."
             }
         }
     },
@@ -69,11 +81,18 @@
                                 "description": "The address space for the first database subnet."
                             }
                         },
-                        "appServicePlanSubnetPrefix": {
+                        "funcAppServicePlanSubnetPrefix": {
                             "type": "string",
                             "defaultValue": "10.0.1.0/24",
                             "metadata": {
                                 "description": "The address space for the function app subnet."
+                            }
+                        },
+                        "webAppServicePlanSubnetPrefix": {
+                            "type": "string",
+                            "defaultValue": "10.0.3.0/24",
+                            "metadata": {
+                                "description": "The address space for the web app subnet."
                             }
                         },
                         "peCoreSubnetPrefix": {
@@ -99,10 +118,16 @@
                         "peCoreSubnetName": {
                             "type": "string"
                         },
-                        "appServicePlanSubnetName": {
+                        "funcAppServicePlanSubnetName": {
                             "type": "string"
                         },
-                        "appServicePlanNsgName": {
+                        "funcAppServicePlanNsgName": {
+                            "type": "string"
+                        },
+                        "webAppServicePlanSubnetName": {
+                            "type": "string"
+                        },
+                        "webAppServicePlanNsgName": {
                             "type": "string"
                         }
                     },
@@ -116,7 +141,8 @@
                             "name": "[parameters('vnetName')]",
                             "location": "[parameters('location')]",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('appServicePlanNsgName'))]"
+                                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('funcAppServicePlanNsgName'))]",
+                                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('webAppServicePlanNsgName'))]"
                             ],
                             "properties": {
                                 "addressSpace": {
@@ -140,9 +166,9 @@
                                         }
                                     },
                                     {
-                                        "name": "[parameters('appServicePlanSubnetName')]",
+                                        "name": "[parameters('funcAppServicePlanSubnetName')]",
                                         "properties": {
-                                            "addressPrefix": "[parameters('appServicePlanSubnetPrefix')]",
+                                            "addressPrefix": "[parameters('funcAppServicePlanSubnetPrefix')]",
                                             "privateEndpointNetworkPolicies": "Disabled",
                                             "delegations": [
                                                 {
@@ -153,7 +179,25 @@
                                                 }
                                             ],
                                             "networkSecurityGroup": {
-                                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('appServicePlanNsgName'))]"
+                                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('funcAppServicePlanNsgName'))]"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "[parameters('webAppServicePlanSubnetName')]",
+                                        "properties": {
+                                            "addressPrefix": "[parameters('webAppServicePlanSubnetPrefix')]",
+                                            "privateEndpointNetworkPolicies": "Disabled",
+                                            "delegations": [
+                                                {
+                                                    "name": "serverfarms",
+                                                    "properties": {
+                                                        "serviceName": "Microsoft.Web/serverfarms"
+                                                    }
+                                                }
+                                            ],
+                                            "networkSecurityGroup": {
+                                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('webAppServicePlanNsgName'))]"
                                             }
                                         }
                                     }
@@ -164,7 +208,7 @@
                         {
                             "type": "Microsoft.Network/networkSecurityGroups",
                             "apiVersion": "2020-11-01",
-                            "name": "[parameters('appServicePlanNsgName')]",
+                            "name": "[parameters('funcAppServicePlanNsgName')]",
                             "location": "[parameters('location')]",
                             "tags": "[parameters('resourceTags')]",
                             "properties": {
@@ -239,6 +283,68 @@
                                     }
                                 ]
                             }
+                        },
+                        {
+                            "type": "Microsoft.Network/networkSecurityGroups",
+                            "apiVersion": "2020-11-01",
+                            "name": "[parameters('webAppServicePlanNsgName')]",
+                            "location": "[parameters('location')]",
+                            "tags": "[parameters('resourceTags')]",
+                            "properties": {
+                                "securityRules": [
+                                    {
+                                        "name": "AllowAAD",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "AzureActiveDirectory",
+                                            "access": "Allow",
+                                            "priority": 100,
+                                            "direction": "Outbound",
+                                            "sourcePortRanges": [],
+                                            "destinationPortRanges": [],
+                                            "sourceAddressPrefixes": [],
+                                            "destinationAddressPrefixes": []
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowAppService",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "AppService",
+                                            "access": "Allow",
+                                            "priority": 110,
+                                            "direction": "Outbound",
+                                            "sourcePortRanges": [],
+                                            "destinationPortRanges": [],
+                                            "sourceAddressPrefixes": [],
+                                            "destinationAddressPrefixes": []
+                                        }
+                                    },
+                                    {
+                                        "name": "DenyInternet",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "Internet",
+                                            "access": "Deny",
+                                            "priority": 120,
+                                            "direction": "Outbound",
+                                            "sourcePortRanges": [],
+                                            "destinationPortRanges": [],
+                                            "sourceAddressPrefixes": [],
+                                            "destinationAddressPrefixes": []
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },
@@ -258,11 +364,17 @@
                     "peCoreSubnetName": {
                         "value": "[parameters('peCoreSubnetName')]"
                     },
-                    "appServicePlanSubnetName": {
-                        "value": "[parameters('appServicePlanSubnetName')]"
+                    "funcAppServicePlanSubnetName": {
+                        "value": "[parameters('funcAppServicePlanSubnetName')]"
                     },
-                    "appServicePlanNsgName": {
-                        "value": "[parameters('appServicePlanNsgName')]"
+                    "funcAppServicePlanNsgName": {
+                        "value": "[parameters('funcAppServicePlanNsgName')]"
+                    },
+                    "webAppServicePlanSubnetName": {
+                        "value": "[parameters('webAppServicePlanSubnetName')]"
+                    },
+                    "webAppServicePlanNsgName": {
+                        "value": "[parameters('webAppServicePlanNsgName')]"
                     }
                 }
             }

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -280,6 +280,19 @@ main () {
       frontDoorId="$front_door_id" \
       frontDoorUri="$front_door_uri"
 
+  echo "Integrating ${DASHBOARD_APP_NAME} into virtual network"
+  vnet_id=$(\
+    az network vnet show \
+      -n "$VNET_NAME" \
+      -g "$RESOURCE_GROUP" \
+      --query id \
+      -o tsv)
+  az functionapp vnet-integration add \
+    --name "$DASHBOARD_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --subnet "$WEBAPP_SUBNET_NAME" \
+    --vnet "$vnet_id"
+
   create_oidc_secret "$DASHBOARD_APP_NAME"
 
   script_completed

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -93,8 +93,10 @@ main () {
         vnetName="$VNET_NAME" \
         peParticipantsSubnetName="$DB_SUBNET_NAME" \
         peCoreSubnetName="$DB_2_SUBNET_NAME" \
-        appServicePlanSubnetName="$FUNC_SUBNET_NAME" \
-        appServicePlanNsgName="$FUNC_NSG_NAME"
+        funcAppServicePlanSubnetName="$FUNC_SUBNET_NAME" \
+        funcAppServicePlanNsgName="$FUNC_NSG_NAME" \
+        webAppServicePlanSubnetName="$WEBAPP_SUBNET_NAME" \
+        webAppServicePlanNsgName="$WEBAPP_NSG_NAME"
 
   # Many CLI commands use a URI to identify nested resources; pre-compute the URI's prefix
   # for our default resource group
@@ -511,6 +513,7 @@ main () {
       -o tsv)
   orch_api_uri="https://${orch_api_uri}/api/v1/"
 
+  echo "Deploying ${QUERY_TOOL_APP_NAME} resources"
   az deployment group create \
     --name "$QUERY_TOOL_APP_NAME" \
     --resource-group "$RESOURCE_GROUP" \
@@ -528,6 +531,13 @@ main () {
       aspNetCoreEnvironment="$PREFIX" \
       frontDoorId="$front_door_id" \
       frontDoorUri="$front_door_uri"
+
+  echo "Integrating ${QUERY_TOOL_APP_NAME} into virtual network"
+  az functionapp vnet-integration add \
+    --name "$QUERY_TOOL_APP_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --subnet "$WEBAPP_SUBNET_NAME" \
+    --vnet "$vnet_id"
 
   # Create a placeholder OIDC IdP secret
   create_oidc_secret "$QUERY_TOOL_APP_NAME"

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -53,6 +53,8 @@ DB_SUBNET_NAME=snet-participants-$ENV # Subnet that participants database privat
 DB_2_SUBNET_NAME=snet-core-$ENV # Subnet that core database private endpoint uses
 FUNC_SUBNET_NAME=snet-apps1-$ENV # Subnet function apps use
 FUNC_NSG_NAME=nsg-apps1-$ENV # Network security groups for function apps subnet
+WEBAPP_SUBNET_NAME=snet-apps2-$ENV # Subnet web apps use
+WEBAPP_NSG_NAME=nsg-apps2-$ENV # Network security groups for web apps subnet
 PRIVATE_ENDPOINT_NAME=pe-participants-$ENV
 CORE_DB_PRIVATE_ENDPOINT_NAME=pe-core-$ENV
 


### PR DESCRIPTION
- Add new subnet for app service apps
- Add network security group for app subnet that limits outbound traffic to only AAD and App Service
- Enable vnet integration for both web apps
- Enable setting to route all outbound web app traffic to vnet

Same approach as #2261, but locked down a little more by not allowing traffic to storage accounts.

Closes #1165 
Closes #1166