### PR TITLE
Bump Npgsql to 6.0.3

### DIFF
--- a/dashboard/src/Piipan.Dashboard/packages.lock.json
+++ b/dashboard/src/Piipan.Dashboard/packages.lock.json
@@ -798,8 +798,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1997,7 +1997,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -2025,7 +2025,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
+++ b/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
@@ -872,8 +872,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2143,7 +2143,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -2171,7 +2171,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Piipan.Etl.Func.BulkUpload.csproj
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Piipan.Etl.Func.BulkUpload.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
@@ -88,9 +88,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2039,7 +2039,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/Piipan.Etl.Func.BulkUpload.Tests.csproj
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/Piipan.Etl.Func.BulkUpload.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="csvhelper" Version="27.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
@@ -39,9 +39,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2155,7 +2155,7 @@
           "Microsoft.Extensions.DependencyInjection": "3.1.22",
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Participants.Api": "1.0.0",
           "Piipan.Participants.Core": "1.0.0",
           "Piipan.Shared": "1.0.0"
@@ -2187,7 +2187,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/match/src/Piipan.Match/Piipan.Match.Api/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Api/packages.lock.json
@@ -366,8 +366,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1501,7 +1501,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Piipan.Match.Core.csproj
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Piipan.Match.Core.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.22" />
     <PackageReference Include="Nanoid" Version="2.1.0" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
   </ItemGroup>

--- a/match/src/Piipan.Match/Piipan.Match.Core/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Core/packages.lock.json
@@ -46,9 +46,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1526,7 +1526,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/match/src/Piipan.Match/Piipan.Match.Func.Api/Piipan.Match.Func.Api.csproj
+++ b/match/src/Piipan.Match/Piipan.Match.Func.Api/Piipan.Match.Func.Api.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="Nanoid" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
@@ -80,9 +80,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2181,7 +2181,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
           "Piipan.Shared": "1.0.0"
@@ -2213,7 +2213,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/match/tests/Piipan.Match.Api.Tests/Piipan.Match.Api.Tests.csproj
+++ b/match/tests/Piipan.Match.Api.Tests/Piipan.Match.Api.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Api.Tests/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1663,7 +1663,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/match/tests/Piipan.Match.Client.Tests/Piipan.Match.Client.Tests.csproj
+++ b/match/tests/Piipan.Match.Client.Tests/Piipan.Match.Client.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Client.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Client.Tests/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1833,7 +1833,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/match/tests/Piipan.Match.Core.IntegrationTests/Piipan.Match.Core.IntegrationTests.csproj
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/Piipan.Match.Core.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Core.Tests/Piipan.Match.Core.Tests.csproj
+++ b/match/tests/Piipan.Match.Core.Tests/Piipan.Match.Core.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Core.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Core.Tests/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1667,7 +1667,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
           "Piipan.Shared": "1.0.0"
@@ -1689,7 +1689,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/match/tests/Piipan.Match.Func.Api.Tests/Piipan.Match.Func.Api.Tests.csproj
+++ b/match/tests/Piipan.Match.Func.Api.Tests/Piipan.Match.Func.Api.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
@@ -36,9 +36,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2312,7 +2312,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
           "Piipan.Shared": "1.0.0"
