### PR TITLE
Added storage redundancy configuration. It close #891 and #892

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .history/
 iac/env/tts/eth.bash
 iac/env/tts/eth1.bash
+iac/env/tts/eth2.bash

--- a/iac/arm-templates/blob-storage.json
+++ b/iac/arm-templates/blob-storage.json
@@ -33,7 +33,7 @@
             "location": "[parameters('location')]",
             "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
             "sku": {
-                "name": "Standard_LRS"
+                "name": "Standard_ZRS"
             },
             "kind": "StorageV2",
             "properties": {

--- a/iac/arm-templates/blob-storage.json
+++ b/iac/arm-templates/blob-storage.json
@@ -16,6 +16,9 @@
         },
         "subnet": {
             "type": "string"
+        },
+        "sku": {
+            "type": "string"
         }
     },
     "variables": {
@@ -33,7 +36,7 @@
             "location": "[parameters('location')]",
             "tags": "[union(parameters('resourceTags'), variables('systemTypeTag'))]",
             "sku": {
-                "name": "Standard_ZRS"
+                "name": "[parameters('sku')]"
             },
             "kind": "StorageV2",
             "properties": {

--- a/iac/arm-templates/function-storage.json
+++ b/iac/arm-templates/function-storage.json
@@ -16,6 +16,9 @@
         },
         "subnet": {
             "type": "string"
+        },
+        "sku": {
+            "type": "string"
         }
     },
     "variables": {
@@ -29,7 +32,8 @@
             "location": "[parameters('location')]",
             "tags": "[parameters('resourceTags')]",
             "sku": {
-                "name": "Standard_ZRS"
+                "name": "[parameters('sku')]"
+                // "Standard_ZRS"
             },
             "kind": "StorageV2",
             "properties": {

--- a/iac/arm-templates/function-storage.json
+++ b/iac/arm-templates/function-storage.json
@@ -29,7 +29,7 @@
             "location": "[parameters('location')]",
             "tags": "[parameters('resourceTags')]",
             "sku": {
-                "name": "Standard_LRS"
+                "name": "Standard_ZRS"
             },
             "kind": "StorageV2",
             "properties": {

--- a/iac/arm-templates/function-storage.json
+++ b/iac/arm-templates/function-storage.json
@@ -33,7 +33,6 @@
             "tags": "[parameters('resourceTags')]",
             "sku": {
                 "name": "[parameters('sku')]"
-                // "Standard_ZRS"
             },
             "kind": "StorageV2",
             "properties": {

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -48,7 +48,7 @@ main () {
     --location "$LOCATION" \
     --resource-group "$RESOURCE_GROUP" \
     --default-action "Deny" \
-    --sku Standard_LRS \
+    --sku $STORAGE_SKU \
     --tags Project=$PROJECT_TAG
 
   echo "Allowing $VNET_NAME to access $COLLECT_STORAGE_NAME"
@@ -174,7 +174,7 @@ main () {
     --location "$LOCATION" \
     --resource-group "$RESOURCE_GROUP" \
     --default-action "Deny" \
-    --sku Standard_LRS \
+    --sku "$STORAGE_SKU" \
     --tags Project=$PROJECT_TAG
 
   echo "Allowing $VNET_NAME to access $API_APP_STORAGE_NAME"

--- a/iac/create-metrics-resources.bash
+++ b/iac/create-metrics-resources.bash
@@ -48,7 +48,7 @@ main () {
     --location "$LOCATION" \
     --resource-group "$RESOURCE_GROUP" \
     --default-action "Deny" \
-    --sku $STORAGE_SKU \
+    --sku "$STORAGE_SKU" \
     --tags Project=$PROJECT_TAG
 
   echo "Allowing $VNET_NAME to access $COLLECT_STORAGE_NAME"

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -180,7 +180,8 @@ main () {
         resourceTags="$RESOURCE_TAGS" \
         location="$LOCATION" \
         vnet="$VNET_ID" \
-        subnet="$FUNC_SUBNET_NAME"
+        subnet="$FUNC_SUBNET_NAME" \
+        sku="$STORAGE_SKU"
   done < states.csv
 
   # Avoid echoing passwords in a manner that may show up in process listing,
@@ -426,7 +427,8 @@ main () {
         resourceTags="$RESOURCE_TAGS" \
         location="$LOCATION" \
         vnet="$VNET_ID" \
-        subnet="$FUNC_SUBNET_NAME"
+        subnet="$FUNC_SUBNET_NAME" \
+        sku="$STORAGE_SKU"
 
     # Even though the OS *should* be abstracted away at the Function level, Azure
     # portal has oddities/limitations when using Linux -- lets just get it

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -158,7 +158,7 @@ main () {
 
   # Send Policy events from subscription's activity log to event hub
   az deployment sub create \
-    --name activity-log-diagnostics \
+    --name activity-log-diagnostics-$LOCATION \
     --location "$LOCATION" \
     --template-file ./arm-templates/activity-log.json \
     --parameters \

--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -4,7 +4,7 @@
 ENV=$(basename "${BASH_SOURCE%.*}")
 
 # Default location
-LOCATION=westus
+LOCATION=westus2
 
 # Default resource group
 RESOURCE_GROUP=rg-core-$ENV
@@ -33,3 +33,7 @@ QUERY_TOOL_APP_IDP_CLIENT_ID=a8e3c164-77a9-45fd-9950-cc9862aa774a
 
 # SIEM tool app registration name
 SIEM_RECEIVER=$PREFIX-siem-tool-$ENV
+
+# Azure Storage SKU
+STORAGE_SKU="Standard_ZRS" # Standard Zone Redundant Storage
+# STORAGE_SKU="Standard_ZRS" # Standard Locally Redundant Storage (Use this when ZRS is not avilable in the region)

--- a/iac/env/tts/dev.bash
+++ b/iac/env/tts/dev.bash
@@ -34,6 +34,6 @@ QUERY_TOOL_APP_IDP_CLIENT_ID=a8e3c164-77a9-45fd-9950-cc9862aa774a
 # SIEM tool app registration name
 SIEM_RECEIVER=$PREFIX-siem-tool-$ENV
 
-# Azure Storage SKU
+# Azure Storage SKU for per-state storage accounts and storage accounts backing function apps
 STORAGE_SKU="Standard_ZRS" # Standard Zone Redundant Storage
-# STORAGE_SKU="Standard_ZRS" # Standard Locally Redundant Storage (Use this when ZRS is not avilable in the region)
+# STORAGE_SKU="Standard_LRS" # Standard Locally Redundant Storage (Use this when ZRS is not available in the region)


### PR DESCRIPTION
## What’s changing?

- Azure Storage sku to add region redundancy
- Changed to the activity monitor name, given that when the resources are changed to another region, the creation of the activity monitor will fail because it is a global resource. Added LOCATION as part of the name.

## Why?

Explained on #891 and #892

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [X] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Test
This was tested on `tts/eth2` deployed to westus2