### PR TITLE
Adjustments to DateRange bound handling

### DIFF
--- a/etl/tests/Piipan.Etl.Func.BulkUpload.IntegrationTests/DbFixture.cs
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.IntegrationTests/DbFixture.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using Piipan.Etl.Func.BulkUpload.Models;
-using Npgsql;
-using Piipan.Participants.Api.Models;
-using Piipan.Shared.Utilities;
-using NpgsqlTypes;
-using System.Linq;
 using Dapper;
+using Npgsql;
+using Piipan.Etl.Func.BulkUpload.Models;
+using Piipan.Participants.Api.Models;
 
 namespace Piipan.Etl.Func.BulkUpload.IntegrationTests
 {
@@ -25,6 +22,8 @@ namespace Piipan.Etl.Func.BulkUpload.IntegrationTests
         {
             ConnectionString = Environment.GetEnvironmentVariable("DatabaseConnectionString");
             Factory = NpgsqlFactory.Instance;
+
+            Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true;
 
             Initialize();
             ApplySchema();
@@ -127,37 +126,16 @@ namespace Piipan.Etl.Func.BulkUpload.IntegrationTests
 
         public IEnumerable<IParticipant> QueryParticipants(string sql)
         {
-            var records = new List<IParticipant>();
+            IEnumerable<IParticipant> records;
 
             using (var conn = Factory.CreateConnection())
             {
                 conn.ConnectionString = ConnectionString;
                 conn.Open();
-
-
-                using (var cmd = Factory.CreateCommand())
-                {
-
-                    cmd.Connection = conn;
-                    cmd.CommandText = sql;
-                    var reader = cmd.ExecuteReader();
-                    while (reader.Read())
-                    {
-                        var record = new Participant
-                        {
-                            LdsHash = reader[1].ToString(),
-                            CaseId = reader[3].ToString(),
-                            ParticipantId = reader[4].ToString(),
-                            ParticipantClosingDate = reader[5] is DBNull ? (DateTime?)null : Convert.ToDateTime(reader[5]),
-                            RecentBenefitIssuanceDates = reader[reader.GetOrdinal("recent_benefit_issuance_dates")] is DBNull ? new List<DateRange>() : ((NpgsqlRange<DateTime>[])reader[reader.GetOrdinal("recent_benefit_issuance_dates")]).Select(user => new DateRange() { Start = user.LowerBound, End = user.UpperBound }).ToList(),
-                            ProtectLocation = reader[reader.GetOrdinal("protect_location")] is DBNull ? (Boolean?)null : Convert.ToBoolean(reader[reader.GetOrdinal("protect_location")])
-                        };
-                        records.Add(record);
-                    }
-
-                    conn.Close();
-                }
+                records = conn.Query<Participant>(sql);
+                conn.Close();
             }
+
             return records;
         }
     }

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/DateRangeListHandler.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/DateRangeListHandler.cs
@@ -1,11 +1,11 @@
-﻿using Dapper;
-using NpgsqlTypes;
-using Piipan.Shared.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Text;
+using Dapper;
+using NpgsqlTypes;
+using Piipan.Shared.Utilities;
 
 namespace Piipan.Participants.Core
 {
@@ -18,25 +18,50 @@ namespace Piipan.Participants.Core
     /// </remarks>
     public class DateRangeListHandler : SqlMapper.TypeHandler<IEnumerable<DateRange>>
     {
+        // <summary>
+        // Implement custom parsing to match PostgreSQL handling of bound inclusion.
+        // See: https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY
+        // </summary>
         public override IEnumerable<DateRange> Parse(object value)
         {
-            IEnumerable<DateRange> typedValue = value is DBNull ? new List<DateRange>() : ((NpgsqlRange<DateTime>[])value).Select(user => new DateRange() { Start = user.LowerBound, End = user.UpperBound }).ToList();
+            if (value is DBNull)
+            {
+                return new List<DateRange>();
+            }
+
+            IEnumerable<DateRange> typedValue = ((NpgsqlRange<DateTime>[])value)
+                .Select(range => new DateRange()
+                {
+                    Start = range.LowerBoundIsInclusive ? range.LowerBound : range.LowerBound.AddDays(1),
+                    End = range.UpperBoundIsInclusive ? range.UpperBound : range.UpperBound.AddDays(-1)
+                })
+                .ToList();
+
             return typedValue;
         }
 
+        // <summary>
+        // Format value DateRange start/end dates into the required input format
+        // for a daterange type with inclusive bounds.
+        // </summary>
         public override void SetValue(IDbDataParameter parameter, IEnumerable<DateRange> value)
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append("{ ");
-            string formatString = "\"[{0},{1})\",";
-            foreach (DateRange Dat in value)
-            {
-                sb.Append(string.Format(formatString, Dat.Start.ToString("yyyy-MM-dd"), Dat.End.ToString("yyyy-MM-dd")));
-            }
-            sb.Remove(sb.Length - 1, 1); 
+            string formatString = "\"[{0},{1}]\"";
+            IEnumerable<string> formattedValues = value
+                .Select(range =>
+                    string.Format(
+                        formatString,
+                        range.Start.ToString("yyyy-MM-dd"),
+                        range.End.ToString("yyyy-MM-dd")
+                    )
+                );
+
+            sb.Append("{");
+            sb.Append(String.Join(",", formattedValues));
             sb.Append("}");
 
             parameter.Value = sb.ToString();
-          }
+        }
     }
 }

