### PR TITLE
Use VerifyFull SSL mode in PostgreSQL connection strings

### DIFF
--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -121,7 +121,7 @@ pg_connection_string () {
     base=${base/.postgres.database.azure.com/.postgres.database.usgovcloudapi.net}
   fi
 
-  echo "${base}Ssl Mode=Require;"
+  echo "${base}Ssl Mode=VerifyFull;"
 }
 
 # Verify that the expected Azure environment is the active cloud


### PR DESCRIPTION
Closes #2495 

Prior to this change and after #2463, applications using PostgreSQL database connection strings with `Ssl Mode=Required` would throw:

```
NpgsqlException

To validate server certificates, please use VerifyFull or VerifyCA instead of Require. To disable validation, explicitly set 'Trust Server Certificate' to true. See https://www.npgsql.org/doc/release-notes/6.0.html for more details.
```