### PR TITLE
Fix preload for hsts on Query Tool and Dashboard

### DIFF
--- a/dashboard/src/Piipan.Dashboard/Startup.cs
+++ b/dashboard/src/Piipan.Dashboard/Startup.cs
@@ -89,9 +89,9 @@ namespace Piipan.Dashboard
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseForwardedHeaders();
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
-                app.UseForwardedHeaders();
             }
 
             app.UseHttpsRedirection();

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -101,9 +101,9 @@ namespace Piipan.QueryTool
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseForwardedHeaders();
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
-                app.UseForwardedHeaders();
             }
 
             app.UseHttpsRedirection();


### PR DESCRIPTION
## What’s changing?

Fix on the startup.cs from the Query Tool and Dashboard App. The last scan does not detect the preload directive in the hsts configuration. [This comment](https://stackoverflow.com/questions/52046895/usehsts-not-working-with-netcore-2-1-website/56934285#56934285) suggests a solution that I tested on our Azure environment and it worked.

## Why?

NAC-36

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?

The scan reported that the duppartapi endpoint has not hsts active. Given that NAC-36 only includes Query Tool and Dashboard apps, I'm adding an additional issue for the duppartapi (APIM).
