### PR TITLE
Add Collaboration subsystem and initial API schema

### DIFF
--- a/collaboration/.gitignore
+++ b/collaboration/.gitignore
@@ -1,0 +1,2 @@
+docs/openapi/**/generated/
+artifacts/

--- a/collaboration/README.md
+++ b/collaboration/README.md
@@ -1,0 +1,9 @@
+# Match Collaboration
+
+⚠️ _Under construction_
+
+*Piipan subsystem for resolving matches found between entities*
+
+## Documentation
+
+[Collaboration API](./docs/collaboration-api.md)

--- a/collaboration/docs/collaboration-api.md
+++ b/collaboration/docs/collaboration-api.md
@@ -1,0 +1,41 @@
+# Match Collaboration API
+
+⚠️ _This API is under construction and is not live_
+
+The Match Collaboration API is an Internal API for resolving matching participant records between states/territories.
+
+## Summary
+
+When a match is found in the system, the states/territories involved in the match must communicate with one another to resolve it. Two or more entities may be involved in resolving a match. The match must be given a final disposition.
+
+For example, if a state eligibility worker in Montana queries a participant in their system and finds a matching participant in Iowa, Iowa and Montana will work together to either transfer benefits from one state to another, or cancel benefits entirely.
+
+As shown in the [Duplicate Participation API](../../docs/openapi/generated/duplicate-participation-api/openapi.md), when a match query is performed and results in a match, a match record is created for each matching pair of states/territories. The Match ID's for each match record are returned in the query. An eligibility worker can then use these Match ID's to collaborate with their counterparts from other programs.
+
+The Match Collaboration API will focus on facilitating this collaboration.
+
+Currently, a single Match (and a single Match ID) pertain to a pair of entities: the querying entity (e.g. Montana) and the matching entity (e.g. Iowa). Although improbable, it's possible to have multiple pairs returned in a single match query (e.g. Montana and Iowa, Montana and Louisiana). Each matching pair will need to be resolved separately.
+
+## Schema and Usage
+
+Please refer to our [Openapi documentation](./openapi/collaboration/index.yaml)
+
+## Environment variables
+
+⚠️ _Coming Soon_
+
+## Local development
+
+⚠️ _Coming Soon_
+
+## Unit / integration tests
+
+⚠️ _Coming Soon_
+
+## App deployment
+
+⚠️ _Coming Soon_
+
+## Remote testing
+
+⚠️ _Coming Soon_

--- a/collaboration/docs/openapi/collaboration/index.yaml
+++ b/collaboration/docs/openapi/collaboration/index.yaml
@@ -1,0 +1,20 @@
+# Collaboration API base spec
+openapi: 3.0.0
+info:
+  title: "Match Collaboration API"
+  version: 1.0.0
+  description: "Internal API for resolving matching participant records"
+tags:
+  - name: "Collaboration"
+servers:
+  - url: "/v1"
+paths:
+  /matches/{match_id}:
+    $ref: './show.yaml'
+security:
+  - BearerAuth: []
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer

--- a/collaboration/docs/openapi/collaboration/show.yaml
+++ b/collaboration/docs/openapi/collaboration/show.yaml
@@ -1,0 +1,14 @@
+get:
+  operationId: "Get a match record"
+  tags:
+    - "Collaboration"
+  summary: "Get a specific match record based on Match ID"
+  description: "Searches matches database to retrieve a specific match record based on Match ID, if exists"
+  parameters:
+    - $ref: '../schemas/match-record.yaml#/components/parameters/MatchId'
+  responses:
+    '200':
+      $ref: '../schemas/match-record.yaml#/components/responses/200'
+    '404':
+      $ref: '../schemas/match-record.yaml#/components/responses/404'
+

--- a/collaboration/docs/openapi/schemas/errors.yaml
+++ b/collaboration/docs/openapi/schemas/errors.yaml
@@ -1,0 +1,27 @@
+HttpErrors:
+  title: "Http Errors"
+  type: object
+  properties:
+    errors:
+      type: array
+      description: "Holds HTTP and other top-level errors. Either an errors or data property will be present in the top-level response, but not both."
+      items:
+        $ref: '#/HttpError'
+
+HttpError:
+  type: object
+  required:
+    - status
+  properties:
+    status:
+      type: string
+      description: "The HTTP status code"
+    code:
+      type: string
+      description: "The application-specific error code"
+    title:
+      type: string
+      description: "The short, human-readable summary of the error, consistent across all occurrences of the error"
+    detail:
+      type: string
+      description: "The human-readable explanation specific to this occurrence of the error"

