### PR TITLE
Add `upload_all_participants` endpoint to public-facing docs

### DIFF
--- a/docs/openapi/generated/bulk-api/openapi.md
+++ b/docs/openapi/generated/bulk-api/openapi.md
@@ -26,14 +26,14 @@ Base URLs:
 
 ```shell
 # You can also use wget
-curl -X PUT /bulk/{stateAbbr}/v2/upload/{filename} \
+curl -X PUT /bulk/{stateAbbr}/v2/upload_all_participants/{filename} \
   -H 'Content-Type: text/plain' \
   -H 'Content-Length: 6413' \
   -H 'Ocp-Apim-Subscription-Key: API_KEY'
 
 ```
 
-`PUT /upload/{filename}`
+`PUT /upload_all_participants/{filename}`
 
 *Upload a CSV file of bulk participant data*
 
@@ -49,9 +49,55 @@ string
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |filename|path|string|true|Name of file being uploaded|
-|Content-Length|header|integer|true|Deprecated. Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.|
+|Content-Length|header|integer|true|Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.|
 
 <h3 id="upload-a-file-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|File uploaded|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Access denied|None|
+|411|[Length Required](https://tools.ietf.org/html/rfc7231#section-6.5.10)|Content-Length not provided|None|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+ApiKeyAuth
+</aside>
+
+## Upload a File (deprecated)
+
+<a id="opIdUpload a File (deprecated)"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X PUT /bulk/{stateAbbr}/v2/upload/{filename} \
+  -H 'Content-Type: text/plain' \
+  -H 'Content-Length: 6413' \
+  -H 'Ocp-Apim-Subscription-Key: API_KEY'
+
+```
+
+`PUT /upload/{filename}`
+
+*Deprecated. This endpoint has been renamed to `upload_all_participants` and will be removed in a future version. Upload a CSV file of bulk participant data.*
+
+> Body parameter
+
+```
+string
+
+```
+
+<h3 id="upload-a-file-(deprecated)-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|filename|path|string|true|Name of file being uploaded|
+|Content-Length|header|integer|true|Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.|
+
+<h3 id="upload-a-file-(deprecated)-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|

--- a/docs/openapi/generated/bulk-api/openapi.yaml
+++ b/docs/openapi/generated/bulk-api/openapi.yaml
@@ -48,8 +48,8 @@ paths:
   '/upload/{filename}':
     description: A Deprecated endpoint.
     put:
-      operationId: Upload a File
-      summary: Upload a CSV file of bulk participant data
+      operationId: Upload a File (deprecated)
+      summary: Deprecated. This endpoint has been renamed to `upload_all_participants` and will be removed in a future version. Upload a CSV file of bulk participant data.
       tags:
         - Upload
       parameters:
@@ -64,7 +64,7 @@ paths:
           schema:
             type: integer
           required: true
-          description: Deprecated. Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.
+          description: Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.
           example: 6413
       requestBody:
         content:

--- a/etl/docs/openapi/upload.yaml
+++ b/etl/docs/openapi/upload.yaml
@@ -1,6 +1,6 @@
 put:
-  operationId: "Upload a File"
-  summary: Upload a CSV file of bulk participant data
+  operationId: "Upload a File (deprecated)"
+  summary: Deprecated. This endpoint has been renamed to `upload_all_participants` and will be removed in a future version. Upload a CSV file of bulk participant data.
   tags:
     - "Upload"
   parameters:
@@ -15,7 +15,7 @@ put:
       schema:
         type: integer
       required: true
-      description: Deprecated. Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.
+      description: Size in bytes of your file to be uploaded. A curl request will add this header by default when including a data or file parameter.
       example: 6413
   requestBody:
     content:


### PR DESCRIPTION
## What’s changing?

- Renames `operationId` for `upload` endpoint. Previous value was the same as the value for `upload_all_participants`, causing only the `upload` endpoint to appear in the docs.
- Adds message to `upload` endpoint stating that it is deprecated and will be removed.

## Why?

Follow-on to #3075. Now that `uploadAllParticipants.yaml` exists, just a couple tweaks to get the new endpoint to show up in the documentation and clarify the old endpoint has been deprecated.

## This PR has:

- ~[ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~
- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- ~[ ] **Automated unit tests** (_to maintain or increase level of code coverage_)~
- ~[ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~

## Anything else?
