### PR TITLE
Update approach to App ID URI usage for App Service Authentication

### DIFF
--- a/docs/securing-internal-apis.md
+++ b/docs/securing-internal-apis.md
@@ -47,7 +47,7 @@ When an Azure resource is created it is effectively unknown to Azure AD. For the
 Once an API server is deployed in the form of an Azure Function, the following steps are taken to create and configure the necessary Azure AD resources to perform authentication and authorization:
 
 1. An [application object](#application-object) is created to function as the server's representative in Azure AD. By convention, the application object shares the same name as the server's Azure Function. The application object defines certain properties of the server for the purposes of authentication:
-    - *[Application ID URI](#application-id-uri)*: used by clients to request access tokens. By convention, the URI value is set to the base URL of the server's Azure Function *without a trailing slash*. E.g., `https://<azure-function-name>.azurewebsites.net`.
+    - *[Application ID URI](#application-id-uri)*: used by clients to request access tokens. The URI value is set to the [Azure AD default schema](https://docs.microsoft.com/en-us/azure/active-directory/develop/security-best-practices-for-app-registration#appid-uri-configuration) of `api://<app-id>`.
     - *[Application role](#application-roles)*: an application-specific role (e.g., `StateApi.Query` or `OrchestratorApi.Query`) that is assigned to authorized clients.
     - *Supported account types*: a setting which determines whether or not the server will accept clients originating from Azure AD tenants external to Piipan's. This setting is set to only allow clients originating within Piipan's tenant.
 1. A [service principal](#service-principal--in-the-context-of-an-application-object) is created to serve as the *local instance* of the application object in Piipan's Azure AD tenant (see the [application object definition](#application-object) for more detail on the distinction between global and local). The service principal inherits the application object's configuration/definitions (including name), and is configured with one additional detail:
@@ -145,7 +145,7 @@ All configuration is done through the associated Azure and Azure AD resources (e
 
 ### Application ID URI
 
-A valid URI string defined on an [application object](#application-object). This URI is used for specifying the resource from which the client should request an [access token]() for authenticating with the server. The URI can be set to any value unique to the tenant, but by convention it is set to the base URL of the server *without a trailing slash*. For example, if a server's API can be called from `https://functionfoo.azurewebsites.net/api/endpoint`, the application ID URI is set to `https://functionfoo.azurewebsites.net`.
+A valid URI string defined on an [application object](#application-object). This URI is used for specifying the resource from which the client should request an [access token](#access-token) for authenticating with the server. The URI can be set to any value unique to the tenant, but [Azure AD specifies a default value](https://docs.microsoft.com/en-us/azure/active-directory/develop/security-best-practices-for-app-registration#appid-uri-configuration) of `api://<app-id>` where `<app-id>` is the application object's application (aka "client") ID.
 
 **Managing the application ID URI**
 - *Portal*: Azure Active Directory > App registration > All applications > {your application object} > Application ID URI

--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -17,6 +17,9 @@
         "metricsApiUri": {
             "type": "string"
         },
+        "metricsApiAppId": {
+            "type": "string"
+        },
         "eventHubName": {
             "type": "String"
         },
@@ -75,6 +78,10 @@
                 {
                     "name": "MetricsApiUri",
                     "value": "[parameters('metricsApiUri')]"
+                },
+                {
+                    "name": "MetricsApiAppId",
+                    "value": "[parameters('metricsApiAppId')]"
                 },
                 {
                     "name": "ASPNETCORE_ENVIRONMENT",

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -17,6 +17,9 @@
         "OrchApiUri": {
             "type": "string"
         },
+        "OrchApiAppId": {
+            "type": "string"
+        },
         "eventHubName": {
             "type": "String"
         },
@@ -75,6 +78,10 @@
                 {
                     "name": "OrchApiUri",
                     "value": "[parameters('OrchApiUri')]"
+                },
+                {
+                    "name": "OrchApiAppId",
+                    "value": "[parameters('OrchApiAppId')]"
                 },
                 {
                     "name": "ASPNETCORE_ENVIRONMENT",

--- a/iac/create-apim.bash
+++ b/iac/create-apim.bash
@@ -93,16 +93,21 @@ main () {
   PUBLISHER_NAME='API Administrator'
   publisher_email=$2
   orch_name=$(get_resources "$ORCHESTRATOR_API_TAG" "$MATCH_RESOURCE_GROUP")
-  orch_base_url=$(\
+  orch_hostname=$(\
     az functionapp show \
       -g "$MATCH_RESOURCE_GROUP" \
       -n "$orch_name" \
       --query defaultHostName \
       --output tsv)
-  orch_base_url="https://${orch_base_url}"
-  orch_api_url="${orch_base_url}/api/v1"
+  orch_api_url="https://${orch_hostname}/api/v1"
+  orch_aad_client_id=$(\
+    az ad app list \
+      --display-name "${orch_name}" \
+      --filter "displayName eq '${orch_name}'" \
+      --query "[0].appId" \
+      --output tsv)
 
-  duppart_policy_xml=$(generate_policy apim-duppart-policy.xml "${orch_base_url}")
+  duppart_policy_xml=$(generate_policy apim-duppart-policy.xml "api://${orch_aad_client_id}")
 
   upload_policy_path=$(dirname "$0")/apim-bulkupload-policy.xml
   upload_policy_xml=$(< "$upload_policy_path")

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -195,6 +195,11 @@ main () {
     --storage-account "$API_APP_STORAGE_NAME" \
     --assign-identity "[system]" \
     --tags Project=$PROJECT_TAG
+  
+  # Create an Active Directory app registration associated with the app.
+  az ad app create \
+    --display-name "$METRICS_API_APP_NAME" \
+    --available-to-other-tenants false
 
   # Integrate function app into Virtual Network
   echo "Integrating $METRICS_API_APP_NAME into virtual network"
@@ -275,6 +280,12 @@ main () {
     --query "defaultHostName" \
     --output tsv)
   metrics_api_uri="https://${metrics_api_hostname}/api/"
+  metrics_api_app_id=$(\
+    az ad app list \
+      --display-name "${METRICS_API_APP_NAME}" \
+      --filter "displayName eq '${METRICS_API_APP_NAME}'" \
+      --query "[0].appId" \
+      --output tsv)
 
   # Create App Service resources for dashboard app
   echo "Creating App Service resources for dashboard app"
@@ -288,6 +299,7 @@ main () {
       appName="$DASHBOARD_APP_NAME" \
       servicePlan="$APP_SERVICE_PLAN" \
       metricsApiUri="$metrics_api_uri" \
+      metricsApiAppId="$metrics_api_app_id" \
       eventHubName="$EVENT_HUB_NAME" \
       idpOidcConfigUri="$DASHBOARD_APP_IDP_OIDC_CONFIG_URI" \
       idpOidcScopes="$DASHBOARD_APP_IDP_OIDC_SCOPES" \

--- a/match/src/Piipan.Match/Piipan.Match.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Client/Extensions/ServiceCollectionExtensions.cs
@@ -15,8 +15,8 @@ namespace Piipan.Match.Client.Extensions
         {
             serviceCollection.Configure<AzureTokenProviderOptions<MatchClient>>(options =>
             {
-                var uri = new Uri(Environment.GetEnvironmentVariable("OrchApiUri"));
-                options.ResourceUri = $"{uri.Scheme}://{uri.Host}";
+                var appId = Environment.GetEnvironmentVariable("OrchApiAppId");
+                options.ResourceUri = $"api://{appId}";
             });
 
             if (env.IsDevelopment())

--- a/match/tools/test-orch-match-api.bash
+++ b/match/tools/test-orch-match-api.bash
@@ -15,10 +15,10 @@ source "$(dirname "$0")"/../../tools/common.bash || exit
 
 MATCH_API_FUNC_NAME="find_matches"
 
-# Hash digest for farrington,10/13/31,000-12-3456
+# Hash digest for farrington,10/13/31,425-46-5417
 JSON='{
     "data": [{
-      "lds_hash": "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458"
+      "lds_hash": "a3cab51dd68da2ac3e5508c8b0ee514ada03b9f166f7035b4ac26d9c56aa7bf9d6271e44c0064337a01b558ff63fd282de14eead7e8d5a613898b700589bcdec"
     }]
 }'
 
@@ -33,18 +33,17 @@ main () {
 
   name=$(get_resources "$ORCHESTRATOR_API_TAG" "$MATCH_RESOURCE_GROUP")
 
-  resource_uri=$(\
-    az functionapp show \
-      -g "$MATCH_RESOURCE_GROUP" \
-      -n "$name" \
-      --query defaultHostName \
-      -o tsv)
-  resource_uri="https://${resource_uri}"
+  aad_app_id=$(\
+    az ad app list \
+      --display-name "${name}" \
+      --filter "displayName eq '${name}'" \
+      --query "[0].appId" \
+      --output tsv)
 
-  echo "Retrieving access token from ${resource_uri}"
+  echo "Retrieving access token from ${name}"
   token=$(\
     az account get-access-token \
-      --resource "${resource_uri}" \
+      --resource "api://${aad_app_id}" \
       --query accessToken \
       -o tsv
   )
@@ -63,6 +62,7 @@ main () {
     --header "Authorization: Bearer ${token}" \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json' \
+    --header 'X-Initiating-State: ea' \
     --data-raw "$JSON" \
     --include
 

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Client/Extensions/ServiceCollectionExtensions.cs
@@ -15,13 +15,13 @@ namespace Piipan.Metrics.Client.Extensions
         {
             serviceCollection.Configure<AzureTokenProviderOptions<ParticipantUploadClient>>(options =>
             {
-                var uri = new Uri(Environment.GetEnvironmentVariable("MetricsApiUri"));
-                options.ResourceUri = $"{uri.Scheme}://{uri.Host}"; 
+                var appId = Environment.GetEnvironmentVariable("MetricsApiAppId");
+                options.ResourceUri = $"api://{appId}";
             });
 
             if (env.IsDevelopment())
             {
-                 serviceCollection.AddTransient<TokenCredential, AzureCliCredential>();
+                serviceCollection.AddTransient<TokenCredential, AzureCliCredential>();
             }
             else
             {

--- a/metrics/tools/test-metricsapi.bash
+++ b/metrics/tools/test-metricsapi.bash
@@ -20,8 +20,13 @@ main () {
   source "$(dirname "$0")"/../../iac/iac-common.bash
   verify_cloud
 
-  domain=$(web_app_host_suffix)
-  token=$(az account get-access-token --resource "https://${METRICS_API_APP_NAME}${domain}" --query accessToken -o tsv)
+  app_id=$(\
+    az ad app list \
+      --display-name "${METRICS_API_APP_NAME}" \
+      --filter "displayName eq '${METRICS_API_APP_NAME}'" \
+      --query "[0].appId" \
+      --output tsv)
+  token=$(az account get-access-token --resource "api://${app_id}" --query accessToken -o tsv)
 
   # grab url for metrics api
   function_uri=$(az functionapp function show \


### PR DESCRIPTION
After this update, clients of our internal APIs secured with app service authentication must request an access token from the API using the URI `api://<aad-app-id>`, consistent with [Microsoft's new guidance](https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-breaking-changes#appid-uri-in-single-tenant-applications-will-require-use-of-default-scheme-or-verified-domains). Before, clients requested a token from the hostname of the API, e.g. `https://<app-name>.azurewebsites.net`.

- Change sequencing of AAD app registration so it is available for subsequent configuration later in the IaC process.
- Update easy auth config to use new `api://<app-id>` format
- Remove unnecessary easy auth config settings
- Update APIM to use new URI format in DupPart policy
- Add new `AppId` application setting for dashboard and query tool
- Update metrics and orchestrator match tools to use new URI format
- Update documentation

Closes #2289 