### PR TITLE
adding vulnerable individual to match api

### DIFF
--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -66,7 +66,7 @@ Searches all state databases for any participant records that are an exact match
 |» participant_id|body|string|false|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |» case_id|body|string|false|Participant's state-specific case number|
 |» search_reason|body|string|true|The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'|
-|» vulnerable_individual|body|string|false|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
+|» vulnerable_individual|body|boolean|false|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
 
 > Example responses
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -50,7 +50,7 @@ Searches all state databases for any participant records that are an exact match
       "case_id": "CaseNumber12345",
       "participant_id": "ParticipantId12345",
       "search_reason": "application",
-      "vulnerable_individual": "yes"
+      "vulnerable_individual": true
     }
   ]
 }

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -66,7 +66,7 @@ Searches all state databases for any participant records that are an exact match
 |» participant_id|body|string|false|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |» case_id|body|string|false|Participant's state-specific case number|
 |» search_reason|body|string|true|The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'|
-|» vulnerable_individual|body|string|false|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
+|» vulnerable_individual|body|string|false|Location protection flag for vulnerable individuals. 'yes' values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual.|
 
 > Example responses
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -49,7 +49,8 @@ Searches all state databases for any participant records that are an exact match
       "lds_hash": "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458",
       "case_id": "CaseNumber12345",
       "participant_id": "ParticipantId12345",
-      "search_reason": "application"
+      "search_reason": "application",
+      "vulnerable_individual": "yes"
     }
   ]
 }
@@ -65,6 +66,7 @@ Searches all state databases for any participant records that are an exact match
 |» participant_id|body|string|false|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |» case_id|body|string|false|Participant's state-specific case number|
 |» search_reason|body|string|true|The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'|
+|» vulnerable_individual|body|string|false|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
 
 > Example responses
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.md
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.md
@@ -66,7 +66,7 @@ Searches all state databases for any participant records that are an exact match
 |» participant_id|body|string|false|Participant's state-specific identifier. Must not be social security number or any personal identifiable information.|
 |» case_id|body|string|false|Participant's state-specific case number|
 |» search_reason|body|string|true|The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'|
-|» vulnerable_individual|body|string|false|Location protection flag for vulnerable individuals. 'yes' values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual.|
+|» vulnerable_individual|body|string|false|Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.|
 
 > Example responses
 

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -52,7 +52,7 @@ paths:
                         type: string
                         description: 'The case action or other valid reason for performing the NAC search.  Valid options are ''application'', ''recertification'', ''new_household_member'', or ''other'''
                       vulnerable_individual:
-                        type: string
+                        type: boolean
                         description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
             examples:
               Single person:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -53,7 +53,7 @@ paths:
                         description: 'The case action or other valid reason for performing the NAC search.  Valid options are ''application'', ''recertification'', ''new_household_member'', or ''other'''
                       vulnerable_individual:
                         type: string
-                        description: Location protection flag for vulnerable individuals. 'yes' values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual.
+                        description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
             examples:
               Single person:
                 description: 'An example request to query a single person, with values for all fields'

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -63,7 +63,7 @@ paths:
                       case_id: CaseNumber12345
                       participant_id: ParticipantId12345
                       search_reason: application
-                      vulnerable_individual: 'yes'
+                      vulnerable_individual: true
               Multiple persons:
                 description: A request with multiple persons
                 value:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -51,6 +51,9 @@ paths:
                       search_reason:
                         type: string
                         description: 'The case action or other valid reason for performing the NAC search.  Valid options are ''application'', ''recertification'', ''new_household_member'', or ''other'''
+                      vulnerable_individual:
+                        type: string
+                        description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
             examples:
               Single person:
                 description: 'An example request to query a single person, with values for all fields'
@@ -60,6 +63,7 @@ paths:
                       case_id: CaseNumber12345
                       participant_id: ParticipantId12345
                       search_reason: application
+                      vulnerable_individual: 'yes'
               Multiple persons:
                 description: A request with multiple persons
                 value:

--- a/docs/openapi/generated/duplicate-participation-api/openapi.yaml
+++ b/docs/openapi/generated/duplicate-participation-api/openapi.yaml
@@ -53,7 +53,7 @@ paths:
                         description: 'The case action or other valid reason for performing the NAC search.  Valid options are ''application'', ''recertification'', ''new_household_member'', or ''other'''
                       vulnerable_individual:
                         type: string
