### PR TITLE
Update APIM match test script to use EB subscription

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -47,10 +47,10 @@ NOTE: If you are using docker you can skip step 1 to 5 running the following com
     ./configure-oidc-apps.bash tts/dev
 ```
 
-7. Create a subscription in the API Management service. For now, the API Management subscriptions are created manually and not by the IaC. For example, you’ll need to create `EA-DupPart` and `EA-BulkUpload` before you can use the `test-apim-upload-api.bash` and `test-apim-match-api.bash` test scripts.
+7. Create a subscription in the API Management service. For now, the API Management subscriptions are created manually and not by the IaC. For example, you’ll need to create `EB-DupPart` and `EA-BulkUpload` before you can use the `test-apim-upload-api.bash` and `test-apim-match-api.bash` test scripts.
 
 ```
-    ./match/tools/create-apim-match-subscription.bash tts/dev ea
+    ./match/tools/create-apim-match-subscription.bash tts/dev eb
     ./etl/tools/create-apim-bulk-subscription.bash tts/dev ea
 ```
 

--- a/match/tools/test-apim-match-api.bash
+++ b/match/tools/test-apim-match-api.bash
@@ -12,7 +12,7 @@
 # shellcheck source=./tools/common.bash
 source "$(dirname "$0")"/../../tools/common.bash || exit
 
-SUBSCRIPTION_NAME="EA-DupPart"
+SUBSCRIPTION_NAME="EB-DupPart"
 MATCH_API_PATH="/match/v2/find_matches"
 
 # Hash digest for farrington,10/13/31,425-46-5417


### PR DESCRIPTION
## What’s changing?

- Upload script uses EA
- Initiating state is now excluded from matching
- Switch match test script to use EB and generate matches
- Update IaC documentation

## Why?

Closes NAC-519

## This PR has:

- ~[ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~
- [x]  **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- ~[ ] **Automated unit tests** (_to maintain or increase level of code coverage_)~
- ~[ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~

## Anything else?
