### PR TITLE
Re-sequence orchestrator networking config in IaC

### DIFF
--- a/iac/arm-templates/function-orch-match.json
+++ b/iac/arm-templates/function-orch-match.json
@@ -34,12 +34,6 @@
         },
         "states": {
             "type": "String"
-        },
-        "vnet": {
-            "type": "string"
-        },
-        "subnet": {
-            "type": "string"
         }
     },
     "variables": {
@@ -67,16 +61,7 @@
             },
             "kind": "StorageV2",
             "properties": {
-                "supportsHttpsTrafficOnly": true,
-                "networkAcls": {
-                    "defaultAction": "Deny",
-                    "virtualNetworkRules": [
-                        {
-                            "id": "[concat(parameters('vnet'),  '/subnets/', parameters('subnet'))]",
-                            "action": "Allow"
-                        }
-                    ]
-                }
+                "supportsHttpsTrafficOnly": true
             }
         },
         {
@@ -95,7 +80,6 @@
             "properties": {
                 "serverFarmId": "[resourceId(parameters('coreResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
                 "httpsOnly": true,
-                "vnetRouteAllEnabled": true,
                 "siteConfig": {
                     "ftpsState": "Disabled",
                     "alwaysOn": true,
@@ -162,10 +146,6 @@
                         {
                             "name": "States",
                             "value": "[parameters('states')]"
-                        },
-                        {
-                            "name": "WEBSITE_CONTENTOVERVNET",
-                            "value": "1"
                         }
                     ]
                 }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -306,7 +306,9 @@ main () {
   state_abbrs=${state_abbrs:1}
 
   # Create orchestrator-level Function app using ARM template and
-  # deploy project code using functions core tools.
+  # deploy project code using functions core tools. Networking
+  # restrictions for the function app and storage account are added
+  # in a separate step to avoid deployment and publishing issues.
   db_conn_str=$(pg_connection_string "$PG_SERVER_NAME" "$DATABASE_PLACEHOLDER" "$ORCHESTRATOR_FUNC_APP_NAME")
   collab_db_conn_str=$(pg_connection_string "$CORE_DB_SERVER_NAME" "$COLLAB_DB_NAME" "$ORCHESTRATOR_FUNC_APP_NAME")
   az deployment group create \
@@ -324,12 +326,28 @@ main () {
       cloudName="$CLOUD_NAME" \
       states="$state_abbrs" \
       coreResourceGroup="$RESOURCE_GROUP" \
-      eventHubName="$EVENT_HUB_NAME" \
-      vnet="$VNET_ID" \
-      subnet="$FUNC_SUBNET_NAME"
+      eventHubName="$EVENT_HUB_NAME"
 
-  #publish function app
+  # Publish function app
   try_run "func azure functionapp publish ${ORCHESTRATOR_FUNC_APP_NAME} --dotnet" 7 "../match/src/Piipan.Match/Piipan.Match.Func.Api"
+
+  echo "Allowing $VNET_NAME to access $ORCHESTRATOR_FUNC_APP_STORAGE_NAME"
+  # Subnet ID is needed when vnet and storage are in different resource groups
+  func_subnet_id=$(\
+    az network vnet subnet show \
+      --vnet-name "$VNET_NAME" \
+      --name "$FUNC_SUBNET_NAME" \
+      --resource-group "$RESOURCE_GROUP" \
+      --query id \
+      -o tsv)
+  az storage account network-rule add \
+    --account-name "$ORCHESTRATOR_FUNC_APP_STORAGE_NAME" \
+    --resource-group "$MATCH_RESOURCE_GROUP" \
+    --subnet "$func_subnet_id"
+  az storage account update \
+    --name "$ORCHESTRATOR_FUNC_APP_STORAGE_NAME" \
+    --resource-group "$MATCH_RESOURCE_GROUP" \
+    --default-action Deny
 
   echo "Integrating ${ORCHESTRATOR_FUNC_APP_NAME} into virtual network"
   az functionapp vnet-integration add \
@@ -337,6 +355,12 @@ main () {
     --resource-group "$MATCH_RESOURCE_GROUP" \
     --subnet "$FUNC_SUBNET_NAME" \
     --vnet "$VNET_ID"
+  az functionapp config appsettings set \
+    --name "$ORCHESTRATOR_FUNC_APP_NAME" \
+    --resource-group "$MATCH_RESOURCE_GROUP" \
+    --settings \
+      WEBSITE_CONTENTOVERVNET=1 \
+      WEBSITE_VNET_ROUTE_ALL=1
 
   # Create an Active Directory app registration associated with the app.
   # Used by subsequent resources to configure auth


### PR DESCRIPTION
Apply networking restrictions after base function app and backing storage account are deployed.

Loosely follows Microsoft's [guide for restricting traffic to a function app's storage account](https://docs.microsoft.com/en-us/azure/azure-functions/configure-networking-how-to#restrict-your-storage-account-to-a-virtual-network). (But does not create multiple storage accounts and lets ARM handle file share creation/configuration).

This brings the ordering of the orchestrator deployment closer to [that of our ETL apps](https://github.com/18F/piipan/blob/dev/iac/create-resources.bash#L393-L430). One key difference remains: the ETL apps are able to deploy the storage account with the [`networkAcls` in place](https://github.com/18F/piipan/blob/dev/iac/arm-templates/function-storage.json#L37-L45). I was only able to get the orchestrator working if those rules were added as a [second step](https://github.com/18F/piipan/blob/61babde0b58f497918b7710a39dcf896992e7fa1/iac/create-resources.bash#L332-L349). I wasn't able to reconcile this difference. My best guess is Azure's resource manager performs some additional steps when deploying a storage <-> function app pair from a single ARM template, and this is different than what happens when using the AZ CLI to deploy the pair in separate steps.

Tested against a fresh `tts/mrk` environment. Deployment was successful and tests passed. Subsequent deployments and publishes to the existing environment were also successful. Environment is still available for review.

Closes #2410 