### PR TITLE
Added hsts policy for APIM

### DIFF
--- a/iac/apim-policy.xml
+++ b/iac/apim-policy.xml
@@ -18,6 +18,10 @@
     <backend>
         <forward-request />
     </backend>
-    <outbound />
+    <outbound>
+        <set-header name="Strict-Transport-Security" exists-action="override">    
+            <value>Strict-Transport-Security: max-age=31536000; includeSubDomains; preload</value>    
+        </set-header>     
+    </outbound>
     <on-error />
 </policies>


### PR DESCRIPTION
## What’s changing?

Added APIM policy for HSTS.

## Why?

Security scanner finding (NAC-36)

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [X] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?

It was tested in TTS environment. 