-                        description: Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values.
+                        description: Location protection flag for vulnerable individuals. 'yes' values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual.
             examples:
               Single person:
                 description: 'An example request to query a single person, with values for all fields'

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -54,7 +54,7 @@ Person:
       description: "The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'"
     vulnerable_individual:
       type: string
-      description: "Location protection flag for vulnerable individuals. 'yes' values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual."
+      description: "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values."
 PersonWithPii:
   type: object
   required:

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -52,6 +52,9 @@ Person:
     search_reason:
       type: string
       description: "The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'"
+    vulnerable_individual:
+      type: string
+      description: "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values."
 PersonWithPii:
   type: object
   required:
@@ -86,6 +89,7 @@ MatchRequestExamples:
           case_id: "CaseNumber12345"
           participant_id: "ParticipantId12345"
           search_reason: "application"
+          vulnerable_individual: "yes"
   Multiple:
     description: "A request with multiple persons"
     value:

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -89,7 +89,7 @@ MatchRequestExamples:
           case_id: "CaseNumber12345"
           participant_id: "ParticipantId12345"
           search_reason: "application"
-          vulnerable_individual: "yes"
+          vulnerable_individual: true
   Multiple:
     description: "A request with multiple persons"
     value:

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -54,7 +54,7 @@ Person:
       description: "The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'"
     vulnerable_individual:
       type: string
-      description: "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values."
+      description: "Location protection flag for vulnerable individuals. 'yes' values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual."
 PersonWithPii:
   type: object
   required:

--- a/match/docs/openapi/schemas/match-query.yaml
+++ b/match/docs/openapi/schemas/match-query.yaml
@@ -53,7 +53,7 @@ Person:
       type: string
       description: "The case action or other valid reason for performing the NAC search.  Valid options are 'application', 'recertification', 'new_household_member', or 'other'"
     vulnerable_individual:
-      type: string
+      type: boolean
       description: "Location protection flag for vulnerable individuals. True values indicate that the individual’s location must be protected from disclosure to avoid harm to the individual. Apply the same protections to true and null values."
 PersonWithPii:
   type: object

--- a/match/src/Piipan.Match/Piipan.Match.Api/Models/OrchMatchRequest.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/Models/OrchMatchRequest.cs
@@ -35,5 +35,9 @@ namespace Piipan.Match.Api.Models
             Required = Required.Always,
             NullValueHandling = NullValueHandling.Ignore)]
         public string SearchReason { get; set; }
+
+        [JsonProperty("vulnerable_individual",
+            NullValueHandling = NullValueHandling.Ignore)]
+        public string VulnerableIndividual { get; set; }
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Api/Models/OrchMatchRequest.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/Models/OrchMatchRequest.cs
@@ -36,8 +36,7 @@ namespace Piipan.Match.Api.Models
             NullValueHandling = NullValueHandling.Ignore)]
         public string SearchReason { get; set; }
 
-        [JsonProperty("vulnerable_individual",
-            NullValueHandling = NullValueHandling.Ignore)]
-        public string VulnerableIndividual { get; set; }
+        [JsonProperty("vulnerable_individual")]
+        public bool? VulnerableIndividual { get; set; }
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
@@ -72,6 +72,17 @@ namespace Piipan.Match.Core.Parsers
                             throw new Exception($"Submitted option for 'search_reason' is not valid. Valid options are {validOptionsString}.");
                         }
                     }
+                    //checking if vulnerable individual field is valid. 
+                    //If not set to empty but still accept the request
+                    if (request.Data[i].VulnerableIndividual != null)
+                    {
+                        request.Data[i].VulnerableIndividual = request.Data[i].VulnerableIndividual.ToLower();
+                        string[] vulnerableIndividualResponses = { "yes", "no", "" };
+                        if (!vulnerableIndividualResponses.Contains(request.Data[i].VulnerableIndividual))
+                        {
+                            request.Data[i].VulnerableIndividual = "";
+                        }
+                    }
                 }
 
                 return request;

--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
@@ -72,17 +72,6 @@ namespace Piipan.Match.Core.Parsers
                             throw new Exception($"Submitted option for 'search_reason' is not valid. Valid options are {validOptionsString}.");
                         }
                     }
