### PR TITLE
Cjc 164

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -61,6 +61,7 @@ Searches all state databases for any participant records that are an exact match
 |» lds_hash|body|string|true|SHA-512 digest of participant's last name, DoB, and SSN. See docs/pprl.md for details|
 |» participant_id|body|string|false|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |» case_id|body|string|false|Participant's state-specific case number|
+|» search_reason|body|string|false|User's reason for running match query. Must be either 'Application', 'Recertification', or 'New Household Member'|
 
 > Example responses
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -47,6 +47,9 @@ paths:
                       case_id:
                         type: string
                         description: Participant's state-specific case number
+                      search_reason:
+                        type: string
+                        description: 'User''s reason for running match query. Must be either ''Application'', ''Recertification'', or ''New Household Member'''
             examples:
               Single person:
                 description: 'An example request to query a single person, with values for all fields'
@@ -120,7 +123,7 @@ paths:
                                     items:
                                       type: string
                                       pattern: '^\d{4}-\d{2}-\d{2}/d{4}-\d{2}-\d{2}$'
-                                      example: 2021-01-01/2021-01-31
+                                      example: 2021-01
                                     minItems: 0
                                     maxItems: 3
                                     description: 'List of up to the last 3 date ranges that participant received benefits, in descending order. Each date range is formatted as ISO 8601 year, month and day. Does not include current benefit issuances date range.'
@@ -184,9 +187,9 @@ paths:
                               participant_id: string
                               participant_closing_date: '2021-10-13'
                               recent_benefit_issuance_dates:
-                                - '2021-05-01/2021-05-31'
-                                - '2021-04-01/2021-04-30'
-                                - '2021-03-01/2021-03-31'
+                                - 2021-05-01/2021-05-31
+                                - 2021-04-01/2021-04-30
+                                - 2021-03-01/2021-03-31
                               protect_location: true
                       errors: []
                 No matches:
@@ -210,9 +213,9 @@ paths:
                               participant_id: string
                               participant_closing_date: '2021-10-13'
                               recent_benefit_issuance_dates:
-                                - '2021-05-01/2021-05-31'
-                                - '2021-04-01/2021-04-30'
-                                - '2021-03-01/2021-03-31'
+                                - 2021-05-01/2021-05-31
+                                - 2021-04-01/2021-04-30
+                                - 2021-03-01/2021-03-31
                               protect_location: true
                             - match_id: 4567CDF
                               state: ec

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -123,7 +123,7 @@ paths:
                                     items:
                                       type: string
                                       pattern: '^\d{4}-\d{2}-\d{2}/d{4}-\d{2}-\d{2}$'
-                                      example: 2021-01
+                                      example: 2021-01-01/2021-01-31
                                     minItems: 0
                                     maxItems: 3
                                     description: 'List of up to the last 3 date ranges that participant received benefits, in descending order. Each date range is formatted as ISO 8601 year, month and day. Does not include current benefit issuances date range.'
@@ -187,9 +187,9 @@ paths:
                               participant_id: string
                               participant_closing_date: '2021-10-13'
                               recent_benefit_issuance_dates:
-                                - 2021-05-01/2021-05-31
-                                - 2021-04-01/2021-04-30
-                                - 2021-03-01/2021-03-31
+                                - '2021-05-01/2021-05-31'
+                                - '2021-04-01/2021-04-30'
+                                - '2021-03-01/2021-03-31'
                               protect_location: true
                       errors: []
                 No matches:
@@ -213,9 +213,9 @@ paths:
                               participant_id: string
                               participant_closing_date: '2021-10-13'
                               recent_benefit_issuance_dates:
-                                - 2021-05-01/2021-05-31
-                                - 2021-04-01/2021-04-30
-                                - 2021-03-01/2021-03-31
+                                - '2021-05-01/2021-05-31'
+                                - '2021-04-01/2021-04-30'
+                                - '2021-03-01/2021-03-31'
                               protect_location: true
                             - match_id: 4567CDF
                               state: ec

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -48,6 +48,9 @@ Person:
     case_id:
       type: string
       description: "Participant's state-specific case number"
