### PR TITLE
Deny default access to Orchestrator function storage account

### DIFF
--- a/iac/arm-templates/function-orch-match.json
+++ b/iac/arm-templates/function-orch-match.json
@@ -34,6 +34,12 @@
         },
         "states": {
             "type": "String"
+        },
+        "vnet": {
+            "type": "string"
+        },
+        "subnet": {
+            "type": "string"
         }
     },
     "variables": {
@@ -59,7 +65,19 @@
             "sku": {
                 "name": "[variables('storageAccountType')]"
             },
-            "kind": "Storage"
+            "kind": "StorageV2",
+            "properties": {
+                "supportsHttpsTrafficOnly": true,
+                "networkAcls": {
+                    "defaultAction": "Deny",
+                    "virtualNetworkRules": [
+                        {
+                            "id": "[concat(parameters('vnet'),  '/subnets/', parameters('subnet'))]",
+                            "action": "Allow"
+                        }
+                    ]
+                }
+            }
         },
         {
             "type": "Microsoft.Web/sites",
@@ -144,6 +162,10 @@
                         {
                             "name": "States",
                             "value": "[parameters('states')]"
+                        },
+                        {
+                            "name": "WEBSITE_CONTENTOVERVNET",
+                            "value": "1"
                         }
                     ]
                 }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -323,7 +323,12 @@ main () {
       cloudName="$CLOUD_NAME" \
       states="$state_abbrs" \
       coreResourceGroup="$RESOURCE_GROUP" \
-      eventHubName="$EVENT_HUB_NAME"
+      eventHubName="$EVENT_HUB_NAME" \
+      vnet="$VNET_ID" \
+      subnet="$FUNC_SUBNET_NAME"
+
+  #publish function app
+  try_run "func azure functionapp publish ${ORCHESTRATOR_FUNC_APP_NAME} --dotnet" 7 "../match/src/Piipan.Match/Piipan.Match.Func.Api"
 
   echo "Integrating ${ORCHESTRATOR_FUNC_APP_NAME} into virtual network"
   az functionapp vnet-integration add \
@@ -331,32 +336,6 @@ main () {
     --resource-group "$MATCH_RESOURCE_GROUP" \
     --subnet "$FUNC_SUBNET_NAME" \
     --vnet "$VNET_ID"
-
-  az storage account update \
-    --name "$ORCHESTRATOR_FUNC_APP_STORAGE_NAME" \
-    --resource-group "$MATCH_RESOURCE_GROUP" \
-    --default-action Allow
-
-  #publish function app
-  try_run "func azure functionapp publish ${ORCHESTRATOR_FUNC_APP_NAME} --dotnet" 7 "../match/src/Piipan.Match/Piipan.Match.Func.Api"
-
-  az storage account update \
-      --name "$ORCHESTRATOR_FUNC_APP_STORAGE_NAME" \
-      --resource-group "$MATCH_RESOURCE_GROUP" \
-      --default-action Deny
-
-  func_subnet_id=$(\
-    az network vnet subnet show \
-      --resource-group rg-core-dev \
-      --vnet-name vnet-core-dev \
-      --name snet-apps1-dev \
-      --query id \
-      --output tsv)
-
-  az storage account network-rule add \
-    --account-name "$ORCHESTRATOR_FUNC_APP_STORAGE_NAME" \
-    --resource-group "$MATCH_RESOURCE_GROUP" \
-    --subnet "$func_subnet_id"
 
   ./config-managed-role.bash "$ORCHESTRATOR_FUNC_APP_NAME" "$MATCH_RESOURCE_GROUP" "${PG_AAD_ADMIN}@${PG_SERVER_NAME}"
 


### PR DESCRIPTION
Closes #2324 
Related to #2258 

Configures the orchestrator function app storage account to disallow default network access. Access is granted only to `vnet-core-$ENV/snet-apps1-$ENV`.

This case is slightly different from the other storage accounts, in that this account is part of the `rg-match` resource group, as opposed to `rg-core`. This seems to cause issues when attempting to publish the function app while network access restrictions are in place. To get around these issues, we temporarily disable the network firewall while executing the function app publish step.