### PR TITLE
Update example values for participant_closing_date

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -113,7 +113,7 @@ paths:
                                   participant_closing_date:
                                     type: string
                                     pattern: '^\d{4}-\d{2}-\d{2}$'
-                                    example: 2021-01
+                                    example: 2021-01-31
                                     description: Date when the Participant's case will close. This will be the last date the participate is eligible to receive benefits.
                                   recent_benefit_months:
                                     type: array

--- a/match/docs/openapi/schemas/participant-record.yaml
+++ b/match/docs/openapi/schemas/participant-record.yaml
@@ -22,7 +22,7 @@ ParticipantRecord:
     participant_closing_date:
       type: string
       pattern: '^\d{4}-\d{2}-\d{2}$'
-      example: "2021-01"
+      example: "2021-01-31"
       description: "Date when the Participant's case will close. This will be the last date the participate is eligible to receive benefits."
     recent_benefit_months:
       type: array


### PR DESCRIPTION
Change example provided for participant_closing_date to a date instead of a month.

## What’s changing?

Minor fixes to documentation for participant_closing_date.  Follow up to PR #2734 

## Why?

Some of the examples provided are still in the month format but the API now works with specific dates.

## This PR has:

- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)