### PR TITLE
Added search reason to query tool when finding matches

### DIFF
--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -53,7 +53,7 @@ namespace Piipan.QueryTool.Pages
                     {
                         Data = new List<RequestPerson>
                         {
-                            new RequestPerson { LdsHash = digest, CaseId = Query.CaseId, ParticipantId = Query.ParticipantId }
+                            new RequestPerson { LdsHash = digest, CaseId = Query.CaseId, ParticipantId = Query.ParticipantId, SearchReason = "other" }
                         }
                     };
 


### PR DESCRIPTION
## What’s changing?

Due to search reason being required, the query tool needs to pass a value for search reason. Just passing "other" for now, we will be adding a search reason field at some point.

## Why?

Otherwise the search cannot be performed

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
