### PR TITLE
Use COPY for bulk inserting participant records

### DIFF
--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
@@ -862,6 +862,31 @@
           "Newtonsoft.Json": "12.0.3"
         }
       },
+      "NodaTime": {
+        "type": "Transitive",
+        "resolved": "3.0.9",
+        "contentHash": "7KzJBkgSzLLyBXNYafDlnzlji3aB/8myvt5RJu5aaTFq6puVCq2WDJY9v9yDMg22+5or5IaKNItQ1jNA8nzQNA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
+      },
+      "Npgsql.NodaTime": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "AKGBaz2dSFkdsJ7eE0H6KVQGH/D+O+afOFQ7ML3XqWjNiiEspr20j64/eqyD0KL4IT4qKXzrSax1opzgjtYhDA==",
+        "dependencies": {
+          "NodaTime": "3.0.9",
+          "Npgsql": "6.0.3"
+        }
+      },
+      "PostgreSQLCopyHelper": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "AUABpBJg+stHcz92D3ZMSIRAeMm0vxCA8+7AHGRSuOnycfSquuA6wLaSNTs2wQ9JrzgcGblgo6dyIK5oyxt53w==",
+        "dependencies": {
+          "Npgsql": "4.1.1"
+        }
+      },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
         "resolved": "4.3.2",
@@ -2025,8 +2050,10 @@
           "Dapper": "2.0.123",
           "Microsoft.Extensions.DependencyInjection": "3.1.23",
           "Microsoft.Extensions.Logging": "3.1.23",
+          "Npgsql.NodaTime": "6.0.3",
           "Piipan.Participants.Api": "1.0.0",
-          "Piipan.Shared": "1.0.0"
+          "Piipan.Shared": "1.0.0",
+          "PostgreSQLCopyHelper": "2.8.0"
         }
       },
       "piipan.shared": {

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/ParticipantTests.cs
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/ParticipantTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Piipan.Etl.Func.BulkUpload.Models;
+using Piipan.Shared.API.Utilities;
+using Xunit;
+
+namespace Piipan.Etl.Func.BulkUpload.Tests.Models
+{
+    public class ParticipantTests
+    {
+        [Fact]
+        public void Getters_Setters_Match()
+        {
+            // Arrange
+            DateTime currentDate = DateTime.UtcNow.Date;
+            List<DateRange> recentBenefitIssuanceDates = new List<DateRange>();
+
+            var participant = new Participant
+            {
+                LdsHash = "l",
+                CaseId = "c",
+                ParticipantId = "p",
+                ParticipantClosingDate = currentDate,
+                RecentBenefitIssuanceDates = recentBenefitIssuanceDates,
+                VulnerableIndividual = false
+            };
+
+            // Act / Assert
+            Assert.Equal("l", participant.LdsHash);
+            Assert.Equal("c", participant.CaseId);
+            Assert.Equal("p", participant.ParticipantId);
+            Assert.Equal(currentDate, participant.ParticipantClosingDate);
+            Assert.False(participant.VulnerableIndividual);
+            Assert.Same(recentBenefitIssuanceDates, participant.RecentBenefitIssuanceDates);
+        }
+    }
+}

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
@@ -938,10 +938,35 @@
           "Newtonsoft.Json": "12.0.3"
         }
       },
+      "NodaTime": {
+        "type": "Transitive",
+        "resolved": "3.0.9",
+        "contentHash": "7KzJBkgSzLLyBXNYafDlnzlji3aB/8myvt5RJu5aaTFq6puVCq2WDJY9v9yDMg22+5or5IaKNItQ1jNA8nzQNA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
+      },
+      "Npgsql.NodaTime": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "AKGBaz2dSFkdsJ7eE0H6KVQGH/D+O+afOFQ7ML3XqWjNiiEspr20j64/eqyD0KL4IT4qKXzrSax1opzgjtYhDA==",
+        "dependencies": {
+          "NodaTime": "3.0.9",
+          "Npgsql": "6.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "PostgreSQLCopyHelper": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "AUABpBJg+stHcz92D3ZMSIRAeMm0vxCA8+7AHGRSuOnycfSquuA6wLaSNTs2wQ9JrzgcGblgo6dyIK5oyxt53w==",
+        "dependencies": {
+          "Npgsql": "4.1.1"
+        }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
@@ -2173,8 +2198,10 @@
           "Dapper": "2.0.123",
           "Microsoft.Extensions.DependencyInjection": "3.1.23",
           "Microsoft.Extensions.Logging": "3.1.23",
+          "Npgsql.NodaTime": "6.0.3",
           "Piipan.Participants.Api": "1.0.0",
-          "Piipan.Shared": "1.0.0"
+          "Piipan.Shared": "1.0.0",
+          "PostgreSQLCopyHelper": "2.8.0"
         }
       },
       "piipan.shared": {

--- a/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
@@ -804,6 +804,31 @@
           "Newtonsoft.Json": "10.0.1"
         }
       },
