### PR TITLE
Subsystem unit testing strategy ADR

### DIFF
--- a/docs/adr/0023-subsystem-unit-testing-strategy.md
+++ b/docs/adr/0023-subsystem-unit-testing-strategy.md
@@ -1,0 +1,25 @@
+# 23. Subsystem unit testing strategy
+
+Date: 2022-01-03
+
+## Status
+
+Accepted
+
+## Context
+
+Piipan is made up of six primary subsystems (`dashboard`, `etl`, `match`, `metrics`, `participants`, `query-tool`), each of which are modeled on our standard subsystem software architecture. In an effort to fully and effectively test these subsystems, we would like to similarly adopt a standard testing approach.
+
+## Decision
+
+Each project within a subsystem (with the exception of `*.Api`, if present) will have a corresponding test project located in the top-level `tests` directory (the `tests` directory structure should match that of `src`).
+
+Each source file (with the exception of `interfaces` and `POCOs`) will have have corresponding test file. A given test file (e.g. `ParticipantServiceTests.cs`) should strive to fully test the executable code of the target file (e.g. `ParticipantService.cs`), while minimizing the execution of executable code that lives outside the target file. This is best achieved through a combination of dependency injection and mocking.
+
+There will be special cases where mocking all external functionality is not possible. This most commonly occurs when there are dependencies on extension methods and/or third-party or system classes which contain non-virtual methods (in both cases, these components cannot be mocked because they are non-overridable).
+
+## Consequences
+
+We have seen that mocking all external dependencies when unit testing greatly reduces the effort required to achieve maximal test coverage. 
+
+Additionally, mocking external depenencies makes the tests we write more robust -- changes to the internal behavior of dependencies does not necessitate updates to the tests. 

--- a/docs/adr/0023-subsystem-unit-testing-strategy.md
+++ b/docs/adr/0023-subsystem-unit-testing-strategy.md
@@ -23,3 +23,5 @@ There will be special cases where mocking all external functionality is not poss
 We have seen that mocking all external dependencies when unit testing greatly reduces the effort required to achieve maximal test coverage. 
 
 Additionally, mocking external depenencies makes the tests we write more robust -- changes to the internal behavior of dependencies does not necessitate updates to the tests. 
+
+This approach to unit testing validates the internal functionality of the individual components, but does not test the relationships between components. Therefore, a separate integration test suite is necessary in order to verify that the system as a whole satisfies functional requirements. 

--- a/docs/adr/0023-subsystem-unit-testing-strategy.md
+++ b/docs/adr/0023-subsystem-unit-testing-strategy.md
@@ -14,7 +14,7 @@ Piipan is made up of six primary subsystems (`dashboard`, `etl`, `match`, `metri
 
 Each project within a subsystem (with the exception of `*.Api`, if present) will have a corresponding `xUnit` test project located in the top-level `tests` directory (the `tests` directory structure should match that of `src`).
 
-Each source file (with the exception of `interfaces` and `POCOs`) will have have corresponding test file. A given test file (e.g. `ParticipantServiceTests.cs`) should strive to fully test the executable code of the target file (e.g. `ParticipantService.cs`), while minimizing the execution of executable code that lives outside the target file. This is best achieved through a combination of dependency injection and mocking.
+Each source file (with the exception of `interfaces` and `POCOs`) will have a corresponding test file. A given test file (e.g. `ParticipantServiceTests.cs`) should strive to fully test the executable code of the target file (e.g. `ParticipantService.cs`), while minimizing the execution of executable code that lives outside the target file. This is best achieved through a combination of dependency injection and mocking.
 
 There will be special cases where mocking all external functionality is not possible. This most commonly occurs when there are dependencies on extension methods and/or third-party or system classes which contain non-virtual methods (in both cases, these components cannot be mocked because they are non-overridable).
 

--- a/docs/adr/0023-subsystem-unit-testing-strategy.md
+++ b/docs/adr/0023-subsystem-unit-testing-strategy.md
@@ -8,11 +8,11 @@ Accepted
 
 ## Context
 
-Piipan is made up of six primary subsystems (`dashboard`, `etl`, `match`, `metrics`, `participants`, `query-tool`), each of which are modeled on our standard subsystem software architecture. In an effort to fully and effectively test these subsystems, we would like to similarly adopt a standard testing approach.
+Piipan is made up of six primary subsystems (`dashboard`, `etl`, `match`, `metrics`, `participants`, `query-tool`), each of which are modeled on our [standard subsystem software architecture](0018-standardize-subsystem-software-architecture.md). In an effort to fully and effectively test these subsystems, we would like to similarly adopt a standard unit stesting approach.
 
 ## Decision
 
-Each project within a subsystem (with the exception of `*.Api`, if present) will have a corresponding test project located in the top-level `tests` directory (the `tests` directory structure should match that of `src`).
+Each project within a subsystem (with the exception of `*.Api`, if present) will have a corresponding `xUnit` test project located in the top-level `tests` directory (the `tests` directory structure should match that of `src`).
 
 Each source file (with the exception of `interfaces` and `POCOs`) will have have corresponding test file. A given test file (e.g. `ParticipantServiceTests.cs`) should strive to fully test the executable code of the target file (e.g. `ParticipantService.cs`), while minimizing the execution of executable code that lives outside the target file. This is best achieved through a combination of dependency injection and mocking.
 


### PR DESCRIPTION
## What’s changing?

Adds an ADR describing our approach to unit testing the primary subsystems.

## Why?

Closes #1838 

## This PR has:

~~- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~~

~~- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)~~

~~- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)~~

~~- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~~

## Anything else?