@@ -2329,7 +2329,7 @@
           "Microsoft.NET.Sdk.Functions": "3.0.13",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Match.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2363,7 +2363,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/Piipan.Metrics.Api.csproj
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/Piipan.Metrics.Api.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/Piipan.Metrics.Func.Api.csproj
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/Piipan.Metrics.Func.Api.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/packages.lock.json
@@ -64,9 +64,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1907,7 +1907,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -1933,7 +1933,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/Piipan.Metrics.Func.Collect.csproj
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/Piipan.Metrics.Func.Collect.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/packages.lock.json
@@ -74,9 +74,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1948,7 +1948,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -1974,7 +1974,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Client.Tests/Piipan.Metrics.Client.Tests.csproj
+++ b/metrics/tests/Piipan.Metrics.Client.Tests/Piipan.Metrics.Client.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/metrics/tests/Piipan.Metrics.Client.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Client.Tests/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2104,7 +2104,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -2132,7 +2132,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Core.IntegrationTests/Piipan.Metrics.Core.IntegrationTests.csproj
+++ b/metrics/tests/Piipan.Metrics.Core.IntegrationTests/Piipan.Metrics.Core.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/metrics/tests/Piipan.Metrics.Core.IntegrationTests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Core.IntegrationTests/packages.lock.json
@@ -39,9 +39,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2032,7 +2032,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -2058,7 +2058,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Core.Tests/Piipan.Metrics.Core.Tests.csproj
+++ b/metrics/tests/Piipan.Metrics.Core.Tests/Piipan.Metrics.Core.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/metrics/tests/Piipan.Metrics.Core.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Core.Tests/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2031,7 +2031,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -2057,7 +2057,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Func.Api.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Func.Api.Tests/packages.lock.json
@@ -820,8 +820,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2039,7 +2039,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -2060,7 +2060,7 @@
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
           "Microsoft.Extensions.DependencyInjection": "3.1.22",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Shared": "1.0.0"
@@ -2079,7 +2079,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Func.Collect.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Func.Collect.Tests/packages.lock.json
@@ -860,8 +860,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2079,7 +2079,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Shared": "1.0.0"
         }
       },
@@ -2101,7 +2101,7 @@
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "2.1.0",
           "Microsoft.Extensions.DependencyInjection": "3.1.22",
           "Microsoft.NET.Sdk.Functions": "3.0.13",
-          "Npgsql": "6.0.2",
+          "Npgsql": "6.0.3",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Shared": "1.0.0"
         }
@@ -2119,7 +2119,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/Piipan.Participants.Core.IntegrationTests.csproj
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/Piipan.Participants.Core.IntegrationTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/participants/tests/Piipan.Participants.Core.Tests/Piipan.Participants.Core.Tests.csproj
+++ b/participants/tests/Piipan.Participants.Core.Tests/Piipan.Participants.Core.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
+++ b/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1667,7 +1667,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/query-tool/src/Piipan.QueryTool/packages.lock.json
+++ b/query-tool/src/Piipan.QueryTool/packages.lock.json
@@ -530,8 +530,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1708,7 +1708,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
+++ b/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
@@ -602,8 +602,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1871,7 +1871,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }

--- a/shared/src/Piipan.Shared/Piipan.Shared.csproj
+++ b/shared/src/Piipan.Shared/Piipan.Shared.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.22" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
   </ItemGroup>
 
 </Project>

--- a/shared/src/Piipan.Shared/packages.lock.json
+++ b/shared/src/Piipan.Shared/packages.lock.json
@@ -122,9 +122,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"

--- a/shared/tests/Piipan.Shared.Tests/packages.lock.json
+++ b/shared/tests/Piipan.Shared.Tests/packages.lock.json
@@ -736,8 +736,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.2",
-        "contentHash": "j/BJY/1lqtu5ssfGEi9D+qJ/3OMrK8ZdicsW4SldV49CahRVXVHldj636ucVcEqJPNDI0h+/PWJD7oHsQ/cFAQ==",
+        "resolved": "6.0.3",
+        "contentHash": "yt/3XFRhHsJ01a4+qHM9+0mtitQ3DY2wJLyGP9vtvZa1cB1nSAw762GJGdSX3Bbc7wZKzeo4dc4drD3yvQe7gA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "6.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1949,7 +1949,7 @@
           "Microsoft.Extensions.Logging": "3.1.22",
           "Microsoft.Extensions.Options": "3.1.22",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.2"
+          "Npgsql": "6.0.3"
         }
       }
     }


### PR DESCRIPTION
## What’s changing?

Bump Npgsql to 6.0.3

## Why?

Flagged by dependabot. See reference: [Updating .NET dependencies](https://github.com/18F/piipan/blob/main/docs/update-deps.md)