+      "NodaTime": {
+        "type": "Transitive",
+        "resolved": "3.0.9",
+        "contentHash": "7KzJBkgSzLLyBXNYafDlnzlji3aB/8myvt5RJu5aaTFq6puVCq2WDJY9v9yDMg22+5or5IaKNItQ1jNA8nzQNA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
+      },
+      "Npgsql.NodaTime": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "AKGBaz2dSFkdsJ7eE0H6KVQGH/D+O+afOFQ7ML3XqWjNiiEspr20j64/eqyD0KL4IT4qKXzrSax1opzgjtYhDA==",
+        "dependencies": {
+          "NodaTime": "3.0.9",
+          "Npgsql": "6.0.3"
+        }
+      },
+      "PostgreSQLCopyHelper": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "AUABpBJg+stHcz92D3ZMSIRAeMm0vxCA8+7AHGRSuOnycfSquuA6wLaSNTs2wQ9JrzgcGblgo6dyIK5oyxt53w==",
+        "dependencies": {
+          "Npgsql": "4.1.1"
+        }
+      },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
         "resolved": "4.3.2",
@@ -2198,8 +2223,10 @@
           "Dapper": "2.0.123",
           "Microsoft.Extensions.DependencyInjection": "3.1.23",
           "Microsoft.Extensions.Logging": "3.1.23",
+          "Npgsql.NodaTime": "6.0.3",
           "Piipan.Participants.Api": "1.0.0",
-          "Piipan.Shared": "1.0.0"
+          "Piipan.Shared": "1.0.0",
+          "PostgreSQLCopyHelper": "2.8.0"
         }
       },
       "piipan.shared": {

--- a/match/tests/Piipan.Match.Func.Api.IntegrationTests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.Api.IntegrationTests/packages.lock.json
@@ -870,6 +870,14 @@
           "Newtonsoft.Json": "12.0.3"
         }
       },
+      "NodaTime": {
+        "type": "Transitive",
+        "resolved": "3.0.9",
+        "contentHash": "7KzJBkgSzLLyBXNYafDlnzlji3aB/8myvt5RJu5aaTFq6puVCq2WDJY9v9yDMg22+5or5IaKNItQ1jNA8nzQNA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
+      },
       "Npgsql": {
         "type": "Transitive",
         "resolved": "6.0.3",
@@ -879,10 +887,27 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
+      "Npgsql.NodaTime": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "AKGBaz2dSFkdsJ7eE0H6KVQGH/D+O+afOFQ7ML3XqWjNiiEspr20j64/eqyD0KL4IT4qKXzrSax1opzgjtYhDA==",
+        "dependencies": {
+          "NodaTime": "3.0.9",
+          "Npgsql": "6.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "c5JVjuVAm4f7E9Vj+v09Z9s2ZsqFDjBpcsyS3M9xRo0bEdm/LVZSzLxxNvfvAwRiiE8nwe1h2G4OwiwlzFKXlA=="
+      },
+      "PostgreSQLCopyHelper": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "AUABpBJg+stHcz92D3ZMSIRAeMm0vxCA8+7AHGRSuOnycfSquuA6wLaSNTs2wQ9JrzgcGblgo6dyIK5oyxt53w==",
+        "dependencies": {
+          "Npgsql": "4.1.1"
+        }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
@@ -2347,8 +2372,10 @@
           "Dapper": "2.0.123",
           "Microsoft.Extensions.DependencyInjection": "3.1.23",
           "Microsoft.Extensions.Logging": "3.1.23",
+          "Npgsql.NodaTime": "6.0.3",
           "Piipan.Participants.Api": "1.0.0",
-          "Piipan.Shared": "1.0.0"
+          "Piipan.Shared": "1.0.0",
+          "PostgreSQLCopyHelper": "2.8.0"
         }
       },
       "piipan.shared": {

--- a/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
@@ -880,10 +880,35 @@
           "Newtonsoft.Json": "12.0.3"
         }
       },