-                    //checking if vulnerable individual field is valid. 
-                    //If not set to empty but still accept the request
-                    if (request.Data[i].VulnerableIndividual != null)
-                    {
-                        request.Data[i].VulnerableIndividual = request.Data[i].VulnerableIndividual.ToLower();
-                        string[] vulnerableIndividualResponses = { "yes", "no", "" };
-                        if (!vulnerableIndividualResponses.Contains(request.Data[i].VulnerableIndividual))
-                        {
-                            request.Data[i].VulnerableIndividual = "";
-                        }
-                    }
                 }
 
                 return request;

--- a/match/tests/Piipan.Match.Core.Tests/Builders/ActiveMatchRecordBuilderTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Builders/ActiveMatchRecordBuilderTests.cs
@@ -59,7 +59,7 @@ namespace Piipan.Match.Core.Tests.Builders
                 .GetRecord();
 
             // Assert
-            Assert.Equal("{\"lds_hash\":\"foo\",\"participant_id\":\"DEF\",\"case_id\":\"ABC\"}", record.Input);
+            Assert.Equal("{\"lds_hash\":\"foo\",\"participant_id\":\"DEF\",\"case_id\":\"ABC\",\"vulnerable_individual\":null}", record.Input);
             Assert.Equal("{\"match_id\":null,\"lds_hash\":\"foo\",\"state\":null,\"case_id\":\"XYZ\",\"participant_id\":\"TUV\",\"participant_closing_date\":null,\"recent_benefit_issuance_dates\":[],\"vulnerable_individual\":null,\"match_url\":null}", record.Data);
 
         }

--- a/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Parsers/OrchMatchRequestParserTests.cs
@@ -150,11 +150,10 @@ namespace Piipan.Match.Core.Tests.Parsers
         }
 
         [Theory]
-        [InlineData("yes", "yes")]
-        [InlineData("no", "no")]
-        [InlineData("test", "")]
-        [InlineData("", "")]
-        public async Task ValidVulnerableIndividual(string vulnerableStatus, string expectedVulnerableIndividual)
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        [InlineData(null, null)]
+        public async Task ValidVulnerableIndividual(bool? vulnerableStatus, bool? expectedVulnerableIndividual)
         {
             // Arrange
             var logger = Mock.Of<ILogger<OrchMatchRequestParser>>();
@@ -183,40 +182,7 @@ namespace Piipan.Match.Core.Tests.Parsers
 
             // Assert
             Assert.NotNull(request);
-            Assert.Equal(expectedVulnerableIndividual.ToString(), request.Data[0].VulnerableIndividual);
-        }
-
-        [Fact]
-        public async Task NullVulnerableIndividual()
-        {
-            // Arrange
-            var logger = Mock.Of<ILogger<OrchMatchRequestParser>>();
-            var validator = new Mock<IValidator<OrchMatchRequest>>();
-            validator
-                .Setup(m => m.ValidateAsync(It.IsAny<OrchMatchRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ValidationResult());
-
-            var parser = new OrchMatchRequestParser(validator.Object, logger);
-
-            var orchMatchRequest = new OrchMatchRequest
-            {
-                Data = new List<RequestPerson>()
-                {
-                    new RequestPerson
-                    {
-                        LdsHash = "eaa834c957213fbf958a5965c46fa50939299165803cd8043e7b1b0ec07882dbd5921bce7a5fb45510670b46c1bf8591bf2f3d28d329e9207b7b6d6abaca5458",
-                        SearchReason = "other",
-                        VulnerableIndividual = null
-                    }
-                }
-            };
-
-            //Act
-            var request = await parser.Parse(BuildStream(JsonConvert.SerializeObject(orchMatchRequest)));
-
-            // Assert
-            Assert.NotNull(request);
-            Assert.Null(request.Data[0].VulnerableIndividual);
+            Assert.Equal(expectedVulnerableIndividual, request.Data[0].VulnerableIndividual);
         }
 
         [Fact]


### PR DESCRIPTION
## What’s changing?

Adding vulnerable_individual as an optional parameter to match api

## Why?

https://e-jira.fns.usda.net/jira-prod/browse/NAC-98

## This PR has:

API Doc updates to all params example, and match api 
comments on new code
tests for all cases and null case
generated docs

## Anything else?

the checking of the vulnerable individual is not in the validator because it is still accepted if it is not valid

the manual checking of yes no and blank is because this will most likely never change and therefore doesn't need an enum