--- a/collaboration/docs/openapi/schemas/match-record.yaml
+++ b/collaboration/docs/openapi/schemas/match-record.yaml
@@ -1,0 +1,113 @@
+MatchRecordResponses:
+  Success:
+    title: "Match Record response - success"
+    type: object
+    properties:
+      data:
+        type: object
+        description: "The response payload representing a match record. Either an errors or data property will be present in the response, but not both."
+        required:
+          - created_at
+          - match_id
+          - initiator
+          - states
+          - hash
+          - hash_type
+          - output
+          - invalid
+          - status
+        properties:
+          created_at:
+            type: string
+            format: date-time
+            example: "2021-04-12T23:20:50.52Z"
+            description: "Match record's creation date/time"
+          match_id:
+            type: string
+            description: "Match record's human-readable unique identifier"
+          initiator:
+            type: string
+            description: "Match record's initiating state or territory"
+          states:
+            type: array
+            description: "List of states/territories involved in match"
+            items:
+              type: string
+          hash:
+            type: string
+            description: "Value of hash used to identify match. See docs/pprl.md for details"
+          hash_type:
+            enum:
+              - "ldshash"
+            description: "Type of hash used to identify match"
+          input:
+            description: "Original request data from real-time match request"
+            $ref: '../../../../match/docs/openapi/schemas/match-query.yaml#/Person'
+          output:
+            description: "Original response data from real-time match request"
+            $ref: '../../../../match/docs/openapi/schemas/participant-record.yaml#/ParticipantRecord'
+          invalid:
+            type: boolean
+            description: "Indicator used for designating match as invalid"
+          status:
+            enum:
+              - "open"
+              - "closed"
+            description: "Match record's status"
+
+MatchRecordResponseExamples:
+  Success:
+    description: "A match record is returned"
+    value:
+      data:
+        created_at: "2021-04-12T23:20:50.52Z"
+        match_id: "ABC1234"
+        initiator: "eb"
+        states:
+          - "ea"
+          - "eb"
+        hash: "a3cab51dd68da2ac3e5508c8b0ee514ada03b9f166f7035b4ac26d9c56aa7bf9d6271e44c0064337a01b558ff63fd282de14eead7e8d5a613898b700589bcdec"
+        hash_type: "ldshash"
+        input:
+          lds_hash: "a3cab51dd68da2ac3e5508c8b0ee514ada03b9f166f7035b4ac26d9c56aa7bf9d6271e44c0064337a01b558ff63fd282de14eead7e8d5a613898b700589bcdec"
+        output:
+          $ref: "../../../../match/docs/openapi/schemas/participant-record.yaml#/ParticipantRecordExamples/All"
+        invalid: false
+        status: "open"
+  NotFound:
+    description: "A match record is not found"
+    value:
+      errors:
+        - status: "404"
+          code: "XYZ"
+          title: "Not Found"
+          detail: "Match record not found"
+
+components:
+  parameters:
+    MatchId:
+      in: path
+      name: match_id
+      required: true
+      description: "the Match ID provided in the results of a previous match query"
+      schema:
+        type: string
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            $ref: '#/MatchRecordResponses/Success'
+          examples:
+            success:
+              $ref: '#/MatchRecordResponseExamples/Success'
+    '404':
+      description: "Match not found"
+      content:
+        application/json:
+          schema:
+            $ref: './errors.yaml#/HttpErrors'
+          examples:
+            not_found:
+              $ref: '#/MatchRecordResponseExamples/NotFound'

--- a/collaboration/tools/generate-specs.bash
+++ b/collaboration/tools/generate-specs.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Validates a decomposed YAML OpenAPI spec and bundles it into a
+# single openapi.yaml file.
+#
+# Requires swagger-cli (https://github.com/APIDevTools/swagger-cli)
+#
+# usage: generate-spec.bash
+
+set -e
+set -u
+
+main () {
+    specs=(collaboration)
+
+    for s in "${specs[@]}"
+    do
+        base_path="../docs/openapi/${s}"
+        spec_path="${base_path}/index.yaml"
+        generated_path="${base_path}/generated/openapi.yaml"
+
+        echo "Validating ${spec_path}"
+        swagger-cli validate "$spec_path"
+
+        echo "Generating ${generated_path}"
+        swagger-cli bundle "$spec_path" -o "$generated_path" -t yaml
+    done
+}
+
+main

