### PR TITLE
Use shared Db fixture for participants and match databases

### DIFF
--- a/dashboard/src/Piipan.Dashboard/packages.lock.json
+++ b/dashboard/src/Piipan.Dashboard/packages.lock.json
@@ -73,6 +73,14 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
         "resolved": "5.2.4",
@@ -1458,14 +1466,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -2017,6 +2019,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
+++ b/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
@@ -101,6 +101,14 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
         "resolved": "5.2.4",
@@ -1537,14 +1545,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -2163,6 +2165,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
@@ -2031,6 +2031,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
@@ -2179,6 +2179,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/src/Piipan.Match/Piipan.Match.Api/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Api/packages.lock.json
@@ -36,6 +36,14 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
         "resolved": "3.1.23",
@@ -995,14 +1003,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -1493,6 +1495,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/src/Piipan.Match/Piipan.Match.Core/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Core/packages.lock.json
@@ -1518,6 +1518,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
@@ -2205,6 +2205,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/packages.lock.json
@@ -1926,6 +1926,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/tests/Piipan.Match.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Api.Tests/packages.lock.json
@@ -100,6 +100,14 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
         "resolved": "3.1.23",
@@ -1099,14 +1107,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -1655,6 +1657,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/tests/Piipan.Match.Client.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Client.Tests/packages.lock.json
@@ -100,6 +100,14 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
         "resolved": "3.1.23",
@@ -1244,14 +1252,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -1825,6 +1827,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/tests/Piipan.Match.Core.IntegrationTests/MatchRecordDaoTests.cs
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/MatchRecordDaoTests.cs
@@ -26,7 +26,7 @@ namespace Piipan.Match.Core.IntegrationTests
                 .ReturnsAsync(() =>
                 {
                     var conn = Factory.CreateConnection();
-                    conn.ConnectionString = ConnectionString;
+                    conn.ConnectionString = CollabConnectionString;
                     conn.Open();
                     return conn;
                 });
@@ -40,7 +40,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
                 ClearMatchRecords();
 
@@ -71,7 +71,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
                 ClearMatchRecords();
 
@@ -104,7 +104,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
                 ClearMatchRecords();
 
@@ -134,7 +134,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
                 ClearMatchRecords();
 
@@ -165,7 +165,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
                 var logger = Mock.Of<ILogger<MatchRecordDao>>();
@@ -209,7 +209,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
                 var logger = Mock.Of<ILogger<MatchRecordDao>>();
@@ -255,7 +255,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
                 var logger = Mock.Of<ILogger<MatchRecordDao>>();

--- a/match/tests/Piipan.Match.Core.IntegrationTests/MatchResEventDaoTests.cs
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/MatchResEventDaoTests.cs
@@ -26,7 +26,7 @@ namespace Piipan.Match.Core.IntegrationTests
                 .ReturnsAsync(() =>
                 {
                     var conn = Factory.CreateConnection();
-                    conn.ConnectionString = ConnectionString;
+                    conn.ConnectionString = CollabConnectionString;
                     conn.Open();
                     return conn;
                 });
@@ -40,7 +40,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
                 ClearMatchResEvents();
 
@@ -83,7 +83,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
                 var logger = Mock.Of<ILogger<MatchResEventDao>>();
@@ -142,7 +142,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
                 var logger = Mock.Of<ILogger<MatchResEventDao>>();
@@ -203,7 +203,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
                 var logger = Mock.Of<ILogger<MatchResEventDao>>();
