### PR TITLE
Add match_res_events table

### DIFF
--- a/match/ddl/match-record.sql
+++ b/match/ddl/match-record.sql
@@ -40,4 +40,21 @@ COMMENT ON COLUMN matches.data IS 'Response data from match request.';
 COMMENT ON COLUMN matches.invalid IS 'Indicator used for designating match as invalid.';
 COMMENT ON COLUMN matches.status IS 'Match record''s status.';
 
+CREATE TABLE IF NOT EXISTS match_res_events(
+    id serial PRIMARY KEY,
+    match_id text NOT NULL REFERENCES matches (match_id),
+    inserted_at timestamptz NOT NULL,
+    actor text NOT NULL,
+    actor_state text,
+    delta jsonb NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS index_match_id_on_match_res_events on match_res_events (match_id);
+
+COMMENT ON TABLE match_res_events IS 'Match resolution events';
+COMMENT ON COLUMN match_res_events.match_id IS 'References match ID of original match';
+COMMENT ON COLUMN match_res_events.actor IS 'the person or automated system performing this change';
+COMMENT ON COLUMN match_res_events.actor_state IS 'indicates if the actor is associated with a state involved in the match';
+COMMENT ON COLUMN match_res_events.delta IS 'json object representing data changes submitted by states, as well as stateful domain data like match status';
+
 COMMIT;

--- a/match/tests/Piipan.Match.Core.IntegrationTests/DbFixture.cs
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/DbFixture.cs
@@ -63,6 +63,8 @@ namespace Piipan.Match.Core.IntegrationTests
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
 
+                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Execute("DROP TYPE IF EXISTS hash_type");
                 conn.Execute("DROP TYPE IF EXISTS status");
@@ -81,6 +83,8 @@ namespace Piipan.Match.Core.IntegrationTests
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
 
+                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Execute("DROP TYPE IF EXISTS hash_type");
                 conn.Execute("DROP TYPE IF EXISTS status");

--- a/match/tests/Piipan.Match.Func.Api.IntegrationTests/DbFixture.cs
+++ b/match/tests/Piipan.Match.Func.Api.IntegrationTests/DbFixture.cs
@@ -74,6 +74,8 @@ namespace Piipan.Match.Func.Api.IntegrationTests
             {
                 conn.ConnectionString = CollabConnectionString;
                 conn.Open();
+                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Close();
             }
@@ -105,6 +107,8 @@ namespace Piipan.Match.Func.Api.IntegrationTests
                 conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
+                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Execute(matchesSql);
 


### PR DESCRIPTION
## What’s changing?

Adds `match_res_events` table schema to collaboration ddl

## Why?

Relates to Jira NAC-165

This is the first step in implementing [match resolution events](https://github.com/18F/piipan/blob/dev/docs/adr/0027-use-event-sourcing-for-match-resolution.md) based on [our decision on how to sequence this work](https://github.com/18F/piipan/pull/2699#issuecomment-1048921838). 

Once this is merged, the next steps in implementing NAC-165 are to:

1. add a MatchResEventDao and Models to handle database queries for this table
1. add a MatchAggregator service to compile stateful data from match res events
1. use the Match Aggregator service to determine open/closed status in `MatchEventService.Reconcile`

These steps will be in the next PR.

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- [X] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)
- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
