### PR TITLE
Added queue storage to be use with the event grid

### DIFF
--- a/iac/arm-templates/blob-storage.json
+++ b/iac/arm-templates/blob-storage.json
@@ -65,6 +65,19 @@
                     "dependsOn": [
                         "[variables('uniqueStorageName')]"
                     ]
+                },
+                {
+                    "type": "queueServices/queues",
+                    "apiVersion": "2019-06-01",
+                    "name": "[concat('default/q', variables('containerName'))]",
+                    "properties": {
+                        "metadata": {
+                            "test":"approved"
+                        }
+                    },
+                    "dependsOn": [
+                        "[variables('uniqueStorageName')]"
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
## What’s changing?

Added queue storage

## Why?

This is the IaC to add the queue storage which is needed for the #PR2985 and the [proposed solution](https://github.com/18F/piipan/pull/2985#pullrequestreview-933712743) 

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [X] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
