### PR TITLE
Add ADR for decision to use Windows-based App Service plans

### DIFF
--- a/docs/adr/0025-use-windows-operating-system-for-app-service-plans.md
+++ b/docs/adr/0025-use-windows-operating-system-for-app-service-plans.md
@@ -1,0 +1,25 @@
+# 25. Use Windows operating system for App Service plans
+
+Date: 2022-01-11
+
+## Status
+
+Accepted
+
+## Context
+
+We use Azure App Service plans to back our Function Apps and App Service web apps. App Service plans can be configured to use Windows or Linux under the hood.
+
+In general, our development team works in Unix-like environments and prefers Linux as a default selection.
+
+However, Azure App Service plans that use Windows under the hood often have a larger feature set than those using Linux. For instance, Windows plans have [several more logging types](https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs#overview) available compared to Linux plans.
+
+## Decision
+
+In the interest of establishing a default OS across all of our Azure resources and in an attempt to gain access to more useful logging/networking features, we will use Windows under the hood on all App Service plans.
+
+## Consequences
+
+- App Service instances using Windows plans require more manual wrangling to produce useful log streams. In contrast, when using Linux logging (while more limited) "just works."
+- Developers working locally in Unix-like environments will need to vigilantly avoid using environment-specific features (e.g., [Time Zone names](https://devblogs.microsoft.com/dotnet/cross-platform-time-zones-with-net-core/)).
+- Similarly, end-to-end testing increases in importance as a means to identify environment-specific issues.


### PR DESCRIPTION
## What’s changing?

Adds and ADR explaining our decision to use Windows under the hood for all App Service plans

## Why?

Closes #1376

## This PR has:

~- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~
~- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)~
~- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)~
~- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~