### PR TITLE
Fix: switch creation order for key vault and event hub monitoring

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -111,18 +111,6 @@ main () {
       --query id \
       -o tsv)
 
-  # Create a key vault which will store credentials for use in other templates
-  az deployment group create \
-    --name "$VAULT_NAME" \
-    --resource-group "$RESOURCE_GROUP" \
-    --template-file ./arm-templates/key-vault.json \
-    --parameters \
-      name="$VAULT_NAME" \
-      location="$LOCATION" \
-      objectId="$CURRENT_USER_OBJID" \
-      resourceTags="$RESOURCE_TAGS" \
-      eventHubName="$EVENT_HUB_NAME"
-
   # Create an Event Hub namespace and hub where resource logs will be streamed,
   # as well as an application registration that can be used to read logs
   siem_app_id=$(\
@@ -155,6 +143,18 @@ main () {
       env="$ENV" \
       prefix="$PREFIX" \
       receiverId="$siem_app_id"
+
+  # Create a key vault which will store credentials for use in other templates
+  az deployment group create \
+    --name "$VAULT_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --template-file ./arm-templates/key-vault.json \
+    --parameters \
+      name="$VAULT_NAME" \
+      location="$LOCATION" \
+      objectId="$CURRENT_USER_OBJID" \
+      resourceTags="$RESOURCE_TAGS" \
+      eventHubName="$EVENT_HUB_NAME"
 
   # Send Policy events from subscription's activity log to event hub
   az deployment sub create \


### PR DESCRIPTION
Fixes a bug introduced in #2352 

Now that the key vault relies on event hub monitoring, event hub monitoring should be created before the key vault.