@@ -229,7 +229,7 @@ namespace Piipan.Match.Core.IntegrationTests
             using (var conn = Factory.CreateConnection())
             {
                 // Arrange
-                conn.ConnectionString = ConnectionString;
+                conn.ConnectionString = CollabConnectionString;
                 conn.Open();
 
                 var logger = Mock.Of<ILogger<MatchResEventDao>>();

--- a/match/tests/Piipan.Match.Core.IntegrationTests/Piipan.Match.Core.IntegrationTests.csproj
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/Piipan.Match.Core.IntegrationTests.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Piipan.Match\Piipan.Match.Core\Piipan.Match.Core.csproj" />
+    <ProjectReference Include="..\..\..\shared\src\Piipan.Shared\Piipan.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/match/tests/Piipan.Match.Core.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Core.Tests/packages.lock.json
@@ -1681,6 +1681,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/tests/Piipan.Match.Func.Api.IntegrationTests/DbFixture.cs
+++ b/match/tests/Piipan.Match.Func.Api.IntegrationTests/DbFixture.cs
@@ -4,6 +4,7 @@ using Dapper;
 using Npgsql;
 using Piipan.Match.Core.Models;
 using Piipan.Participants.Core.Models;
+using Piipan.Shared.Database;
 
 namespace Piipan.Match.Func.Api.IntegrationTests
 {
@@ -12,136 +13,8 @@ namespace Piipan.Match.Func.Api.IntegrationTests
     /// Creates a fresh set of participants and uploads tables, dropping them
     /// when testing is complete.
     /// </summary>
-    public class DbFixture : IDisposable
+    public class DbFixture : TestDbFixture
     {
-        public readonly string ConnectionString;
-        public readonly string CollabConnectionString;
-        public readonly NpgsqlFactory Factory;
-
-        public DbFixture()
-        {
-            ConnectionString = Environment.GetEnvironmentVariable("DatabaseConnectionString");
-            CollabConnectionString = Environment.GetEnvironmentVariable("CollaborationDatabaseConnectionString");
-            Factory = NpgsqlFactory.Instance;
-
-            Initialize(ConnectionString);
-            Initialize(CollabConnectionString);
-            ApplySchema();
-        }
-
-        /// <summary>
-        /// Ensure the database is able to receive connections before proceeding.
-        /// </summary>
-        public void Initialize(string connectionString)
-        {
-            var retries = 10;
-            var wait = 2000; // ms
-
-            while (retries >= 0)
-            {
-                try
-                {
-                    using (var conn = Factory.CreateConnection())
-                    {
-                        conn.ConnectionString = connectionString;
-                        conn.Open();
-                        conn.Close();
-
-                        return;
-                    }
-                }
-                catch (Npgsql.NpgsqlException ex)
-                {
-                    retries--;
-                    Console.WriteLine(ex.Message);
-                    Thread.Sleep(wait);
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            using (var conn = Factory.CreateConnection())
-            {
-                conn.ConnectionString = ConnectionString;
-                conn.Open();
-                conn.Execute("DROP TABLE IF EXISTS participants");
-                conn.Execute("DROP TABLE IF EXISTS uploads");
-                conn.Close();
-            }
-
-            using (var conn = Factory.CreateConnection())
-            {
-                conn.ConnectionString = CollabConnectionString;
-                conn.Open();
-                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
-                conn.Execute("DROP TABLE IF EXISTS match_res_events");
-                conn.Execute("DROP TABLE IF EXISTS matches");
-                conn.Close();
-            }
-
-        }
-
-        private void ApplySchema()
-        {
-            string perstateSql = System.IO.File.ReadAllText("per-state.sql", System.Text.Encoding.UTF8);
-            string matchesSql = System.IO.File.ReadAllText("match-record.sql", System.Text.Encoding.UTF8);
-
-            // Participants DB
-            using (var conn = Factory.CreateConnection())
-            {
-                conn.ConnectionString = ConnectionString;
-                conn.Open();
-
-                conn.Execute("DROP TABLE IF EXISTS participants");
-                conn.Execute("DROP TABLE IF EXISTS uploads");
-                conn.Execute(perstateSql);
-                conn.Execute("INSERT INTO uploads(created_at, publisher) VALUES(now() at time zone 'utc', current_user)");
-
-                conn.Close();
-            }
-
-            // Collaboration DB
-            using (var conn = Factory.CreateConnection())
-            {
-                conn.ConnectionString = CollabConnectionString;
-                conn.Open();
-
-                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
-                conn.Execute("DROP TABLE IF EXISTS match_res_events");
-                conn.Execute("DROP TABLE IF EXISTS matches");
-                conn.Execute(matchesSql);
-
-                conn.Close();
-            }
-        }
-
-        public void ClearParticipants()
-        {
-            using (var conn = Factory.CreateConnection())
-            {
-                conn.ConnectionString = ConnectionString;
-                conn.Open();
-
-                conn.Execute("DELETE FROM participants");
-
-                conn.Close();
-            }
-        }
-
-        public void ClearMatchRecords()
-        {
-            using (var conn = Factory.CreateConnection())
-            {
-                conn.ConnectionString = CollabConnectionString;
-                conn.Open();
-
-                conn.Execute("DELETE FROM matches");
-
-                conn.Close();
-            }
-        }
-
         public int CountMatchRecords()
         {
             int count;

--- a/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
@@ -2355,6 +2355,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/packages.lock.json
@@ -2060,6 +2060,7 @@
           "Moq": "4.17.2",
           "Npgsql": "6.0.3",
           "Piipan.Match.Core": "1.0.0",
+          "Piipan.Shared": "1.0.0",
           "xunit": "2.4.1"
         }
       },
@@ -2080,6 +2081,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/packages.lock.json
@@ -2071,6 +2071,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/packages.lock.json
@@ -1925,6 +1925,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/packages.lock.json
@@ -1966,6 +1966,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/metrics/tests/Piipan.Metrics.Client.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Client.Tests/packages.lock.json
@@ -111,6 +111,14 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
         "resolved": "5.2.4",
@@ -1520,14 +1528,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -2124,6 +2126,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/metrics/tests/Piipan.Metrics.Core.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Core.Tests/packages.lock.json
@@ -2049,6 +2049,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/metrics/tests/Piipan.Metrics.Func.Api.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Func.Api.Tests/packages.lock.json
@@ -2071,6 +2071,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/metrics/tests/Piipan.Metrics.Func.Collect.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Func.Collect.Tests/packages.lock.json
@@ -2111,6 +2111,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
+++ b/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
@@ -1659,6 +1659,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/query-tool/src/Piipan.QueryTool/package-lock.json
+++ b/query-tool/src/Piipan.QueryTool/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "Piipan.QueryTool",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/query-tool/src/Piipan.QueryTool/packages.lock.json
+++ b/query-tool/src/Piipan.QueryTool/packages.lock.json
@@ -60,6 +60,14 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
         "resolved": "3.1.23",
@@ -1169,14 +1177,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -1700,6 +1702,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
+++ b/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
@@ -96,6 +96,14 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
         "resolved": "3.1.23",
@@ -1262,14 +1270,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -1863,6 +1865,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",

--- a/shared/src/Piipan.Shared/Database/TestDbFixture.cs
+++ b/shared/src/Piipan.Shared/Database/TestDbFixture.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Threading;
+using Dapper;
+using Npgsql;
+
+namespace Piipan.Shared.Database
+{
+    /// <summary>
+    /// Base database fixture for integration testing.
+    /// Creates a fresh set of participants, uploads, matches and match_res_events tables, dropping them
+    /// when testing is complete.
+    /// Integration test projects can inherit from this class for their own needs.
+    /// </summary>
+    public class TestDbFixture : IDisposable
+    {
+        public readonly string ConnectionString;
+        public readonly string CollabConnectionString;
+        public readonly NpgsqlFactory Factory;
+
+        public TestDbFixture()
+        {
+            ConnectionString = Environment.GetEnvironmentVariable("DatabaseConnectionString");
+            CollabConnectionString = Environment.GetEnvironmentVariable("CollaborationDatabaseConnectionString");
+            Factory = NpgsqlFactory.Instance;
+
+            Initialize(ConnectionString);
+            Initialize(CollabConnectionString);
+            ApplySchema();
+        }
+
+        /// <summary>
+        /// Ensure the database is able to receive connections before proceeding.
+        /// </summary>
+        public void Initialize(string connectionString)
+        {
+            var retries = 10;
+            var wait = 2000; // ms
+
+            while (retries >= 0)
+            {
+                try
+                {
+                    using (var conn = Factory.CreateConnection())
+                    {
+                        conn.ConnectionString = connectionString;
+                        conn.Open();
+                        conn.Close();
+
+                        return;
+                    }
+                }
+                catch (Npgsql.NpgsqlException ex)
+                {
+                    retries--;
+                    Console.WriteLine(ex.Message);
+                    Thread.Sleep(wait);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            using (var conn = Factory.CreateConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+                conn.Execute("DROP TABLE IF EXISTS participants");
+                conn.Execute("DROP TABLE IF EXISTS uploads");
+                conn.Close();
+            }
+
+            using (var conn = Factory.CreateConnection())
+            {
+                conn.ConnectionString = CollabConnectionString;
+                conn.Open();
+                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS matches");
+                conn.Close();
+            }
+
+        }
+
+        private void ApplySchema()
+        {
+            string perstateSql = System.IO.File.ReadAllText("per-state.sql", System.Text.Encoding.UTF8);
+            string matchesSql = System.IO.File.ReadAllText("match-record.sql", System.Text.Encoding.UTF8);
+
+            // Participants DB
+            using (var conn = Factory.CreateConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                conn.Execute("DROP TABLE IF EXISTS participants");
+                conn.Execute("DROP TABLE IF EXISTS uploads");
+                conn.Execute(perstateSql);
+                conn.Execute("INSERT INTO uploads(created_at, publisher) VALUES(now() at time zone 'utc', current_user)");
+
+                conn.Close();
+            }
+
+            // Collaboration DB
+            using (var conn = Factory.CreateConnection())
+            {
+                conn.ConnectionString = CollabConnectionString;
+                conn.Open();
+
+                conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS match_res_events");
+                conn.Execute("DROP TABLE IF EXISTS matches");
+                conn.Execute(matchesSql);
+
+                conn.Close();
+            }
+        }
+
+        public void ClearParticipants()
+        {
+            using (var conn = Factory.CreateConnection())
+            {
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                conn.Execute("DELETE FROM participants");
+
+                conn.Close();
+            }
+        }
+
+        public void ClearMatchRecords()
+        {
+            using (var conn = Factory.CreateConnection())
+            {
+                conn.ConnectionString = CollabConnectionString;
+                conn.Open();
+
+                conn.Execute("DELETE FROM matches");
+
+                conn.Close();
+            }
+        }
+
+        public void ClearMatchResEvents()
+        {
+            using (var conn = Factory.CreateConnection())
+            {
+                conn.ConnectionString = CollabConnectionString;
+                conn.Open();
+
+                conn.Execute("DELETE FROM match_res_events");
+
+                conn.Close();
+            }
+        }
+    }
+}

--- a/shared/src/Piipan.Shared/Piipan.Shared.csproj
+++ b/shared/src/Piipan.Shared/Piipan.Shared.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.23" />
     <PackageReference Include="Azure.Core" Version="1.22.0" />
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
@@ -18,6 +19,11 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.23" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="Npgsql" Version="6.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\..\ddl\per-state.sql" Link="per-state.sql" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\..\match\ddl\match-record.sql" Link="match-record.sql" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/shared/src/Piipan.Shared/packages.lock.json
+++ b/shared/src/Piipan.Shared/packages.lock.json
@@ -32,6 +32,15 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
+      "Dapper": {
+        "type": "Direct",
+        "requested": "[2.0.123, )",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Direct",
         "requested": "[3.1.23, )",
@@ -1005,14 +1014,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",

--- a/shared/tests/Piipan.Shared.Tests/packages.lock.json
+++ b/shared/tests/Piipan.Shared.Tests/packages.lock.json
@@ -105,6 +105,14 @@
           "System.Xml.XmlDocument": "4.3.0"
         }
       },
+      "Dapper": {
+        "type": "Transitive",
+        "resolved": "2.0.123",
+        "contentHash": "RDFF4rBLLmbpi6pwkY7q/M6UXHRJEOerplDGE5jwEkP/JGJnBauAClYavNKJPW1yOTWRPIyfj4is3EaJxQXILQ==",
+        "dependencies": {
+          "System.Reflection.Emit.Lightweight": "4.7.0"
+        }
+      },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
         "resolved": "5.2.4",
@@ -1391,14 +1399,8 @@
       },
       "System.Reflection.Emit.Lightweight": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "4.7.0",
+        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Extensions": {
         "type": "Transitive",
@@ -1941,6 +1943,7 @@
         "dependencies": {
           "Azure.Core": "1.22.0",
           "Azure.Identity": "1.5.0",
+          "Dapper": "2.0.123",
           "Microsoft.AspNetCore.Authorization": "3.1.23",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",


### PR DESCRIPTION
## What’s changing?

This creates a shared database fixture responsible for applying the schema, setup, and teardown for the `participants` and `matches` databases. 

## Why?

Relates to #2841 

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)
- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