+      "NodaTime": {
+        "type": "Transitive",
+        "resolved": "3.0.9",
+        "contentHash": "7KzJBkgSzLLyBXNYafDlnzlji3aB/8myvt5RJu5aaTFq6puVCq2WDJY9v9yDMg22+5or5IaKNItQ1jNA8nzQNA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
+      },
+      "Npgsql.NodaTime": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "AKGBaz2dSFkdsJ7eE0H6KVQGH/D+O+afOFQ7ML3XqWjNiiEspr20j64/eqyD0KL4IT4qKXzrSax1opzgjtYhDA==",
+        "dependencies": {
+          "NodaTime": "3.0.9",
+          "Npgsql": "6.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "PostgreSQLCopyHelper": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "AUABpBJg+stHcz92D3ZMSIRAeMm0vxCA8+7AHGRSuOnycfSquuA6wLaSNTs2wQ9JrzgcGblgo6dyIK5oyxt53w==",
+        "dependencies": {
+          "Npgsql": "4.1.1"
+        }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
@@ -2348,8 +2373,10 @@
           "Dapper": "2.0.123",
           "Microsoft.Extensions.DependencyInjection": "3.1.23",
           "Microsoft.Extensions.Logging": "3.1.23",
+          "Npgsql.NodaTime": "6.0.3",
           "Piipan.Participants.Api": "1.0.0",
-          "Piipan.Shared": "1.0.0"
+          "Piipan.Shared": "1.0.0",
+          "PostgreSQLCopyHelper": "2.8.0"
         }
       },
       "piipan.shared": {

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDao.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/DataAccessObjects/ParticipantDao.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Data.Common;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Extensions.Logging;
+using NodaTime;
+using Npgsql;
 using Piipan.Participants.Core.Models;
 using Piipan.Shared.Database;
+using PostgreSQLCopyHelper;
 
 namespace Piipan.Participants.Core.DataAccessObjects
 {
@@ -54,45 +55,37 @@ namespace Piipan.Participants.Core.DataAccessObjects
 
         public async Task AddParticipants(IEnumerable<ParticipantDbo> participants)
         {
-            const string sql = @"
-                INSERT INTO participants
-                (
-                    lds_hash,
-                    upload_id,
-                    case_id,
-                    participant_id,
-                    participant_closing_date,
-                    recent_benefit_issuance_dates,
-                    vulnerable_individual
-                )
-                VALUES
-                (
-                    @LdsHash,
-                    @UploadId,
-                    @CaseId,
-                    @ParticipantId,
-                    @ParticipantClosingDate,
-                    @RecentBenefitIssuanceDates::daterange[],
-                    @VulnerableIndividual
-                )
-            ";
-
-            using (var connection = await _dbConnectionFactory.Build() as DbConnection)
+            using (var connection = await _dbConnectionFactory.Build() as NpgsqlConnection)
             {
-                // A performance optimization. Dapper will open/close around invidual
-                // calls if it is passed a closed connection. 
                 await connection.OpenAsync();
+
+                // Use NodaTime as a convenience to handle converting DateInterval[]
+                // to a valid daterange[] input format
+                connection.TypeMapper.UseNodaTime();
 
                 try
                 {
-                    foreach (var participant in participants)
-                    {
-                        _logger.LogDebug(
-                            $"Adding participant for upload {participant.UploadId} with LDS Hash: {participant.LdsHash}");
-                        await connection.ExecuteAsync(sql, participant);
-                    }
+                    var copyHelper = new PostgreSQLCopyHelper<ParticipantDbo>("participants")
+                        .MapText("lds_hash", p => p.LdsHash)
+                        .MapText("participant_id", p => p.ParticipantId)
+                        .MapText("case_id", p => p.CaseId)
+                        .MapInteger("upload_id", p => (int)p.UploadId)
+                        .MapDate("participant_closing_date", p => p.ParticipantClosingDate)
+                        .Map("recent_benefit_issuance_dates", p =>
+                            p.RecentBenefitIssuanceDates.Select(range =>
+                                new DateInterval(
+                                    LocalDate.FromDateTime(range.Start),
+                                    LocalDate.FromDateTime(range.End)
+                                )
+                            ).ToArray<DateInterval>()
+                        )
+                        .MapBoolean("vulnerable_individual", p => p.VulnerableIndividual);
+
+                    _logger.LogDebug("Bulk inserting participant upload");
+                    var result = await copyHelper.SaveAllAsync(connection, participants);
+                    _logger.LogDebug("Completed bulk insert of {0} participant records", result);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     _logger.LogError(ex, ex.Message);
                     throw;

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Piipan.Participants.Core.csproj
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Piipan.Participants.Core.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.23" />
+    <PackageReference Include="Npgsql.NodaTime" Version="6.0.3" />
+    <PackageReference Include="PostgreSQLCopyHelper" Version="2.8.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
@@ -1,14 +1,13 @@
+using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Transactions;
 using Microsoft.Extensions.Logging;
 using Piipan.Participants.Api;
 using Piipan.Participants.Api.Models;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Models;
-using System;
-using System.Transactions;
-using Dapper;
 
 namespace Piipan.Participants.Core.Services
 {
@@ -37,7 +36,7 @@ namespace Piipan.Participants.Core.Services
             {
                 var upload = await _uploadDao.GetLatestUpload(state);
                 var participants = await _participantDao.GetParticipants(state, ldsHash, upload.Id);
-    
+
                 // Set the participant State before returning
                 return participants.Select(p => new ParticipantDto(p) { State = state });
             }
@@ -49,7 +48,12 @@ namespace Piipan.Participants.Core.Services
 
         public async Task AddParticipants(IEnumerable<IParticipant> participants)
         {
-            using (TransactionScope scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            // Large participant uploads can be long-running processes and require
+            // an increased time out duration to avoid System.TimeoutException
+            using (TransactionScope scope = new TransactionScope(
+                TransactionScopeOption.Required,
+                TimeSpan.FromSeconds(600),
+                TransactionScopeAsyncFlowOption.Enabled))
             {
                 var upload = await _uploadDao.AddUpload();
 

--- a/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
+++ b/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
@@ -464,10 +464,35 @@
           "Newtonsoft.Json": "12.0.3"
         }
       },
+      "NodaTime": {
+        "type": "Transitive",
+        "resolved": "3.0.9",
+        "contentHash": "7KzJBkgSzLLyBXNYafDlnzlji3aB/8myvt5RJu5aaTFq6puVCq2WDJY9v9yDMg22+5or5IaKNItQ1jNA8nzQNA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.7.1"
+        }
+      },
+      "Npgsql.NodaTime": {
+        "type": "Transitive",
+        "resolved": "6.0.3",
+        "contentHash": "AKGBaz2dSFkdsJ7eE0H6KVQGH/D+O+afOFQ7ML3XqWjNiiEspr20j64/eqyD0KL4IT4qKXzrSax1opzgjtYhDA==",
+        "dependencies": {
+          "NodaTime": "3.0.9",
+          "Npgsql": "6.0.3"
+        }
+      },
       "NuGet.Frameworks": {
         "type": "Transitive",
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "PostgreSQLCopyHelper": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "AUABpBJg+stHcz92D3ZMSIRAeMm0vxCA8+7AHGRSuOnycfSquuA6wLaSNTs2wQ9JrzgcGblgo6dyIK5oyxt53w==",
+        "dependencies": {
+          "Npgsql": "4.1.1"
+        }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
@@ -1653,8 +1678,10 @@
           "Dapper": "2.0.123",
           "Microsoft.Extensions.DependencyInjection": "3.1.23",
           "Microsoft.Extensions.Logging": "3.1.23",
+          "Npgsql.NodaTime": "6.0.3",
           "Piipan.Participants.Api": "1.0.0",
-          "Piipan.Shared": "1.0.0"
+          "Piipan.Shared": "1.0.0",
+          "PostgreSQLCopyHelper": "2.8.0"
         }
       },
       "piipan.shared": {


### PR DESCRIPTION
## What’s changing?

- Use `COPY` (via `PostgreSQLCopyHelper`) to improve performance of writing large participant uploads to database
- Increase timeout duration for participant upload transaction to accomodate large uploads
- Introduce `Npgsql.NodaTime` plugin to handle setting the proper value for recent_benefit_issuance_dates field

## Why?

NAC-556

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)
- ~[ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)~
- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)
- ~[ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~

## Anything else?

@bgfoshay I made some tweaks from the proof-of-concept branch we'd be working on. The primary change is using `PostgreSQLCopyHelper` to abstract away some of the complexity of writing individual rows/values. I think the benefit from a developer's perspective is worthwhile, with the tradeoff that we no longer are adding records within a loop where we could perform other per-participant operations (logging progress, etc).

Curious for your thoughts on this. My thinking is that our short-term extensions of the bulk upload process will not require that functionality, and, when we do need that functionality we'll likely want it decoupled from the database operations anyway. E.g., a discrete step that checks for invalid records, followed by another discrete step for adding valid records to the database.