### PR TITLE
Update CircleCI frontend tests for dotnet/sdk:6.0 container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,12 @@ commands:
           # https://medium.com/@ssmak/how-to-fix-puppetteer-error-while-loading-shared-libraries-libx11-xcb-so-1-c1918b75acc3
           # https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies
           command : |
-            curl -sL https://deb.nodesource.com/setup_10.x |  bash -
+            curl -sL https://deb.nodesource.com/setup_14.x |  bash -
             apt-get install -y nodejs
             npm install -g n
             n stable
             PATH="$PATH"
-            apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm-dev libnotify-dev xauth xvfb
+            apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libnss3 lsb-release xdg-utils wget libgbm-dev libnotify-dev xauth xvfb
             npm install -g pa11y-ci --unsafe-perm=true --allow-root
             npm install cypress
       - run:


### PR DESCRIPTION
## What’s changing?

Frontend tests require some initial node configuration that was not compatible with the updated `dotnet/sdk6.0` image. Resolution is to install node from a newer version supported by the image. Also dropped unnecessary `libappindicator1` package.

## Why

Nightly frontend tests in CircleCI are failing.

## This PR has:

- ~[ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~
- ~[ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)~
- ~[ ] **Automated unit tests** (_to maintain or increase level of code coverage_)~
- ~[ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~

## Anything else?

@bgfoshay No need to try and sneak this into this sprint's release if it's too late. Just wanted to get a fix up sooner than later.