+    search_reason:
+      type: string
+      description: "User's reason for running match query. Must be either 'Application', 'Recertification', or 'New Household Member'"
 PersonWithPii:
   type: object
   required:

--- a/match/src/Piipan.Match/Piipan.Match.Api/Models/OrchMatchRequest.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/Models/OrchMatchRequest.cs
@@ -30,5 +30,9 @@ namespace Piipan.Match.Api.Models
         [JsonProperty("case_id",
             NullValueHandling = NullValueHandling.Ignore)]
         public string CaseId { get; set; }
+
+        [JsonProperty("search_reason",
+            NullValueHandling = NullValueHandling.Ignore)]
+        public string SearchReason { get; set; }
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Enums/Enums.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Enums/Enums.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Piipan.Match.Core.Enums
+{
+    public enum ValidSearchReasons
+    {
+        application,recertification,new_household_member,other
+    }
+}

--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
@@ -56,6 +56,19 @@ namespace Piipan.Match.Core.Parsers
                 {
                     throw new ValidationException("request validation failed", validationResult.Errors);
                 }
+                ///Checking search_reason for valid reason. If reason given is not 
+                ///"Application","Recertification" or "New Household Member" setting to null
+                for (int i = 0; i < request.Data.Count; i++)
+                {
+                    if (request.Data[i].SearchReason != null)
+                    {
+                        if (!request.Data[i].SearchReason.ToLower().Contains("application") && !request.Data[i].SearchReason.ToLower().Contains("recertification") && !request.Data[i].SearchReason.ToLower().Contains("new household member"))
+                        {
+                            request.Data[i].SearchReason = null;
+                        }
+                    }
+                    
+                }
                 
                 return request;
             }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
@@ -6,6 +6,7 @@ using Piipan.Match.Api.Models;
 using Newtonsoft.Json;
 using FluentValidation;
 using System.Linq;
+using Piipan.Match.Core.Enums;
 
 namespace Piipan.Match.Core.Parsers
 {
@@ -59,19 +60,14 @@ namespace Piipan.Match.Core.Parsers
                 }
                 ///Checking search_reason for valid reason. If reason given is not 
                 ///in allowed list of search reasons then setting reason to null
-                string[] validSearchReasons =
-                {
-                    "application",
-                    "recertification",
-                    "new household member"
-                };
                 for (int i = 0; i < request.Data.Count; i++)
                 {
                     if (request.Data[i].SearchReason != null)
                     {
-                        if (!validSearchReasons.Contains(request.Data[i].SearchReason.ToLower()))
+                        request.Data[i].SearchReason = request.Data[i].SearchReason.ToLower();
+                        if (!Enum.IsDefined(typeof(ValidSearchReasons), request.Data[i].SearchReason))
                         {
-                            request.Data[i].SearchReason = null;
+                            request.Data[i].SearchReason = ValidSearchReasons.other.ToString();
                         }
                     }
                     

--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Piipan.Match.Api.Models;
 using Newtonsoft.Json;
 using FluentValidation;
+using System.Linq;
 
 namespace Piipan.Match.Core.Parsers
 {
@@ -57,15 +58,23 @@ namespace Piipan.Match.Core.Parsers
                     throw new ValidationException("request validation failed", validationResult.Errors);
                 }
                 ///Checking search_reason for valid reason. If reason given is not 
-                ///"Application","Recertification" or "New Household Member" setting to null
+                ///in allowed list of search reasons then setting reason to null
+                string[] validSearchReasons =
+                {
+                    "application",
+                    "recertification",
+                    "new household member"
+                };
                 for (int i = 0; i < request.Data.Count; i++)
                 {
                     if (request.Data[i].SearchReason != null)
                     {
-                        if (!request.Data[i].SearchReason.ToLower().Contains("application") && !request.Data[i].SearchReason.ToLower().Contains("recertification") && !request.Data[i].SearchReason.ToLower().Contains("new household member"))
+                        
+                        if (!validSearchReasons.Contains(request.Data[i].SearchReason.ToLower()))
                         {
                             request.Data[i].SearchReason = null;
                         }
+                        
                     }
                     
                 }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
@@ -69,12 +69,10 @@ namespace Piipan.Match.Core.Parsers
                 {
                     if (request.Data[i].SearchReason != null)
                     {
-                        
                         if (!validSearchReasons.Contains(request.Data[i].SearchReason.ToLower()))
                         {
                             request.Data[i].SearchReason = null;
                         }
-                        
                     }
                     
                 }

--- a/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
@@ -124,6 +124,7 @@ namespace Piipan.Match.Core.Tests.Parsers
             var body = @"{'data':[
                 { 'lds_hash':'eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458' }
             ]}";
