### PR TITLE
Add instruction for new sources in repo

### DIFF
--- a/docs/source-guidelines.md
+++ b/docs/source-guidelines.md
@@ -13,6 +13,7 @@ When new source trees (e.g., a new component or test suite) are added to this re
 1. For test suites, update [.circleci/config.yml](/.circleci/config.yml) to run the test code, format the coverage data, and include it in the coverage sum that gets sent to [Code Climate Quality project](https://codeclimate.com/github/18F/piipan).
 1. For new components, update [.circleci/config.yml](/.circleci/config.yml) to build and deploy it to Azure. Any infrastructure should be pre-existing and established separately via [create-resources.bash](/iac/create-resources.bash).
 1. For any `dotnet` command in CircleCI that calls MSBuild under the hood (e.g., `build`, `test`, `publish`), ensure that the `ContinuousIntegrationBuild=true` property is set. See the job-level `$MSBUILD_PROPS` variable in [.circleci/config.yml](/.circleci/config.yml).
+1. Add project to the subsystem solutions (sln) file
 
 ## Source code conventions
 


### PR DESCRIPTION
## What’s changing?

Mention adding a new source tree (project) to the subsystem solutions file.

## Why?

I wasn't sure whether these instructions were up-to-date. If they are, we should mention adding any new projects to solutions files for build/test/deploy purposes. 

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- [X] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)
- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
