### PR TITLE
Updating readme and schemas for the new Match URL field

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -93,7 +93,8 @@ Searches all state databases for any participant records that are an exact match
                 "end": "2021-03-31"
               }
             ],
-            "protect_location": true
+            "protect_location": true,
+            "match_url": "https://nac.example/match/BCD2345"
           }
         ]
       }
@@ -148,7 +149,8 @@ Searches all state databases for any participant records that are an exact match
                 "end": "2021-03-31"
               }
             ],
-            "protect_location": true
+            "protect_location": true,
+            "match_url": "https://nac.example/match/XYZ9876"
           },
           {
             "match_id": "4567CDF",
@@ -156,7 +158,8 @@ Searches all state databases for any participant records that are an exact match
             "case_id": "string",
             "participant_id": "string",
             "participant_closing_date": null,
-            "protect_location": null
+            "protect_location": null,
+            "match_url": "https://nac.example/match/4567CDF"
           }
         ]
       }
@@ -181,7 +184,8 @@ Searches all state databases for any participant records that are an exact match
             "case_id": "string",
             "participant_id": "string",
             "participant_closing_date": null,
-            "protect_location": null
+            "protect_location": null,
+            "match_url": "https://nac.example/match/4567CDF"
           }
         ]
       },
@@ -208,7 +212,8 @@ Searches all state databases for any participant records that are an exact match
                 "end": "2021-03-31"
               }
             ],
-            "protect_location": true
+            "protect_location": true,
+            "match_url": "https://nac.example/match/BCD2345"
           }
         ]
       }
@@ -237,7 +242,8 @@ Searches all state databases for any participant records that are an exact match
             "case_id": "string",
             "participant_id": "string",
             "participant_closing_date": null,
-            "protect_location": null
+            "protect_location": null,
+            "match_url": "https://nac.example/match/4567CDF"
           }
         ]
       }
@@ -262,7 +268,8 @@ Searches all state databases for any participant records that are an exact match
             "case_id": "string",
             "participant_id": "string",
             "participant_closing_date": null,
-            "protect_location": null
+            "protect_location": null,
+            "match_url": "https://nac.example/match/4567CDF"
           }
         ]
       }
@@ -323,6 +330,7 @@ Status Code **200**
 |»»»»» start|string|false|none|start date for date range|
 |»»»»» end|string|false|none|end date for date range|
 |»»»» protect_location|boolean|false|none|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
+|»»»» match_url|string|true|none|The URL to visit to acquire more information about this match.|
 |»» errors|array|true|none|Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items.|
 |»»» index|integer|true|none|The index of the person that the result corresponds to, starting from 0. Index is derived from the implicit order of persons provided in the request.|
 |»»» code|string|false|none|The application-specific error code|

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -19,6 +19,12 @@ paths:
           schema:
             type: string
           description: 'As in the HTTP/1.1 RFC, used for logging purposes as a means for identifying the source of invalid or unwanted requests. The interpretation of this field is that the request is being performed on behalf of the state government-affiliated person whose email address (or username) is specified here. It is not used for authentication or authorization.'
+        - in: header
+          name: X-Initiating-State
+          schema:
+            type: string
+          description: Two-letter postal abbreviation for the caller's state role
+          required: true
       requestBody:
         required: true
         content:
@@ -139,6 +145,9 @@ paths:
                                     nullable: true
                                     example: true
                                     description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
+                                  match_url:
+                                    type: string
+                                    description: URL to visit to view details about this match.
                       errors:
                         type: array
                         description: 'Array of error objects corresponding to a person in the request. If a query for a single person fails, the failure data will display here. Note that a single person in a request could have multiple error items.'
@@ -201,6 +210,7 @@ paths:
                                 - start: '2021-03-01'
                                   end: '2021-03-31'
                               protect_location: true
+                              match_url: 'https://nac.example/match/BCD2345'
                       errors: []
                 No matches:
                   description: A query for a single person returning no matches
@@ -230,12 +240,14 @@ paths:
                                 - start: '2021-03-01'
                                   end: '2021-03-31'
                               protect_location: true
+                              match_url: 'https://nac.example/match/XYZ9876'
                             - match_id: 4567CDF
                               state: ec
                               case_id: string
                               participant_id: string
                               participant_closing_date: null
                               protect_location: null
+                              match_url: 'https://nac.example/match/4567CDF'
                       errors: []
                 Multiple persons with matches:
                   description: A query for two persons returning one match for each person

--- a/match/docs/openapi/orchestrator/find.yaml
+++ b/match/docs/openapi/orchestrator/find.yaml
@@ -3,7 +3,8 @@ post:
   tags:
     - "Match"
   summary: "Search for all matching participant records using de-identified data"
-  description: "Searches all state databases for any participant records that are an exact match to the `lds_hash` of persons provided in the request. Does not search the database for the state initiating the request."  parameters:
+  description: "Searches all state databases for any participant records that are an exact match to the `lds_hash` of persons provided in the request. Does not search the database for the state initiating the request."
+  parameters:
     - $ref: '../schemas/match-query.yaml#/components/parameters/From'
     - $ref: '../schemas/match-query.yaml#/components/parameters/InitiatingState'
   requestBody:

--- a/match/docs/openapi/schemas/participant-record.yaml
+++ b/match/docs/openapi/schemas/participant-record.yaml
@@ -75,7 +75,7 @@ ParticipantRecordExamples:
       }
     ]
     protect_location: true
-    match_url: "https://test.com/match?id=BCD2345"
+    match_url: "https://nac.example/match/BCD2345"
   AllEB:
     match_id: "XYZ9876"
     state: "eb"
@@ -98,7 +98,7 @@ ParticipantRecordExamples:
       }
     ]
     protect_location: true
-    match_url: "https://test.com/match?id=XYZ9876"
+    match_url: "https://nac.example/match/XYZ9876"
   Required:
     match_id: "4567CDF"
     state: "ec"
@@ -106,4 +106,4 @@ ParticipantRecordExamples:
     participant_id: "string"
     participant_closing_date: null
     protect_location: null
-    match_url: "https://test.com/match?id=4567CDF"
+    match_url: "https://nac.example/match/4567CDF"


### PR DESCRIPTION
## What’s changing?

Adding the Match URL field to the generated API documentation, as well as updating the links to point to example domains.

## Why?

Closes NAC-554

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
