### PR TITLE
Api Request Logging Middleware

### DIFF
--- a/shared/src/Piipan.Shared/Logging/ApiRequestLoggingMiddleware.cs
+++ b/shared/src/Piipan.Shared/Logging/ApiRequestLoggingMiddleware.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace Piipan.Shared.Logging
+{
+    public class ApiRequestLoggingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public ApiRequestLoggingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context,
+            ILogger<RequestLoggingMiddleware> logger)
+        {
+            logger.LogInformation("Executing request from user {User}", context.User?.Identity.Name);
+
+            HttpRequest request = context.Request;
+            string subscription = request.Headers["Ocp-Apim-Subscription-Name"];
+            if (subscription != null)
+            {
+                logger.LogInformation("Using APIM subscription {Subscription}", subscription);
+            }
+
+            string username = request.Headers["From"];
+            if (username != null)
+            {
+                logger.LogInformation("on behalf of {Username}", username);
+            }
+            await _next(context);
+        }
+    }
+}

--- a/shared/tests/Piipan.Shared.Tests/Logging/ApiRequestLoggingMiddlewareTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Logging/ApiRequestLoggingMiddlewareTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Piipan.Shared.Claims;
+using Xunit;
+
+namespace Piipan.Shared.Logging.Tests
+{
+    public class ApiRequestLoggingMiddlewareTests
+    {
+        [Fact]
+        public async void InvokeAsync_Succeeds()
+        {
+            // Arrange
+            var requestDelegate = new RequestDelegate((innerContext) => Task.FromResult(0));
+            var middleware = new ApiRequestLoggingMiddleware(requestDelegate);
+
+            var headers = new HeaderDictionary(new Dictionary<String, StringValues>
+            {
+                { "Ocp-Apim-Subscription-Name", "sub-name" },
+                { "From", "foobar"},
+                { "X-Initiating-State", "ea"}
+            }) as IHeaderDictionary;
+            var httpRequest = new Mock<HttpRequest>();
+            httpRequest
+                .Setup(m => m.Headers)
+                .Returns(headers);
+
+            var httpContext = new Mock<HttpContext>();
+            httpContext
+                .Setup(m => m.Request)
+                .Returns(httpRequest.Object);
+
+            var logger = new Mock<ILogger<RequestLoggingMiddleware>>();
+
+            // Act
+            await middleware.InvokeAsync(httpContext.Object, logger.Object);
+
+            // Assert
+            logger.Verify(x => x.Log(
+                It.Is<LogLevel>(l => l == LogLevel.Information),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Using APIM subscription sub-name")),
+                It.IsAny<Exception>(),
+                It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)
+            ));
+        }
+    }
+}


### PR DESCRIPTION
## What’s changing?

- Creates Middleware for Api request logging
~~- Implements Middleware into Api's~~

## Why?

Relates to GH issue #2833 

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [X] **Automated unit tests** (_to maintain or increase level of code coverage_)
- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
