### PR TITLE
Updates to Query Tool errors

### DIFF
--- a/components/src/Piipan.Components.Demo/Models/InputSSNModel.cs
+++ b/components/src/Piipan.Components.Demo/Models/InputSSNModel.cs
@@ -10,11 +10,11 @@ namespace Piipan.Components.Demo.Models
     {
         [UsaSSN]
         [Display(Name = "Optional SSN")]
-        public string? OptionalSSN { get; set; }
+        public string OptionalSSN { get; set; }
 
         [UsaSSN]
         [UsaRequired]
         [Display(Name = "Required SSN")]
-        public string? RequiredSSN { get; set; }
+        public string RequiredSSN { get; set; }
     }
 }

--- a/components/src/Piipan.Components.Demo/Models/InputTextModel.cs
+++ b/components/src/Piipan.Components.Demo/Models/InputTextModel.cs
@@ -9,10 +9,10 @@ namespace Piipan.Components.Demo.Models
     public class InputTextModel
     {
         [Display(Name = "Optional Field")]
-        public string? NotRequiredField { get; set; }
+        public string NotRequiredField { get; set; }
 
         [UsaRequired]
         [Display(Name = "Required Field")]
-        public string? RequiredField { get; set; }
+        public string RequiredField { get; set; }
     }
 }

--- a/components/src/Piipan.Components.Demo/Pages/Index.razor
+++ b/components/src/Piipan.Components.Demo/Pages/Index.razor
@@ -9,17 +9,17 @@
     public class IndexModel
     {
         [Display(Name = "Input Text")]
-        public string? InputTextField { get; set; }
+        public string InputTextField { get; set; }
 
         [Display(Name = "Input Text Area")]
-        public string? InputTextAreaField { get; set; }
+        public string InputTextAreaField { get; set; }
 
         [Display(Name = "Input Date")]
         public DateTime? InputDateField { get; set; }
 
         [UsaSSN]
         [Display(Name = "Input SSN")]
-        public string? InputSSNField { get; set; }
+        public string InputSSNField { get; set; }
     }
 
     private IndexModel indexModel = new IndexModel();

--- a/components/src/Piipan.Components.Demo/wwwroot/models/InputSSNModel.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/models/InputSSNModel.txt
@@ -10,11 +10,11 @@ namespace Piipan.Components.Demo.Models
     {
         [UsaSSN]
         [Display(Name = "Optional SSN")]
-        public string? OptionalSSN { get; set; }
+        public string OptionalSSN { get; set; }
 
         [UsaSSN]
         [UsaRequired]
         [Display(Name = "Required SSN")]
-        public string? RequiredSSN { get; set; }
+        public string RequiredSSN { get; set; }
     }
 }

--- a/components/src/Piipan.Components.Demo/wwwroot/models/InputTextModel.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/models/InputTextModel.txt
@@ -9,10 +9,10 @@ namespace Piipan.Components.Demo.Models
     public class InputTextModel
     {
         [Display(Name = "Optional Field")]
-        public string? NotRequiredField { get; set; }
+        public string NotRequiredField { get; set; }
 
         [UsaRequired]
         [Display(Name = "Required Field")]
-        public string? RequiredField { get; set; }
+        public string RequiredField { get; set; }
     }
 }

