### PR TITLE
Added host name and match URL to the participant match record

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -115,6 +115,7 @@ The following environment variables are pre-configured by the Infrastructure-as-
 | `MetricsApiAppId` | [Application ID](./securing-internal-apis.md#application-id-uri) for Metrics API's Azure Active Directory application object | Piipan.Dashboard |
 | `KeyVaultName` | Name of key vault resource needed to acquire a secret | Piipan.Metrics.Func.Api, Piipan.Metrics.Func.Collect |
 | `CloudName` | Name of the active Azure cloud environment, either `AzureCloud` or `AzureUSGovernment` | Piipan.Etl, Piipan.Match.Orchestrator, Piipan.Metrics.Func.Api, Piipan.Metrics.Func.Collect |
+| `QueryToolUrl` | URL for the associated Query Tool. | Piipan.Match.Orchestrator |
 
 
 ## `SysType` resource tag

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -31,6 +31,8 @@ set_constants () {
   ORCHESTRATOR_FUNC_APP_STORAGE_NAME=${PREFIX}storchestrator${ENV}
 
   PRIVATE_DNS_ZONE=$(private_dns_zone)
+
+  FRONT_DOOR_URI="https://$QUERY_TOOL_FRONTDOOR_NAME"$(front_door_host_suffix)
 }
 
 # Generate the storage account connection string for the corresponding
@@ -363,7 +365,8 @@ main () {
     --resource-group "$MATCH_RESOURCE_GROUP" \
     --settings \
       WEBSITE_CONTENTOVERVNET=1 \
-      WEBSITE_VNET_ROUTE_ALL=1
+      WEBSITE_VNET_ROUTE_ALL=1 \
+      QueryToolUrl="$FRONT_DOOR_URI"
 
   # Create an Active Directory app registration associated with the app.
   # Used by subsequent resources to configure auth
@@ -630,7 +633,7 @@ main () {
       idpClientId="$QUERY_TOOL_APP_IDP_CLIENT_ID" \
       aspNetCoreEnvironment="$PREFIX" \
       frontDoorId="$front_door_id" \
-      frontDoorUri="$front_door_uri"
+      frontDoorUri="$FRONT_DOOR_URI"
 
   echo "Integrating ${QUERY_TOOL_APP_NAME} into virtual network"
   az functionapp vnet-integration add \

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -32,7 +32,7 @@ set_constants () {
 
   PRIVATE_DNS_ZONE=$(private_dns_zone)
 
-  FRONT_DOOR_URI="https://$QUERY_TOOL_FRONTDOOR_NAME"$(front_door_host_suffix)
+  QUERY_TOOL_URL="https://$QUERY_TOOL_FRONTDOOR_NAME"$(front_door_host_suffix)
 }
 
 # Generate the storage account connection string for the corresponding
@@ -366,7 +366,7 @@ main () {
     --settings \
       WEBSITE_CONTENTOVERVNET=1 \
       WEBSITE_VNET_ROUTE_ALL=1 \
-      QueryToolUrl="$FRONT_DOOR_URI"
+      QueryToolUrl="$QUERY_TOOL_URL"
 
   # Create an Active Directory app registration associated with the app.
   # Used by subsequent resources to configure auth
@@ -600,7 +600,6 @@ main () {
     --output tsv)
   echo "Front Door iD: ${front_door_id}"
 
-  front_door_uri="https://$QUERY_TOOL_FRONTDOOR_NAME"$(front_door_host_suffix)
   orch_api_uri=$(\
     az functionapp show \
       -g "$MATCH_RESOURCE_GROUP" \
@@ -633,7 +632,7 @@ main () {
       idpClientId="$QUERY_TOOL_APP_IDP_CLIENT_ID" \
       aspNetCoreEnvironment="$PREFIX" \
       frontDoorId="$front_door_id" \
-      frontDoorUri="$FRONT_DOOR_URI"
+      frontDoorUri="$QUERY_TOOL_URL"
 
   echo "Integrating ${QUERY_TOOL_APP_NAME} into virtual network"
   az functionapp vnet-integration add \

--- a/match/docs/openapi/schemas/participant-record.yaml
+++ b/match/docs/openapi/schemas/participant-record.yaml
@@ -38,6 +38,9 @@ ParticipantRecord:
       nullable: true
       example: true
       description: "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values."
+    match_url:
+      type: string
+      description: "URL to visit to view details about this match."
 
 ParticipantRecordExamples:
   All:
@@ -51,6 +54,7 @@ ParticipantRecordExamples:
       - "2021-04-01/2021-04-30"
       - "2021-03-01/2021-03-31"
     protect_location: true
+    match_url: "https://test.com/match?id=BCD2345"
   AllEB:
     match_id: "XYZ9876"
     state: "eb"
@@ -62,6 +66,7 @@ ParticipantRecordExamples:
       - "2021-04-01/2021-04-30"
       - "2021-03-01/2021-03-31"
     protect_location: true
+    match_url: "https://test.com/match?id=XYZ9876"
   Required:
     match_id: "4567CDF"
     state: "ec"
@@ -69,3 +74,4 @@ ParticipantRecordExamples:
     participant_id: "string"
     participant_closing_date: null
     protect_location: null
+    match_url: "https://test.com/match?id=4567CDF"

--- a/match/docs/orchestrator-match.md
+++ b/match/docs/orchestrator-match.md
@@ -24,6 +24,7 @@ The following environment variables are required by the orchestrator and are set
 |---|---|
 | `DatabaseConnectionString` | [details](../../docs/iac.md#\:\~\:text=DatabaseConnectionString) — Additionally, `Database` is set to the placeholder value `{database}`. The relevant per-state database name is inserted at run-time as needed. |
 | `States` | [details](../../docs/iac.md#\:\~\:text=States) |
+| `QueryToolUrl` | [details](../../docs/iac.md#\:\~\:text=QueryToolUrl) |
 
 ## Local development
 

--- a/match/src/Piipan.Match/Piipan.Match.Api/Models/ParticipantMatch.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/Models/ParticipantMatch.cs
@@ -36,6 +36,9 @@ namespace Piipan.Match.Api.Models
         [JsonProperty("protect_location")]
         public bool? ProtectLocation { get; set; }
 
+        [JsonProperty("match_url")]
+        public string MatchUrl { get; set; }
+
         public ParticipantMatch() { }
 
         public ParticipantMatch(IParticipant p)

--- a/match/src/Piipan.Match/Piipan.Match.Core/Services/MatchEventService.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Services/MatchEventService.cs
@@ -91,7 +91,7 @@ namespace Piipan.Match.Core.Services
             }
             if (participantMatchRecord != null)
             {
-                var queryToolUrl = Environment.GetEnvironmentVariable("QueryToolUri");
+                var queryToolUrl = Environment.GetEnvironmentVariable("QueryToolUrl");
                 participantMatchRecord.MatchUrl = $"{queryToolUrl}/match?id={participantMatchRecord.MatchId}";
             }
             return participantMatchRecord;

--- a/match/src/Piipan.Match/Piipan.Match.Core/Services/MatchEventService.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Services/MatchEventService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -75,17 +76,25 @@ namespace Piipan.Match.Core.Services
         private async Task<ParticipantMatch> ResolveSingleMatch(IParticipant match, IMatchRecord record)
         {
             var existingRecords = await _recordApi.GetRecords(record);
-
+            ParticipantMatch participantMatchRecord;
             if (existingRecords.Any())
             {
-                return await Reconcile(match, record, existingRecords);
+                participantMatchRecord = await Reconcile(match, record, existingRecords);
             }
-
-            // No existing records
-            return new ParticipantMatch(match)
+            else
             {
-                MatchId = await _recordApi.AddRecord(record)
-            };
+                // No existing records
+                participantMatchRecord = new ParticipantMatch(match)
+                {
+                    MatchId = await _recordApi.AddRecord(record)
+                };
+            }
+            if (participantMatchRecord != null)
+            {
+                var queryToolUrl = Environment.GetEnvironmentVariable("QueryToolUri");
+                participantMatchRecord.MatchUrl = $"{queryToolUrl}/match?id={participantMatchRecord.MatchId}";
+            }
+            return participantMatchRecord;
         }
 
         private async Task<ParticipantMatch> Reconcile(IParticipant match, IMatchRecord pendingRecord, IEnumerable<IMatchRecord> existingRecords)

--- a/match/tests/Piipan.Match.Core.Tests/Builders/ActiveMatchRecordBuilderTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Builders/ActiveMatchRecordBuilderTests.cs
@@ -60,7 +60,7 @@ namespace Piipan.Match.Core.Tests.Builders
 
             // Assert
             Assert.Equal("{\"lds_hash\":\"foo\",\"participant_id\":\"DEF\",\"case_id\":\"ABC\"}", record.Input);
-            Assert.Equal("{\"match_id\":null,\"lds_hash\":\"foo\",\"state\":null,\"case_id\":\"XYZ\",\"participant_id\":\"TUV\",\"participant_closing_date\":null,\"recent_benefit_issuance_dates\":[],\"protect_location\":null}", record.Data);
+            Assert.Equal("{\"match_id\":null,\"lds_hash\":\"foo\",\"state\":null,\"case_id\":\"XYZ\",\"participant_id\":\"TUV\",\"participant_closing_date\":null,\"recent_benefit_issuance_dates\":[],\"protect_location\":null,\"match_url\":null}", record.Data);
 
         }
 

--- a/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
@@ -174,6 +174,8 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsMatchId()
         {
             // Arrange
+            var queryToolUri = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
             var mockMatchId = "BDC2345";
             var record = new MatchRecordDbo
             {
@@ -210,8 +212,10 @@ namespace Piipan.Match.Core.Tests.Services
 
             // Act
             var resolvedResponse = await service.ResolveMatches(request, response, "ea");
+            var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
+            Assert.Equal($"{queryToolUri}/match?id={mockMatchId}", firstMatch.MatchUrl);
             Assert.Equal(mockMatchId, resolvedResponse.Data.Results.First().Matches.First().MatchId);
         }
 
@@ -219,6 +223,8 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsMostRecentMatchId()
         {
             // Arrange
+            var queryToolUri = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
             var openMatchId = "BDC2345";
             var closedMatchId = "CDB5432";
             var record = new MatchRecordDbo
@@ -267,15 +273,19 @@ namespace Piipan.Match.Core.Tests.Services
 
             // Act
             var resolvedResponse = await service.ResolveMatches(request, response, "ea");
-
+            var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
+            
             // Assert
-            Assert.Equal(openMatchId, resolvedResponse.Data.Results.First().Matches.First().MatchId);
+            Assert.Equal($"{queryToolUri}/match?id={openMatchId}", firstMatch.MatchUrl);
+            Assert.Equal(openMatchId, firstMatch.MatchId);
         }
 
         [Fact]
         public async void Resolve_InsertsOpenMatchId()
         {
             // Arrange
+            var queryToolUri = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
             var openMatchId = "BDC2345";
             var record = new MatchRecordDbo
             {
@@ -318,15 +328,20 @@ namespace Piipan.Match.Core.Tests.Services
 
             // Act
             var resolvedResponse = await service.ResolveMatches(request, response, "ea");
+            var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal(openMatchId, resolvedResponse.Data.Results.First().Matches.First().MatchId);
+            Assert.Equal($"{queryToolUri}/match?id={openMatchId}", firstMatch.MatchUrl);
+            Assert.Equal(openMatchId, firstMatch.MatchId);
         }
 
         [Fact]
         public async void Resolve_InsertsNewMatchIdIfMostRecentRecordIsClosed()
         {
             // Arrange
+            var queryToolUri = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
+
             var newId = "newId";
             var record = new MatchRecordDbo
             {
@@ -372,9 +387,11 @@ namespace Piipan.Match.Core.Tests.Services
 
             // Act
             var resolvedResponse = await service.ResolveMatches(request, response, "ea");
+            var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal(newId, resolvedResponse.Data.Results.First().Matches.First().MatchId);
+            Assert.Equal($"{queryToolUri}/match?id={newId}", firstMatch.MatchUrl);
+            Assert.Equal(newId, firstMatch.MatchId);
         }
     }
 }

--- a/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
@@ -15,6 +15,13 @@ namespace Piipan.Match.Core.Tests.Services
 {
     public class MatchEventServiceTests
     {
+        private const string QueryToolUrl = "https://tts.test";
+
+        public MatchEventServiceTests()
+        {
+            Environment.SetEnvironmentVariable("QueryToolUrl", QueryToolUrl);
+        }
+
         private Mock<IActiveMatchRecordBuilder> BuilderMock(MatchRecordDbo record)
         {
             var recordBuilder = new Mock<IActiveMatchRecordBuilder>();
@@ -174,8 +181,6 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsMatchId()
         {
             // Arrange
-            var queryToolUrl = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
             var mockMatchId = "BDC2345";
             var record = new MatchRecordDbo
             {
@@ -215,7 +220,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal($"{queryToolUrl}/match?id={mockMatchId}", firstMatch.MatchUrl);
+            Assert.Equal($"{QueryToolUrl}/match?id={mockMatchId}", firstMatch.MatchUrl);
             Assert.Equal(mockMatchId, resolvedResponse.Data.Results.First().Matches.First().MatchId);
         }
 
@@ -223,8 +228,6 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsMostRecentMatchId()
         {
             // Arrange
-            var queryToolUrl = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
             var openMatchId = "BDC2345";
             var closedMatchId = "CDB5432";
             var record = new MatchRecordDbo
@@ -276,7 +279,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
             
             // Assert
-            Assert.Equal($"{queryToolUrl}/match?id={openMatchId}", firstMatch.MatchUrl);
+            Assert.Equal($"{QueryToolUrl}/match?id={openMatchId}", firstMatch.MatchUrl);
             Assert.Equal(openMatchId, firstMatch.MatchId);
         }
 
@@ -284,8 +287,6 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsOpenMatchId()
         {
             // Arrange
-            var queryToolUrl = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
             var openMatchId = "BDC2345";
             var record = new MatchRecordDbo
             {
@@ -331,7 +332,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal($"{queryToolUrl}/match?id={openMatchId}", firstMatch.MatchUrl);
+            Assert.Equal($"{QueryToolUrl}/match?id={openMatchId}", firstMatch.MatchUrl);
             Assert.Equal(openMatchId, firstMatch.MatchId);
         }
 
@@ -339,9 +340,6 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsNewMatchIdIfMostRecentRecordIsClosed()
         {
             // Arrange
-            var queryToolUrl = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
-
             var newId = "newId";
             var record = new MatchRecordDbo
             {
@@ -390,7 +388,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal($"{queryToolUrl}/match?id={newId}", firstMatch.MatchUrl);
+            Assert.Equal($"{QueryToolUrl}/match?id={newId}", firstMatch.MatchUrl);
             Assert.Equal(newId, firstMatch.MatchId);
         }
     }

--- a/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
@@ -174,8 +174,8 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsMatchId()
         {
             // Arrange
-            var queryToolUri = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
+            var queryToolUrl = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
             var mockMatchId = "BDC2345";
             var record = new MatchRecordDbo
             {
@@ -215,7 +215,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal($"{queryToolUri}/match?id={mockMatchId}", firstMatch.MatchUrl);
+            Assert.Equal($"{queryToolUrl}/match?id={mockMatchId}", firstMatch.MatchUrl);
             Assert.Equal(mockMatchId, resolvedResponse.Data.Results.First().Matches.First().MatchId);
         }
 
@@ -223,8 +223,8 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsMostRecentMatchId()
         {
             // Arrange
-            var queryToolUri = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
+            var queryToolUrl = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
             var openMatchId = "BDC2345";
             var closedMatchId = "CDB5432";
             var record = new MatchRecordDbo
@@ -276,7 +276,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
             
             // Assert
-            Assert.Equal($"{queryToolUri}/match?id={openMatchId}", firstMatch.MatchUrl);
+            Assert.Equal($"{queryToolUrl}/match?id={openMatchId}", firstMatch.MatchUrl);
             Assert.Equal(openMatchId, firstMatch.MatchId);
         }
 
@@ -284,8 +284,8 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsOpenMatchId()
         {
             // Arrange
-            var queryToolUri = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
+            var queryToolUrl = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
             var openMatchId = "BDC2345";
             var record = new MatchRecordDbo
             {
@@ -331,7 +331,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal($"{queryToolUri}/match?id={openMatchId}", firstMatch.MatchUrl);
+            Assert.Equal($"{queryToolUrl}/match?id={openMatchId}", firstMatch.MatchUrl);
             Assert.Equal(openMatchId, firstMatch.MatchId);
         }
 
@@ -339,8 +339,8 @@ namespace Piipan.Match.Core.Tests.Services
         public async void Resolve_InsertsNewMatchIdIfMostRecentRecordIsClosed()
         {
             // Arrange
-            var queryToolUri = "https://tts.test";
-            Environment.SetEnvironmentVariable("QueryToolUri", queryToolUri);
+            var queryToolUrl = "https://tts.test";
+            Environment.SetEnvironmentVariable("QueryToolUrl", queryToolUrl);
 
             var newId = "newId";
             var record = new MatchRecordDbo
@@ -390,7 +390,7 @@ namespace Piipan.Match.Core.Tests.Services
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
 
             // Assert
-            Assert.Equal($"{queryToolUri}/match?id={newId}", firstMatch.MatchUrl);
+            Assert.Equal($"{queryToolUrl}/match?id={newId}", firstMatch.MatchUrl);
             Assert.Equal(newId, firstMatch.MatchId);
         }
     }


### PR DESCRIPTION
## What’s changing?

The participant match record returned back from the Duplicate Participation API needs to return a MatchURL field, which should be populated with the associated Query Tool link.

## Why?

This satisfies NAC-229

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [X] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [X] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
