### PR TITLE
Dispose DbConnections to allow connection pooling

### DIFF
--- a/etl/tests/Piipan.Etl.Func.BulkUpload.IntegrationTests/BulkUploadIntegrationTests.cs
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.IntegrationTests/BulkUploadIntegrationTests.cs
@@ -34,7 +34,6 @@ namespace Piipan.Etl.Func.BulkUpload.IntegrationTests
                     {
                         var connection = Factory.CreateConnection();
                         connection.ConnectionString = ConnectionString;
-                        connection.Open();
                         return connection;
                     });
                 return factory.Object;

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
@@ -67,13 +67,14 @@ namespace Piipan.Match.Core.DataAccessObjects
                 RETURNING match_id;
             ";
 
-            var connection = await _dbConnectionFactory.Build();
-
             // Match IDs are randomly generated at the service level and may result
             // in unique constraint violations in the rare case of a collision.
             try
             {
-                return await connection.ExecuteScalarAsync<string>(sql, record);
+                using (var connection = await _dbConnectionFactory.Build())
+                {
+                    return await connection.ExecuteScalarAsync<string>(sql, record);
+                }
             }
             catch (PostgresException ex)
             {
@@ -108,9 +109,10 @@ namespace Piipan.Match.Core.DataAccessObjects
                     states @> @States AND
                     states <@ @States;";
 
-            var connection = await _dbConnectionFactory.Build();
-
-            return await connection.QueryAsync<MatchRecordDbo>(sql, record);
+            using (var connection = await _dbConnectionFactory.Build())
+            {
+                return await connection.QueryAsync<MatchRecordDbo>(sql, record);
+            }
         }
     }
 }

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDao.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDao.cs
@@ -75,6 +75,8 @@ namespace Piipan.Participants.Core.DataAccessObjects
 
             using (var connection = await _dbConnectionFactory.Build() as DbConnection)
             {
+                // A performance optimization. Dapper will open/close around invidual
+                // calls if it is passed a closed connection. 
                 await connection.OpenAsync();
                 foreach (var participant in participants)
                 {

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/UploadDao.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/UploadDao.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using System.Threading.Tasks;
 using Dapper;
 using Piipan.Participants.Api.Models;
@@ -17,33 +18,38 @@ namespace Piipan.Participants.Core.DataAccessObjects
 
         public async Task<IUpload> GetLatestUpload(string state = null)
         {
-            var connection = await _dbConnectionFactory.Build(state);
-            return await connection
-                .QuerySingleAsync<UploadDbo>(@"
+            using (var connection = await _dbConnectionFactory.Build(state))
+            {
+                return await connection
+                    .QuerySingleAsync<UploadDbo>(@"
                     SELECT id, created_at, publisher
                     FROM uploads
                     ORDER BY id DESC
                     LIMIT 1");
+            }
         }
 
         public async Task<IUpload> AddUpload()
         {
-            var connection = await _dbConnectionFactory.Build();
-            var tx = connection.BeginTransaction();
+            using (var connection = await _dbConnectionFactory.Build() as DbConnection)
+            {
+                await connection.OpenAsync();
+                var tx = connection.BeginTransaction();
 
-            await connection.ExecuteAsync(@"
+                await connection.ExecuteAsync(@"
                 INSERT INTO uploads (created_at, publisher)
                 VALUES (now() at time zone 'utc', current_user)");
 
-            var upload = await connection.QuerySingleAsync<UploadDbo>(@"
+                var upload = await connection.QuerySingleAsync<UploadDbo>(@"
                     SELECT id, created_at, publisher
                     FROM uploads
                     ORDER BY id DESC
                     LIMIT 1");
 
-            tx.Commit();
+                tx.Commit();
 
-            return upload;
+                return upload;
+            }
         }
     }
 }

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantDaoTests.cs
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantDaoTests.cs
@@ -62,7 +62,6 @@ namespace Piipan.Participants.Core.IntegrationTests
                 {
                     var conn = Factory.CreateConnection();
                     conn.ConnectionString = ConnectionString;
-                    conn.Open();
                     return conn;
                 });
 

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/UploadDaoTests.cs
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/UploadDaoTests.cs
@@ -20,7 +20,6 @@ namespace Piipan.Participants.Core.IntegrationTests
                 {
                     var conn = Factory.CreateConnection();
                     conn.ConnectionString = ConnectionString;
-                    conn.Open();
                     return conn;
                 });
 

--- a/shared/src/Piipan.Shared/Database/AzurePgConnectionFactory.cs
+++ b/shared/src/Piipan.Shared/Database/AzurePgConnectionFactory.cs
@@ -79,7 +79,6 @@ namespace Piipan.Shared.Database
             var connection = _dbProviderFactory.CreateConnection();
 
             connection.ConnectionString = builder.ConnectionString;
-            await connection.OpenAsync();
 
             return connection;
         }

--- a/shared/src/Piipan.Shared/Database/BasicPgConnectionFactory.cs
+++ b/shared/src/Piipan.Shared/Database/BasicPgConnectionFactory.cs
@@ -31,10 +31,9 @@ namespace Piipan.Shared.Database
                 builder.Database = database;
             }
 
-            var connection = _dbProviderFactory.CreateConnection();
+            var connection = await Task.FromResult(_dbProviderFactory.CreateConnection());
 
             connection.ConnectionString = builder.ConnectionString;
-            await connection.OpenAsync();
 
             return connection;
         }


### PR DESCRIPTION
- Return unopened connections from DB connection factories
- Wrap queries in `using` to dispose connections
- Lets Dapper manage opening and closing of one-off queries

Observed the issue by connecting to the database, running match queries, and using `select count(*) from pg_stat_activity;` to see any affect on the number of open connections. Prior to this change the number of open connections would climb after each query. With this change in place, the number is relatively stable (as expected).

Since all the `using` blocks affect indentation, hiding whitespace changes is helpful for review.

Closes #2499