--- a/shared/src/Piipan.Shared/Utilities/DateRange.cs
+++ b/shared/src/Piipan.Shared/Utilities/DateRange.cs
@@ -1,66 +1,65 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
- using System.Text;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Piipan.Shared.Utilities
 {
-	public class DateRange
-	{
-		/// <summary>
-		///     Initializes a new instance of the <see cref="DateRange" /> structure to the specified start and end date.
-		/// </summary>
-		/// <param name="start">A Datetime that contains that first date in the date range.</param>
-		/// <param name="end">A Datetime that contains the last date in the date range.</param>
-		/// 
+    public class DateRange
+    {
+        /// <summary>
+        /// 	Initializes a new instance of the <see cref="DateRange" /> structure to the specified start and end date.
+        /// </summary>
+        /// <param name="start">A Datetime that contains that first date in the date range.</param>
+        /// <param name="end">A Datetime that contains the last date in the date range.</param>
+        /// <remarks>
+        ///	Start and end dates are considered inclusive bounds.
+        /// </remarks>
 
-		public DateRange(DateTime start, DateTime end)
-		{
-			Start = start;
-			End = end;
-		}
-		public DateRange()
-		{ }
+        public DateRange(DateTime start, DateTime end)
+        {
+            Start = start;
+            End = end;
+        }
+        public DateRange()
+        { }
 
-		/// <summary>
-		///     Gets the start date component of the date range.
-		/// </summary>
-		/// 
-		[JsonProperty("start")]
-		[JsonConverter(typeof(JsonConvertersShared.DateTimeConverter))]
-		public DateTime Start { get; set; }
+        /// <summary>
+        ///     Gets the start date component of the date range.
+        /// </summary>
+        [JsonProperty("start")]
+        [JsonConverter(typeof(JsonConvertersShared.DateTimeConverter))]
+        public DateTime Start { get; set; }
 
 
-		/// <summary>
-		///     Gets the end date component of the date range.
-		/// </summary>
-		[JsonProperty("end")]
-		  [JsonConverter(typeof(JsonConvertersShared.DateTimeConverter))]
-		public DateTime End { get; set; }
+        /// <summary>
+        ///     Gets the end date component of the date range.
+        /// </summary>
+        [JsonProperty("end")]
+        [JsonConverter(typeof(JsonConvertersShared.DateTimeConverter))]
+        public DateTime End { get; set; }
 
-		public override bool Equals(Object obj)
-		{
-			if (obj == null)
-			{
-				return false;
-			}
+        public override bool Equals(Object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
 
-			DateRange p = obj as DateRange;
-			if (p == null)
-			{
-				return false;
-			}
+            DateRange p = obj as DateRange;
+            if (p == null)
+            {
+                return false;
+            }
 
-			return
-				Start == p.Start &&
-				End == p.End;
-		}
-		public override int GetHashCode()
-		{
- 			return HashCode.Combine(
-				Start,
-				End
-			);
-		}
-	}
+            return
+                Start == p.Start &&
+                End == p.End;
+        }
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+               Start,
+               End
+            );
+        }
+    }
 }

