### PR TITLE
Update docs to specify required Node.js version

### DIFF
--- a/dashboard/docs/dashboard.md
+++ b/dashboard/docs/dashboard.md
@@ -2,6 +2,7 @@
 
 ## Prerequisites
 - [.NET Core SDK 3.1](https://dotnet.microsoft.com/download)
+- [Node.js](https://nodejs.org/en/) >= 12.20.0 and `npm` [Node Package Manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for compiling assets during build
 
 ## Local development
 To run the app locally:

--- a/docs/iac.md
+++ b/docs/iac.md
@@ -7,7 +7,7 @@
 - [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download)
 - `bash` shell >= 4.1, `/dev/urandom` – included in macOS, Linux, Git for Windows, Azure Cloud Shell
 - `psql` client for PostgreSQL – included in Azure Cloud Shell
-- [Node.js](https://nodejs.org/en/) and `npm` [Node Package Manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for compiling assets during the build of ASP.NET Core web applications
+- [Node.js](https://nodejs.org/en/) >= 12.20.0 and `npm` [Node Package Manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for compiling assets during the build of ASP.NET Core web applications
 
 ## Steps
 To (re)create the Azure resources that `piipan` uses:

--- a/query-tool/docs/query-tool.md
+++ b/query-tool/docs/query-tool.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 - [.NET Core SDK](https://dotnet.microsoft.com/download)
-- [npm](https://npmjs.com)
+- [Node.js](https://nodejs.org/en/) >= 12.20.0 and `npm` [Node Package Manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for compiling assets during build
 
 ## Local development
 To run the app locally:


### PR DESCRIPTION
## What’s changing?

- Update web apps docs
- Update IaC doc

## Why?

Closes #2521

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
