### PR TITLE
add example value for content-length header

### DIFF
--- a/docs/openapi/generated/bulk-api/openapi.md
+++ b/docs/openapi/generated/bulk-api/openapi.md
@@ -28,7 +28,7 @@ Base URLs:
 # You can also use wget
 curl -X PUT /bulk/{stateAbbr}/v2/upload/{filename} \
   -H 'Content-Type: text/plain' \
-  -H 'Content-Length: 0' \
+  -H 'Content-Length: 6413' \
   -H 'Ocp-Apim-Subscription-Key: API_KEY'
 
 ```

--- a/docs/openapi/generated/bulk-api/openapi.yaml
+++ b/docs/openapi/generated/bulk-api/openapi.yaml
@@ -31,6 +31,7 @@ paths:
             type: integer
           required: true
           description: Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.
+          example: 6413
       requestBody:
         content:
           text/plain:

--- a/etl/docs/openapi/upload.yaml
+++ b/etl/docs/openapi/upload.yaml
@@ -16,6 +16,7 @@ put:
         type: integer
       required: true
       description: Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.
+      example: 6413
   requestBody:
     content:
       text/plain:


### PR DESCRIPTION
## What’s changing?

Adds example value for Content-Length header for Bulk Upload API. 

## Why?

Some of our examples from our generated API docs have been confusing users. It's tempting to copy/paste the cURL request examples from the docs. 

Currently, API requests with a Content Length header of 0 will silently fail, and it takes a little while to debug when that happens. I figured putting an example content length that's equal to the byte-size of our example csv file could alleviate that confusion, for now. 

I'm still exploring options for widdershins template updates, and may post separate PR's related to that. 

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)
- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