--- a/shared/tests/Piipan.Shared.Tests/Utilities/DateRangeTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Utilities/DateRangeTests.cs
@@ -1,0 +1,100 @@
+using System;
+using Xunit;
+
+namespace Piipan.Shared.Utilities
+{
+    public class DateRangeTests
+    {
+        [Fact]
+        public void Equals_NullObj()
+        {
+            // Arrange
+            var range = new DateRange
+            {
+                Start = new DateTime(2021, 1, 1),
+                End = new DateTime(2021, 1, 31)
+            };
+
+            // Act / Assert
+            Assert.False(range.Equals(null));
+        }
+
+        [Fact]
+        public void Equals_WrongType()
+        {
+            // Arrange
+            var range = new DateRange
+            {
+                Start = new DateTime(2021, 1, 1),
+                End = new DateTime(2021, 1, 31)
+            };
+            var notRange = new
+            {
+                value = 1
+            };
+
+            // Act / Assert
+            Assert.False(range.Equals(notRange));
+        }
+
+        [Fact]
+        public void Equals_HashCode_StartMismatch()
+        {
+            // Arrange
+            var range = new DateRange
+            {
+                Start = new DateTime(2021, 1, 1),
+                End = new DateTime(2021, 1, 31)
+            };
+            var rangeMistmatch = new DateRange
+            {
+                Start = new DateTime(2021, 1, 2),
+                End = new DateTime(2021, 1, 31)
+            };
+
+            // Act / Assert
+            Assert.False(range.Equals(rangeMistmatch));
+            Assert.NotEqual(range.GetHashCode(), rangeMistmatch.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_HashCode_EndMismatch()
+        {
+            // Arrange
+            var range = new DateRange
+            {
+                Start = new DateTime(2021, 1, 1),
+                End = new DateTime(2021, 1, 31)
+            };
+            var rangeMistmatch = new DateRange
+            {
+                Start = new DateTime(2021, 1, 1),
+                End = new DateTime(2021, 1, 30)
+            };
+
+            // Act / Assert
+            Assert.False(range.Equals(rangeMistmatch));
+            Assert.NotEqual(range.GetHashCode(), rangeMistmatch.GetHashCode());
+        }
+
+        [Fact]
+        public void Equals_HashCode_BoundsMatch()
+        {
+            // Arrange
+            var range = new DateRange
+            {
+                Start = new DateTime(2021, 1, 1),
+                End = new DateTime(2021, 1, 31)
+            };
+            var rangeMistmatch = new DateRange
+            {
+                Start = new DateTime(2021, 1, 1),
+                End = new DateTime(2021, 1, 31)
+            };
+
+            // Act / Assert
+            Assert.True(range.Equals(rangeMistmatch));
+            Assert.Equal(range.GetHashCode(), rangeMistmatch.GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
## What’s changing?

- Use inclusive bounding for both upper and lower bounds when setting database value
- Check bound inclusion property when parsing database values to DateRange instances
- Use Dapper in ETL db fixture to remove custom bound parsing
- Additional unit tests for DateRangeListHandler for value parsing / setting

Only changes to `DateRange.cs` were small updates to the documentation comments, but Omnisharp picked up some whitespace edits that make it look like more.

## Why?

NAC-542

Sets the stage for using Npgsql's NodaTime extension when writing complex `daterange[]` values in a `COPY` statement

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)
- ~[ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~

## Anything else?

@kcherukupalli Tagging you for review since this builds on your recent work.

@bgfoshay Tagging you for awareness / review.

@edwintorres Tagging you because this includes a small update to the ETL integration tests `DbFixture`. I don't think this will conflict with any of your ETL work, but wanted to give you the heads up just in case it does.