--- a/match/docs/openapi/schemas/errors.yaml
+++ b/match/docs/openapi/schemas/errors.yaml
@@ -1,0 +1,27 @@
+HttpErrors:
+  title: "Http Errors"
+  type: object
+  properties:
+    errors:
+      type: array
+      description: "Holds HTTP and other top-level errors. Either an errors or data property will be present in the top-level response, but not both."
+      items:
+        $ref: '#/HttpError'
+
+HttpError:
+  type: object
+  required:
+    - status
+  properties:
+    status:
+      type: string
+      description: "The HTTP status code"
+    code:
+      type: string
+      description: "The application-specific error code"
+    title:
+      type: string
+      description: "The short, human-readable summary of the error, consistent across all occurrences of the error"
+    detail:
+      type: string
+      description: "The human-readable explanation specific to this occurrence of the error"

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -82,33 +82,30 @@ MatchRequestExamples:
 
 #/components/schemas/MatchResponse
 MatchResponse:
-  title: Match response
-  type: object
-  properties:
-    data:
-      type: object
-      nullable: true
-      description: The response payload. Either an errors or data property will be present in the response, but not both.
-      required:
-        - results
-        - errors
-      properties:
-        results:
-          type: array
-          description: "Array of query results. For every person provided in the request, a result is returned, even if no matches are found. If a query fails, the failure data will be in the errors array."
-          items:
-            $ref: '#/Result'
-        errors:
-          type: array
-          description: "Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items."
-          items:
-            $ref: '#/DataError'
-    errors:
-      type: array
-      nullable: true
-      description: "Holds HTTP and other top-level errors. Either an errors or data property will be present in the response, but not both."
-      items:
-        $ref: '#/ResponseError'
+  Success:
+    title: Match response Success
+    type: object
+    properties:
+      data:
+        type: object
+        nullable: true
+        description: The response payload.
+        required:
+          - results
+          - errors
+        properties:
+          results:
+            type: array
+            description: "Array of query results. For every person provided in the request, a result is returned, even if no matches are found. If a query fails, the failure data will be in the errors array."
+            items:
+              $ref: '#/Result'
+          errors:
+            type: array
+            description: "Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items."
+            items:
+              $ref: '#/DataError'
+  Failure:
+    $ref: './errors.yaml#/HttpErrors'
 
 Result:
   type: object
@@ -215,24 +212,6 @@ DataError:
       type: string
       description: "The human-readable explanation specific to this occurrence of the error"
 
-ResponseError:
-  type: object
-  required:
-    - status
-  properties:
-    status:
-      type: string
-      description: "The HTTP status code"
-    code:
-      type: string
-      description: "The application-specific error code"
-    title:
-      type: string
-      description: "The short, human-readable summary of the error, consistent across all occurrences of the error"
-    detail:
-      type: string
-      description: "The human-readable explanation specific to this occurrence of the error"
-
 components:
   parameters:
     From:
@@ -254,7 +233,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '../schemas/match-query.yaml#/MatchResponse'
+            $ref: '../schemas/match-query.yaml#/MatchResponse/Success'
           examples:
             Single match:
               $ref: '../schemas/match-query.yaml#/MatchResponseExamples/Single'
@@ -272,3 +251,7 @@ components:
               $ref: '../schemas/match-query.yaml#/MatchResponseExamples/TopLevelError'
     '400':
       description: "Bad request. Request body does not match the required format."
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/match-query.yaml#/MatchResponse/Failure'


### PR DESCRIPTION
## What’s changing?

- Adds initial Collaboration subsystem to focus on match resolution 
- Adds openapi schema for a new Collaboration API for internal use 
- Adds openapi schema to get a single match record from Collaboration API
- Also includes a bit of refactoring on Error handling in match query API schemas

## Why?

Partially Addresses #1940 

This API schema simply exposes the [match record data we already store](https://github.com/18F/piipan/blob/dev/match/ddl/match-record.sql#L17). #1940 defines API fields for full match resolution, i.e. state-level disposition tracking. Our current data store doesn't yet handle state-level disposition tracking. However, it holds enough data to get an initial Match Record page up in the Query Tool, which are:

- Match status (open / closed)
- Match creation date
- Name of querying state
- Name of matched state
- vulnerable status in the matched state (provided in the original data output)
- Case id in the matched state (provided in the original data output)
- Participant ID in the matched state (provided in the original data output)
- Benefits end date in matched state (provided in the original data output)
- Recent benefits months in matched state (provided in the original data output)

You'll see that a lot of this data comes from the data output of the original match query, which is stored as a `jsonb` field on the match record. I think there's discussion to be had on how heavily we want to rely on this data, or if we should retrieve this data in a different way. 

## This PR has:

- [X] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)
- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
