### PR TITLE
Added hsts policy on errors

### DIFF
--- a/iac/apim-policy.xml
+++ b/iac/apim-policy.xml
@@ -10,6 +10,9 @@
                     <set-header name="Content-Type" exists-action="override">
                         <value>application/json; charset=UTF-8</value>
                     </set-header>
+                    <set-header name="Strict-Transport-Security" exists-action="override">    
+                        <value>Strict-Transport-Security: max-age=31536000; includeSubDomains; preload</value>
+                    </set-header>     
                     <set-body>{"statusCode": 401, "message": "Access denied due to invalid subscription key. Make sure to provide a valid key for an active subscription."}</set-body>
                 </return-response>
             </when>
@@ -20,8 +23,12 @@
     </backend>
     <outbound>
         <set-header name="Strict-Transport-Security" exists-action="override">    
-            <value>Strict-Transport-Security: max-age=31536000; includeSubDomains; preload</value>    
+            <value>Strict-Transport-Security: max-age=31536000; includeSubDomains; preload</value>
         </set-header>     
     </outbound>
-    <on-error />
+    <on-error>
+        <set-header name="Strict-Transport-Security" exists-action="override">    
+            <value>Strict-Transport-Security: max-age=31536000; includeSubDomains; preload</value>
+        </set-header>  
+    </on-error>
 </policies>


### PR DESCRIPTION
## What’s changing?

Added hsts policy on error pages for the scanner.

## Why?

NAC-36

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [x] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