+            
             var logger = Mock.Of<ILogger<OrchMatchRequestParser>>();
             var validator = new Mock<IValidator<OrchMatchRequest>>();
             validator

--- a/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
@@ -124,7 +124,6 @@ namespace Piipan.Match.Core.Tests.Parsers
             var body = @"{'data':[
                 { 'lds_hash':'eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458' }
             ]}";
-
             var logger = Mock.Of<ILogger<OrchMatchRequestParser>>();
             var validator = new Mock<IValidator<OrchMatchRequest>>();
             validator

--- a/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
@@ -10,6 +10,8 @@ using Moq;
 using Xunit;
 using FluentValidation;
 using FluentValidation.Results;
+using Newtonsoft.Json;
+using Piipan.Match.Core.Enums;
 
 namespace Piipan.Match.Core.Tests.Parsers
 {
@@ -76,6 +78,45 @@ namespace Piipan.Match.Core.Tests.Parsers
             Assert.Equal(count, request.Data.Count());
         }
 
+        [Theory]
+        [InlineData("Application", ValidSearchReasons.application)]
+        [InlineData("ASDF", ValidSearchReasons.other)]
+        [InlineData("Recertification", ValidSearchReasons.recertification)]
+        [InlineData("New_household_member", ValidSearchReasons.new_household_member)]
+        [InlineData("New household member", ValidSearchReasons.other)]
+        [InlineData("OTHER", ValidSearchReasons.other)]
+        [InlineData("", ValidSearchReasons.other)]
+        public async Task ValidSearchReason(string searchReason, ValidSearchReasons expectedSearchReason)
+        {
+            // Arrange
+            var logger = Mock.Of<ILogger<OrchMatchRequestParser>>();
+            var validator = new Mock<IValidator<OrchMatchRequest>>();
+            validator
+                .Setup(m => m.ValidateAsync(It.IsAny<OrchMatchRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ValidationResult());
+
+            var parser = new OrchMatchRequestParser(validator.Object, logger);
+
+            var orchMatchRequest = new OrchMatchRequest
+            {
+                Data = new List<RequestPerson>()
+                {
+                    new RequestPerson
+                    {
+                        LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458",
+                        SearchReason = searchReason
+                    }
+                }
+            };
+
+            //Act
+            var request = await parser.Parse(BuildStream(JsonConvert.SerializeObject(orchMatchRequest)));
+
+            // Assert
+            Assert.NotNull(request);
+            Assert.Equal(expectedSearchReason.ToString(), request.Data[0].SearchReason);
+        }
+
         [Fact]
         public async Task ThrowsWhenValidatorThrows()
         {
@@ -83,7 +124,7 @@ namespace Piipan.Match.Core.Tests.Parsers
             var body = @"{'data':[
                 { 'lds_hash':'eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458' }
             ]}";
-        
+
             var logger = Mock.Of<ILogger<OrchMatchRequestParser>>();
             var validator = new Mock<IValidator<OrchMatchRequest>>();
             validator


### PR DESCRIPTION
## What’s changing?

Match API now accepts search reason. 

## Why?

ticket 164

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?

Api was updated. for testing the search reason must be one of the following, "Application", "Recertification", "New Household Member". If it is not one of those inputs it will still make the match record but have a null search reason