### PR TITLE
Misspelling Corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Duplicate participation API for PPRL approach
   - base URL is now `/match/v2`
   - `query` renamed to `find_matches` which takes de-identified PII
-  - `participant_id` and `case_id` is now required in match esponses
+  - `participant_id` and `case_id` is now required in match responses
 - Bulk upload API for PPRL approach
   - base URL is now `/bulk/v2`
   - `first`, `middle`, `last`, `dob`, and `ssn` columns in CSV replaced with `lds_hash`
@@ -155,7 +155,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - duplicate participation API to allow an entire household to be queried for
 - App Service instances to use Windows under-the-hood
-- query tool to remove lookup API feature and accomodate query API changes
+- query tool to remove lookup API feature and accommodate query API changes
 - Front Door to use a designated public file in dashboard and query tool for health check
 - duplicate participation Function Apps so they do not hibernate
 - Orchestrator Function App so that network egress is through a VNet

--- a/docs/adr/0023-subsystem-unit-testing-strategy.md
+++ b/docs/adr/0023-subsystem-unit-testing-strategy.md
@@ -22,6 +22,6 @@ There will be special cases where mocking all external functionality is not poss
 
 We have seen that mocking all external dependencies when unit testing greatly reduces the effort required to achieve maximal test coverage. 
 
-Additionally, mocking external depenencies makes the tests we write more robust -- changes to the internal behavior of dependencies does not necessitate updates to the tests. 
+Additionally, mocking external dependencies makes the tests we write more robust -- changes to the internal behavior of dependencies does not necessitate updates to the tests. 
 
 This approach to unit testing validates the internal functionality of the individual components, but does not test the relationships between components. Therefore, a separate integration test suite is necessary in order to verify that the system as a whole satisfies functional requirements. 

--- a/docs/engineering-team-practices.md
+++ b/docs/engineering-team-practices.md
@@ -45,7 +45,7 @@ We use this commit message template:
 The usual suspects, plus some variants:
 - Commented source code: required on public classes, methods; elsewhere as appropriate
 - Supporting developer documentation for new build/test/API changes or for particularly complex portions of the system
-- Architectual Decision Records (as appropriate) for research spikes
+- Architectural Decision Records (as appropriate) for research spikes
 - Automated unit tests to maintain or increase level of code coverage
 - If a PR changes the IaC, the IaC should be manually applied to tts/dev as our CI/CD pipeline does not run IaC automatically
 - As warranted, add the `changelog` tag to the PR and leave text to add to CHANGELOG at the end of the sprint – this is particularly important for any external API changes (e.g.; [#1374](https://github.com/18F/piipan/pull/1374))
@@ -60,7 +60,7 @@ We work in 2 week sprint cycles, starting on Tuesdays and ending on Mondays. A [
 Dependabot does not support package lock files with .NET and so the automated PRs that it generates will fail in CI.
 
 To address these Dependabot PRs, a developer can:
-- assign the PRs to themselves (typically in bulk via the Asignee function)
+- assign the PRs to themselves (typically in bulk via the Assignee function)
 - follow the [steps to update dependencies](./update-deps.md) using a a new PR
 
 The Dependabot PRs should close automatically after the new PR is merged.


### PR DESCRIPTION
## What’s changing?

Across three `*.md` files correct misspelings.

| Misspelling | Fix | File|
| -- | -- | -- |
| esponses | responses | CHANGELOG.md |
| accomodate | accommodate | CHANGELOG.md |
| depenencies | dependencies | docs/adr/0023-subsystem-unit-testing-strategy.md |
| Architectual | Architectural | docs/engineering-team-practices.md |
| Asignee | Assignee | docs/engineering-team-practices.md |

## Why?

Misspellings.

## This PR has:

- [x] Fixed misspellings.