--- a/components/src/Piipan.Components.Demo/wwwroot/sass/custom/_component_styles.scss
+++ b/components/src/Piipan.Components.Demo/wwwroot/sass/custom/_component_styles.scss
@@ -38,7 +38,7 @@
 // SSN Styles
 .usa-ssn-group {
     display: grid;
-    grid-template-columns: 108px 1.5em;
+    grid-template-columns: 118px 1.5em;
     grid-gap: .5rem;
     gap: .5rem;
     align-items: center;

--- a/components/src/Piipan.Components/Forms/UsaForm.razor
+++ b/components/src/Piipan.Components/Forms/UsaForm.razor
@@ -26,27 +26,30 @@
                 {
                     foreach (var error in errorPair.Errors)
                     {
-                        var linkPart = error.IndexOf("@@@");
-                        @if (linkPart >= 0 && errorPair.FormGroup != null)
+                        var splitErrors = error.Split('\n');
+                        foreach (var splitError in splitErrors)
                         {
-                            <li>
-                                @if (linkPart > 0)
-                                {
-                                    @error.Substring(0, linkPart)
-                                }
-                                <button class="@ButtonClass @ButtonUnstyledClass"
-                                    @onclick="async () => { await FocusElement(errorPair.FormGroup.InputElementId); }">
-                                    @errorPair.FormGroup.Label
-                                </button>
-                                @error.Substring(linkPart + 3)
-                            </li>
-                        }
-                        else
-                        {
-                            <li>@error</li>    
+                            var linkPart = splitError.IndexOf("@@@");
+                            @if (linkPart >= 0 && errorPair.FormGroup != null)
+                            {
+                                <li>
+                                    @if (linkPart > 0)
+                                    {
+                                        @splitError.Substring(0, linkPart)
+                                    }
+                                    <button class="@ButtonClass @ButtonUnstyledClass"
+                                        @onclick="async () => { await FocusElement(errorPair.FormGroup.InputElementId); }">
+                                        @errorPair.FormGroup.Label
+                                    </button>
+                                    @splitError.Substring(linkPart + 3)
+                                </li>
+                            }
+                            else
+                            {
+                                <li>@splitError</li>    
+                            }
                         }
                     }
-                    
                 }
             </ul>
         </UsaAlertBox>

--- a/components/src/Piipan.Components/Forms/UsaForm.razor
+++ b/components/src/Piipan.Components/Forms/UsaForm.razor
@@ -1,5 +1,6 @@
 ﻿@using Piipan.Components.Alerts
 @using static Shared.CommonConstants
+@using static Piipan.Components.Validation.ValidationConstants
 @using static FormConstants
 @code {
     [Parameter] public RenderFragment ChildContent { get; set; }
@@ -29,7 +30,7 @@
                         var splitErrors = error.Split('\n');
                         foreach (var splitError in splitErrors)
                         {
-                            var linkPart = splitError.IndexOf("@@@");
+                            var linkPart = splitError.IndexOf(ValidationFieldPlaceholder);
                             @if (linkPart >= 0 && errorPair.FormGroup != null)
                             {
                                 <li>

--- a/components/src/Piipan.Components/Forms/UsaFormGroup.razor
+++ b/components/src/Piipan.Components/Forms/UsaFormGroup.razor
@@ -27,7 +27,17 @@
         }
         @if (HasErrors)
         {
-            <span class="@InputErrorMessageClass" id="@(InputElementId)-message">@ValidationMessages.First().Replace("@@@", Label)</span>
+            <span class="@InputErrorMessageClass" id="@(InputElementId)-message">
+                @foreach (var message in ValidationMessages)
+                {
+                    var splitMessages = message.Split('\n');
+                    @foreach (var splitMessage in splitMessages)
+                    {
+                        @splitMessage.Replace("@@@", Label)
+                        <br />
+                    }
+                }
+            </span>
         }
         @ChildContent
     </div>

--- a/components/src/Piipan.Components/Forms/UsaFormGroup.razor
+++ b/components/src/Piipan.Components/Forms/UsaFormGroup.razor
@@ -1,5 +1,6 @@
 ﻿@using static FormConstants
 @using static Shared.CommonConstants
+@using static Piipan.Components.Validation.ValidationConstants
 @code {
     [CascadingParameter] public UsaForm Form { get; set; }
     [Parameter] public RenderFragment LabelOverride { get; set; }
@@ -33,7 +34,7 @@
                     var splitMessages = message.Split('\n');
                     @foreach (var splitMessage in splitMessages)
                     {
-                        @splitMessage.Replace("@@@", Label)
+                        @splitMessage.Replace(ValidationFieldPlaceholder, Label)
                         <br />
                     }
                 }

--- a/components/src/Piipan.Components/Validation/UsaNameAttribute.cs
+++ b/components/src/Piipan.Components/Validation/UsaNameAttribute.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Piipan.Components.Validation
 {
@@ -12,7 +8,7 @@ namespace Piipan.Components.Validation
     {
         public override bool IsValid(object value)
         {
-            var stringValue = value?.ToString();
+            var stringValue = value?.ToString()?.Trim();
 
             // If the name is required, we'll pick it up with a UsaRequired attribute. Don't flag it here
             if (string.IsNullOrEmpty(stringValue))
@@ -36,23 +32,10 @@ namespace Piipan.Components.Validation
                 ErrorMessage = string.Format(ValidationConstants.InvalidCharacterInNameMessage, string.Join(',', invalidValues), stringValue);
                 return false;
             }
-            // Convert to lower case
-            string result = stringValue.ToLower();
-            // Replace hyphens with a space
-            result = result.Replace("-", " ");
-            // Replace multiple spaces with one space
-            result = Regex.Replace(result, @"\s{2,}", " ");
-            // Trim any spaces at the start and end of the last name
-            char[] charsToTrim = { ' ' };
-            result = result.Trim(charsToTrim);
-            // Remove suffixes: roman numerals i-ix, variations of junior/senior
-            result = Regex.Replace(result, @"(\s(?:ix|iv|v?i{0,3}|junior|jr\.|jr|jnr|senior|sr\.|sr|snr)$)", "");
-            // Remove any character not an ASCII space(0x20) or not in range[a - z]
-            result = Regex.Replace(result, @"[^a-z|\s]", "");
-            // Validate that the resulting value is at least one ASCII character in length
-            if (result.Length < 1) // not at least one char
+
+            if (!char.IsLetter(stringValue[0])) // not at least one char
             {
-                ErrorMessage = ValidationConstants.NormalizedNameTooShortMessage;
+                ErrorMessage = ValidationConstants.MustStartWithALetter;
                 return false;
             }
             return true;

--- a/components/src/Piipan.Components/Validation/UsaSSNAttribute.cs
+++ b/components/src/Piipan.Components/Validation/UsaSSNAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Piipan.Components.Validation
 {
@@ -15,39 +16,39 @@ namespace Piipan.Components.Validation
 
         public override bool IsValid(object value)
         {
-            if (!base.IsValid(value))
-            {
-                ErrorMessage = ValidationConstants.SSNInvalidFormatMessage;
-                return false;
-            }
             var stringValue = value?.ToString();
-
             // If the SSN is required, we'll pick it up with a UsaRequired attribute. Don't flag it here
             if (string.IsNullOrEmpty(stringValue))
             {
                 return true;
             }
 
-            // If we're here, our string will be ###-##-#### because we already checked it against the base Regex.
-            var areaNumber = int.Parse(stringValue[0..3]);
-            if (areaNumber == 0 || areaNumber == 666 || areaNumber >= 900)
+            List<string> allErrors = new List<string>();
+            ErrorMessage = "";
+            if (!base.IsValid(value))
             {
-                ErrorMessage = string.Format(ValidationConstants.SSNInvalidFirstThreeDigitsMessage, stringValue[0..3]);
-                return false;
-            }
-            if (stringValue[4..6] == "00")
-            {
-                ErrorMessage = ValidationConstants.SSNInvalidMiddleTwoDigitsMessage;
-                return false;
-            }
-            if (stringValue[7..11] == "0000")
-            {
-                ErrorMessage = ValidationConstants.SSNInvalidLastFourDigitsMessage;
-                return false;
+                allErrors.Add(ValidationConstants.SSNInvalidFormatMessage);
             }
 
-            return true;
+            if (stringValue.Length >= 3 && int.TryParse(stringValue[0..3], out int areaNumber))
+            {
+                if (areaNumber == 0 || areaNumber == 666 || areaNumber >= 900)
+                {
+                    allErrors.Add(string.Format(ValidationConstants.SSNInvalidFirstThreeDigitsMessage, stringValue[0..3]));
+                }
+            }
+            if (stringValue.Length >= 6 && stringValue[4..6] == "00")
+            {
+                allErrors.Add(ValidationConstants.SSNInvalidMiddleTwoDigitsMessage);
+            }
+            if (stringValue.Length >= 11 && stringValue[7..11] == "0000")
+            {
+                allErrors.Add(ValidationConstants.SSNInvalidLastFourDigitsMessage);
+            }
 
+            ErrorMessage = string.Join('\n', allErrors);
+
+            return string.IsNullOrEmpty(ErrorMessage);
         }
     }
 }

--- a/components/src/Piipan.Components/Validation/ValidationConstants.cs
+++ b/components/src/Piipan.Components/Validation/ValidationConstants.cs
@@ -8,43 +8,48 @@
     public class ValidationConstants
     {
         /// <summary>
+        /// Used for a placeholder for the name of whatever field is being validated.
+        /// </summary>
+        public const string ValidationFieldPlaceholder = "@@@";
+
+        /// <summary>
         /// Used when a field is invalid, such as an invalid date
         /// </summary>
-        public const string InvalidMessage = "@@@ is invalid";
+        public const string InvalidMessage = $"{ValidationFieldPlaceholder} is invalid";
 
         /// <summary>
         /// Used for when a field is required, and is not filled in
         /// </summary>
-        public const string RequiredMessage = "@@@ is required";
+        public const string RequiredMessage = $"{ValidationFieldPlaceholder} is required";
 
         /// <summary>
         /// Used for social security number validation, when the SSN is not in the correct format
         /// </summary>
-        public const string SSNInvalidFormatMessage = "@@@ must have the form ###-##-####";
+        public const string SSNInvalidFormatMessage = $"{ValidationFieldPlaceholder} must have the form ###-##-####";
 
         /// <summary>
         /// Used for social security number validation, when the SSN doesn't have valid first 3 digits
         /// </summary>
-        public const string SSNInvalidFirstThreeDigitsMessage = "The first three numbers of @@@ cannot be {0}";
+        public const string SSNInvalidFirstThreeDigitsMessage = $"The first three numbers of {ValidationFieldPlaceholder} cannot be {{0}}";
 
         /// <summary>
         /// Used for social security number validation, when the SSN doesn't have valid middle 2 digits
         /// </summary>
-        public const string SSNInvalidMiddleTwoDigitsMessage = "The middle two numbers of @@@ cannot be 00";
+        public const string SSNInvalidMiddleTwoDigitsMessage = $"The middle two numbers of {ValidationFieldPlaceholder} cannot be 00";
 
         /// <summary>
         /// Used for social security number validation, when the SSN doesn't have valid last 4 digits
         /// </summary>
-        public const string SSNInvalidLastFourDigitsMessage = "The last four numbers of @@@ cannot be 0000";
+        public const string SSNInvalidLastFourDigitsMessage = $"The last four numbers of {ValidationFieldPlaceholder} cannot be 0000";
 
         /// <summary>
         /// Used for names when validating they would have at least one character after normalization
         /// </summary>
-        public const string MustStartWithALetter = "@@@ must start with a letter";
+        public const string MustStartWithALetter = $"{ValidationFieldPlaceholder} must start with a letter";
 
         /// <summary>
         /// Used for names when checking to see if it contains any non-ascii characters
         /// </summary>
-        public const string InvalidCharacterInNameMessage = "Change {0} in {1}. The @@@ should only contain standard ASCII characters, including the letters A-Z, numbers 0-9, and some select characters including hyphens.";
+        public const string InvalidCharacterInNameMessage = $"Change {{0}} in {{1}}. The {ValidationFieldPlaceholder} should only contain standard ASCII characters, including the letters A-Z, numbers 0-9, and some select characters including hyphens.";
     }
 }

--- a/components/src/Piipan.Components/Validation/ValidationConstants.cs
+++ b/components/src/Piipan.Components/Validation/ValidationConstants.cs
@@ -40,7 +40,7 @@
         /// <summary>
         /// Used for names when validating they would have at least one character after normalization
         /// </summary>
-        public const string NormalizedNameTooShortMessage = "Normalized @@@ must be at least 1 character long.";
+        public const string MustStartWithALetter = "@@@ must start with a letter";
 
         /// <summary>
         /// Used for names when checking to see if it contains any non-ascii characters

--- a/components/tests/Piipan.Components.Tests/Input/UsaFormTests.razor
+++ b/components/tests/Piipan.Components.Tests/Input/UsaFormTests.razor
@@ -3,6 +3,7 @@
 @using Piipan.Components.Forms
 @using static Piipan.Components.Forms.FormConstants
 @using static Piipan.Components.Shared.CommonConstants
+@using static Piipan.Components.Validation.ValidationConstants
 @inherits BaseTest<UsaForm>
 @code {
     public class TestModel {
@@ -10,7 +11,6 @@
         [Display(Name = "Required Field")]
         public string? RequiredField { get; set; }
     }
-    private IRenderedComponent<UsaForm>? form = null;
     private IElement? inputElement = null;
     private TestModel model = new TestModel();
     private RenderFragment? renderFragment = null;
@@ -33,13 +33,13 @@
 
         // Act
         bool isFormValid = true;
-        await Component.InvokeAsync(async () =>
+        await Component!.InvokeAsync(async () =>
         {
-            isFormValid = await Component.Instance.ValidateForm();
+            isFormValid = await Component!.Instance.ValidateForm();
         });
-        await Component.InvokeAsync(async () =>
+        await Component!.InvokeAsync(async () =>
         {
-            await Component.Instance.PresubmitForm();
+            await Component!.Instance.PresubmitForm();
         });
 
         // Assert
@@ -91,8 +91,8 @@
         // Arrange
         InitialValues.InitialErrors = new List<(string Property, string Error)>()
         {
-            ("model_RequiredField", "@@@ is required"),
-            ("model_RequiredField", "Testing link in the middle: @@@ is required"),
+            ("model_RequiredField", $"{ValidationFieldPlaceholder} is required"),
+            ("model_RequiredField", $"Testing link in the middle: {ValidationFieldPlaceholder} is required"),
             ("", "Some other server error")
         };
         CreateTestComponent();

--- a/components/tests/Piipan.Components.Tests/Validation/UsaNameAttributeTests.cs
+++ b/components/tests/Piipan.Components.Tests/Validation/UsaNameAttributeTests.cs
@@ -36,7 +36,7 @@ namespace Piipan.Components.Tests.Validation
         /// Validate that if an error occurs that the correct error message is returned
         /// </summary>
         [Fact]
-        public void CorrectErrorMessageForNormalizedNameTooShort()
+        public void CorrectErrorMessageForMustStartWithALetter()
         {
             // Arrange
             var attribute = new UsaNameAttribute();

--- a/components/tests/Piipan.Components.Tests/Validation/UsaNameAttributeTests.cs
+++ b/components/tests/Piipan.Components.Tests/Validation/UsaNameAttributeTests.cs
@@ -46,7 +46,7 @@ namespace Piipan.Components.Tests.Validation
 
             // Assert
             Assert.False(result);
-            Assert.Equal(ValidationConstants.NormalizedNameTooShortMessage, attribute.ErrorMessage);
+            Assert.Equal(ValidationConstants.MustStartWithALetter, attribute.ErrorMessage);
         }
 
         /// <summary>

--- a/match/tests/Piipan.Match.Core.Tests/Services/MatchServiceTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Services/MatchServiceTests.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Services;
 using Piipan.Participants.Api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Piipan.Match.Core.Tests.Services
@@ -244,7 +244,7 @@ namespace Piipan.Match.Core.Tests.Services
             Assert.Single(response.Data.Results, r => r.Index == 0);
 
             var matches = response.Data.Results.First().Matches;
-            Assert.Equal(0, matches.Count());
+            Assert.Empty(matches);
             Assert.Equal(0, matches.Count(m => m.ParticipantId == "p1"));
             Assert.Equal(0, matches.Count(m => m.ParticipantId == "p2"));
         }
@@ -283,7 +283,7 @@ namespace Piipan.Match.Core.Tests.Services
             var response = await service.FindMatches(request, "ea");
 
             participantApi.Verify(r => r.GetParticipants("ea", request.Data[0].LdsHash), Times.Never);
-            
+
         }
     }
 }

--- a/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
@@ -70,7 +70,7 @@
         <UsaFormGroup>
             <HintContent>###-##-####</HintContent>
             <ChildContent>
-                <UsaInputSSN @bind-Value="Query.SocialSecurityNum" Width="108" />
+                <UsaInputSSN @bind-Value="Query.SocialSecurityNum" />
             </ChildContent>
         </UsaFormGroup>
         <UsaFormGroup>

--- a/query-tool/src/Piipan.QueryTool.Client/Models/MatchSearchRequest.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Models/MatchSearchRequest.cs
@@ -1,13 +1,14 @@
 ﻿using Piipan.Components.Validation;
 using System.ComponentModel.DataAnnotations;
+using static Piipan.Components.Validation.ValidationConstants;
 
 namespace Piipan.QueryTool.Client.Models
 {
     public class MatchSearchRequest
     {
         [UsaRequired]
-        [StringLength(7, ErrorMessage = "@@@ must be 7 characters", MinimumLength = 7)]
-        [RegularExpression("^[a-zA-Z0-9]*$", ErrorMessage = "@@@ contains invalid characters")]
+        [StringLength(7, ErrorMessage = $"{ValidationFieldPlaceholder} must be 7 characters", MinimumLength = 7)]
+        [RegularExpression("^[a-zA-Z0-9]*$", ErrorMessage = $"{ValidationFieldPlaceholder} contains invalid characters")]
         [Display(Name = "Match ID")]
         public string MatchId { get; set; }
     }

--- a/query-tool/src/Piipan.QueryTool.Client/Models/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Models/PiiRecord.cs
@@ -2,7 +2,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
-
+using static Piipan.Components.Validation.ValidationConstants;
 namespace Piipan.QueryTool.Client.Models
 {
     /// <summary>
@@ -20,7 +20,7 @@ namespace Piipan.QueryTool.Client.Models
         [Display(Name = "Date of Birth")]
         [DataType(DataType.Date),
             DisplayFormat(DataFormatString = "{0:MM/dd/yyyy}")]
-        [DateOfBirthRange("01/01/1900", ErrorMessage = "@@@ must be between 01-01-1900 and today's date")]
+        [DateOfBirthRange("01/01/1900", ErrorMessage = $"{ValidationFieldPlaceholder} must be between 01-01-1900 and today's date")]
         [JsonPropertyName("dob")]
         public DateTime? DateOfBirth { get; set; }
 

--- a/query-tool/src/Piipan.QueryTool/wwwroot/sass/custom/_component_styles.scss
+++ b/query-tool/src/Piipan.QueryTool/wwwroot/sass/custom/_component_styles.scss
@@ -41,7 +41,7 @@
 // SSN Styles
 .usa-ssn-group {
     display: grid;
-    grid-template-columns: 108px 1.5em;
+    grid-template-columns: 118px 1.5em;
     grid-gap: .5rem;
     gap: .5rem;
     align-items: center;

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchFormTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchFormTests.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 using static Piipan.Components.Forms.FormConstants;
+using static Piipan.Components.Validation.ValidationConstants;
 
 namespace Piipan.QueryTool.Tests.Components
 {
@@ -158,7 +159,7 @@ namespace Piipan.QueryTool.Tests.Components
         public void Form_With_Server_Error_Should_Show_Errors()
         {
             // Arrange
-            InitialValues.ServerErrors = new List<ServerError> { new("Query.MatchId", "@@@ is required") };
+            InitialValues.ServerErrors = new List<ServerError> { new("Query.MatchId", $"{ValidationFieldPlaceholder} is required") };
             CreateTestComponent();
 
             var alertBox = queryForm.FindComponent<UsaAlertBox>();

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 using static Piipan.Components.Forms.FormConstants;
+using static Piipan.Components.Validation.ValidationConstants;
 
 namespace Piipan.QueryTool.Tests.Components
 {
@@ -215,7 +216,7 @@ namespace Piipan.QueryTool.Tests.Components
         public void Form_With_Server_Error_Should_Show_Errors()
         {
             // Arrange
-            InitialValues.ServerErrors = new List<ServerError> { new("Query.LastName", "@@@ is required") };
+            InitialValues.ServerErrors = new List<ServerError> { new("Query.LastName", $"{ValidationFieldPlaceholder} is required") };
             CreateTestComponent();
 
             var alertBox = queryForm.FindComponent<UsaAlertBox>();

--- a/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Xunit;
+using static Piipan.Components.Validation.ValidationConstants;
 
 namespace Piipan.QueryTool.Tests
 {
@@ -169,10 +170,10 @@ namespace Piipan.QueryTool.Tests
         }
 
         [Theory]
-        [InlineData("123", "@@@ must be 7 characters")]
-        [InlineData("12345678", "@@@ must be 7 characters")]
-        [InlineData("m1$2345", "@@@ contains invalid characters")]
-        [InlineData("", "@@@ is required")]
+        [InlineData("123", $"{ValidationFieldPlaceholder} must be 7 characters")]
+        [InlineData("12345678", $"{ValidationFieldPlaceholder} must be 7 characters")]
+        [InlineData("m1$2345", $"{ValidationFieldPlaceholder} contains invalid characters")]
+        [InlineData("", $"{ValidationFieldPlaceholder} is required")]
         public async Task TestInvalidMatchId_Post(string matchId, string expectedError)
         {
             // arrange


### PR DESCRIPTION
It was decided that if there were multiple errors with a certain field, we would show all of the errors instead of just the first one. In addition, the wording for when the user doesn't type in any letters is confusing, as it said "Normalized Last Name must be at least 1 character long." Now, we'll just say "Last Name must start with a letter" and update the requirements for that field appropriately.

## What’s changing?

- The UsaSSN attribute validation now returns all errors instead of just the first one
- The UsaName attribute now just simply checks to make sure the first non-space character they've typed is a letter
- The alert box was updated to show all errors on multiple list items when the returned error has more than one line
- The error above the field on a form was updated to show all errors instead of just the first one. Line breaks separate the errors.
- The SSN input field was widened by 10 more pixels so that the last digit wouldn't get cut off when the field had an error.

## Why?

Closes NAC-655

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
