### PR TITLE
Eth/hsts policy

### DIFF
--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -47,17 +47,9 @@ namespace Piipan.Dashboard
 
             services.AddHsts(options =>
             {
-                options.Preload = true;
-                options.IncludeSubDomains = true;
-                options.MaxAge = TimeSpan.FromSeconds(31536000);
-                // options.ExcludedHosts.Add("example.com");
-                // options.ExcludedHosts.Add("www.example.com");
-            });
-
-            services.AddHttpsRedirection(options =>
-            {
-                options.RedirectStatusCode = (int) HttpStatusCode.TemporaryRedirect;
-                options.HttpsPort = 5001;
+                options.Preload = true; //Sets the preload parameter of the Strict-Transport-Security header. Preload isn't part of the RFC HSTS specification, but is supported by web browsers to preload HSTS sites on fresh install. For more information, see https://hstspreload.org
+                options.IncludeSubDomains = true; //Enables includeSubDomain, which applies the HSTS policy to Host subdomains.
+                options.MaxAge = TimeSpan.FromSeconds(31536000); //Explicitly sets the max-age parameter of the Strict-Transport-Security header to 365 days. If not set, defaults to 30 days.
             });
 
             services.AddHttpContextAccessor();

--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Net;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Net;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -41,6 +43,21 @@ namespace Piipan.Dashboard
             {
                 options.Conventions.AuthorizeFolder("/");
                 options.Conventions.AllowAnonymousToPage("/SignedOut");
+            });
+
+            services.AddHsts(options =>
+            {
+                options.Preload = true;
+                options.IncludeSubDomains = true;
+                options.MaxAge = TimeSpan.FromSeconds(31536000);
+                // options.ExcludedHosts.Add("example.com");
+                // options.ExcludedHosts.Add("www.example.com");
+            });
+
+            services.AddHttpsRedirection(options =>
+            {
+                options.RedirectStatusCode = (int) HttpStatusCode.TemporaryRedirect;
+                options.HttpsPort = 5001;
             });
 
             services.AddHttpContextAccessor();

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -54,17 +54,9 @@ namespace Piipan.QueryTool
 
             services.AddHsts(options =>
             {
-                options.Preload = true;
-                options.IncludeSubDomains = true;
-                options.MaxAge = TimeSpan.FromSeconds(31536000);
-                // options.ExcludedHosts.Add("example.com");
-                // options.ExcludedHosts.Add("www.example.com");
-            });
-
-            services.AddHttpsRedirection(options =>
-            {
-                options.RedirectStatusCode = (int) HttpStatusCode.TemporaryRedirect;
-                options.HttpsPort = 5001;
+                options.Preload = true; //Sets the preload parameter of the Strict-Transport-Security header. Preload isn't part of the RFC HSTS specification, but is supported by web browsers to preload HSTS sites on fresh install. For more information, see https://hstspreload.org
+                options.IncludeSubDomains = true; //Enables includeSubDomain, which applies the HSTS policy to Host subdomains.
+                options.MaxAge = TimeSpan.FromSeconds(31536000); //Explicitly sets the max-age parameter of the Strict-Transport-Security header to 365 days. If not set, defaults to 30 days.
             });
 
             services.AddTransient<IClaimsProvider, ClaimsProvider>();
@@ -86,8 +78,6 @@ namespace Piipan.QueryTool
                     .GetSection(AuthorizationPolicyOptions.SectionName)
                     .Get<AuthorizationPolicyOptions>());
             });
-
-            
 
             services.RegisterMatchClientServices(_env);
 

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -51,6 +52,21 @@ namespace Piipan.QueryTool
                 options.ModelBinderProviders.Insert(0, new TrimModelBinderProvider());
             });
 
+            services.AddHsts(options =>
+            {
+                options.Preload = true;
+                options.IncludeSubDomains = true;
+                options.MaxAge = TimeSpan.FromSeconds(31536000);
+                // options.ExcludedHosts.Add("example.com");
+                // options.ExcludedHosts.Add("www.example.com");
+            });
+
+            services.AddHttpsRedirection(options =>
+            {
+                options.RedirectStatusCode = (int) HttpStatusCode.TemporaryRedirect;
+                options.HttpsPort = 5001;
+            });
+
             services.AddTransient<IClaimsProvider, ClaimsProvider>();
             
             services.AddSingleton<INameNormalizer, NameNormalizer>();
@@ -70,6 +86,8 @@ namespace Piipan.QueryTool
                     .GetSection(AuthorizationPolicyOptions.SectionName)
                     .Get<AuthorizationPolicyOptions>());
             });
+
+            
 
             services.RegisterMatchClientServices(_env);
 


### PR DESCRIPTION
## What’s changing?

This change adds HSTS to the ConfigureServices in Startup.cs on the applications Dashboard and Query tool. This configuration sets max-age to 31536000 seconds. The HSTS can be configured in the middleware (Startup.cs) or in Azure Front Door. The middleware seems easier to configure based on the environment. Given that we have an Azure Front Door by application, there is no advantage of a single point of configuration with that option.

## Why?

Close NAC-36: HSTS Policy Not Enable. See AppSec report.

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
