### PR TITLE
Release v1.0.0.33 back to dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project **does not** adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0.33] - 2022-02-08
+
+### Changed
+- Updated Engineering Practices doc to specify approach to cross-team review
+### Added
+- Engineering quick start guide
+
 ## [1.0] - 2022-01-25
 
 ### Changed
@@ -215,6 +222,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Initial APIs for use by group 1A state integrators.
 
+[1.0.0.33]: https://github.com/18F/piipan/releases/tag/v1.0.0.33
 [1.0]: https://github.com/18F/piipan/releases/tag/v1.0
 [0.97]: https://github.com/18F/piipan/releases/tag/v0.97
 [0.96]: https://github.com/18F/piipan/releases/tag/v0.96


### PR DESCRIPTION
## What’s changing?

Releasing v1.0.0.33 back to dev to include CHANGELOG updates.

## Why?

Jira-NAC/192
