### PR TITLE
Updating changelog for 1.0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project **does not** adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1.36] - 2022-03-22
+
+### Added
+- Added Match Collaboration page and Error pages.
+- Added Match Resolution App and GetMatch endpoint
+- Added Bulk Upload Performance Test Runner utility
+### Fixed
+- Fixed middleware initialization ordering issue for HSTS
+- Fixed search logic to avoid searching within the initiating state's own database for matches.
+
 ## [1.0.1] - 2022-03-08
 
 ### Changed


### PR DESCRIPTION
## What’s changing?

Updating changelog after end of sprint 36.

## Why?

Updating changelog after end of sprint 36.

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
