### PR TITLE
Updating package lock using a different node version

### DIFF
--- a/docs/iac.md
+++ b/docs/iac.md
@@ -7,7 +7,7 @@
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download)
 - `bash` shell >= 4.1, `/dev/urandom` – included in macOS, Linux, Git for Windows, Azure Cloud Shell
 - `psql` client for PostgreSQL – included in Azure Cloud Shell
-- [Node.js](https://nodejs.org/en/) >= 12.20.0 and `npm` [Node Package Manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for compiling assets during the build of ASP.NET Core web applications
+- [Node.js](https://nodejs.org/en/) >= 12.20.0 and `npm` [Node Package Manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for compiling assets during the build of ASP.NET Core web applications. NOTE: As of 4/26/22, it is recommended to use Node.js version 14.19.1, otherwise the package-lock files you generate may not be compatible with the rest of the team's setup.
 
 ## Steps
 To (re)create the Azure resources that `piipan` uses:

--- a/query-tool/src/Piipan.QueryTool/package-lock.json
+++ b/query-tool/src/Piipan.QueryTool/package-lock.json
@@ -108,10 +108,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/@gulp-sourcemaps/identity-map/node_modules/through2": {
@@ -213,12 +209,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
     },
     "node_modules/acorn": {
       "version": "6.4.2",
@@ -766,9 +756,9 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
-      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.3.tgz",
+      "integrity": "sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -928,9 +918,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/bindings": {
@@ -1315,9 +1302,6 @@
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -1405,7 +1389,6 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-      "deprecated": "Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies",
       "dev": true,
       "dependencies": {
         "anymatch": "^2.0.0",
@@ -1986,7 +1969,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
       "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -3181,7 +3163,6 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -3217,9 +3198,6 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
@@ -3289,9 +3267,6 @@
       },
       "engines": {
         "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3664,9 +3639,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-value": {
@@ -3715,19 +3687,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/hogan.js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
-      "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
-      "dev": true,
-      "dependencies": {
-        "mkdirp": "0.3.0",
-        "nopt": "1.0.10"
-      },
-      "bin": {
-        "hulk": "bin/hulk"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -3793,9 +3752,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "dependencies": {
         "agent-base": "6",
@@ -4056,9 +4015,6 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-data-descriptor": {
@@ -4393,9 +4349,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/jpeg-js": {
@@ -4651,9 +4604,9 @@
       }
     },
     "node_modules/lighthouse-stack-packs": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.7.0.tgz",
-      "integrity": "sha512-ggLg9V6Hs31Qcn29L2fwKsaQq8L5t+mIv3lNqwd85bc7zFxpMVybK71b4w2OeBLpa0H8gATIi9fxPlP+9moMDA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.8.1.tgz",
+      "integrity": "sha512-LSCu9Ugt9NPvRfBNzAjMDLvYev9r/93OTmbIWt9iXwiCmd999I/zneRTwsFLtlQWGKwNbDHS9vXnU+KpXUb1qg==",
       "dev": true
     },
     "node_modules/lighthouse/node_modules/ansi-regex": {
@@ -4678,15 +4631,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/lighthouse/node_modules/axe-core": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.3.tgz",
-      "integrity": "sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/lighthouse/node_modules/cliui": {
@@ -5519,16 +5463,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -5540,6 +5474,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/mute-stdout": {
       "version": "1.0.1",
@@ -5634,21 +5577,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/normalize-package-data": {
@@ -5803,9 +5731,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.defaults": {
@@ -5979,9 +5904,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -6003,18 +5925,18 @@
       }
     },
     "node_modules/pa11y": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-6.1.1.tgz",
-      "integrity": "sha512-2NzqA3D9CUlDWj8WuOI4fM2P0qM1d/IUxsRRpzCOfDT5eMR1oEgmUwW2TAk+f90ff/GVck0BewdYT4et4BANew==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-6.2.3.tgz",
+      "integrity": "sha512-69JoUlfW2QVmrgQAm+17XBxIvmd1u0ImFBYIHPyjC61CzAkmxO3kkbqDVxIcl0OKLvAMYSMbvfCH8kMFE9xsbg==",
       "dev": true,
       "dependencies": {
-        "axe-core": "^4.0.2",
+        "axe-core": "~4.2.1",
         "bfj": "~7.0.2",
         "commander": "~8.0.0",
         "envinfo": "~7.8.1",
-        "hogan.js": "^3.0.2",
-        "html_codesniffer": "^2.5.1",
+        "html_codesniffer": "~2.5.1",
         "kleur": "~4.1.4",
+        "mustache": "~4.2.0",
         "node.extend": "~2.0.2",
         "p-timeout": "~4.1.0",
         "puppeteer": "~9.1.1",
@@ -6037,9 +5959,9 @@
       }
     },
     "node_modules/pa11y/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6236,9 +6158,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pify": {
@@ -6852,9 +6771,6 @@
       "dependencies": {
         "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-dir": {
@@ -6900,7 +6816,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/responselike": {
@@ -7074,7 +6989,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7460,7 +7374,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
@@ -7474,7 +7387,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
     "node_modules/sparkles": {
@@ -7782,9 +7694,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/third-party-web": {
@@ -8348,7 +8257,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/url-parse-lax": {
@@ -8388,25 +8296,8 @@
       }
     },
     "node_modules/uswds-gulp": {
-      "version": "0.1.0",
       "resolved": "git+ssh://git@github.com/uswds/uswds-gulp.git#0896d3be9681541f200e45309d183fdae837d737",
-      "integrity": "sha512-ZWnjP0IkfX3ydWBhElf8Goddux+ZAO9BylrZwtFkrSGqnl6NXT1L9HUkubCSSrjiRfzfizGNWVqd75iRR1Yi1Q==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "autoprefixer": "^10.2.4",
-        "gulp": "^4.0.2",
-        "gulp-postcss": "^9.0.0",
-        "gulp-rename": "^2.0.0",
-        "gulp-replace": "^1.0.0",
-        "gulp-sass": "^4.1.0",
-        "gulp-sourcemaps": "^3.0.0",
-        "gulp-svg-sprite": "^1.5.0",
-        "postcss": "^8.2.5",
-        "postcss-csso": "^5.0.0",
-        "sass": "^1.32.6",
-        "uswds": "^2.10.0"
-      }
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -8954,12 +8845,6 @@
         "@types/node": "*"
       }
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "acorn": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
@@ -9356,9 +9241,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
-      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.3.tgz",
+      "integrity": "sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==",
       "dev": true
     },
     "bach": {
@@ -11699,16 +11584,6 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
-    "hogan.js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
-      "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.3.0",
-        "nopt": "1.0.10"
-      }
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -11760,9 +11635,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "requires": {
         "agent-base": "6",
@@ -12428,12 +12303,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "axe-core": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.3.tgz",
-          "integrity": "sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==",
-          "dev": true
-        },
         "cliui": {
           "version": "7.0.4",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -12543,9 +12412,9 @@
       }
     },
     "lighthouse-stack-packs": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.7.0.tgz",
-      "integrity": "sha512-ggLg9V6Hs31Qcn29L2fwKsaQq8L5t+mIv3lNqwd85bc7zFxpMVybK71b4w2OeBLpa0H8gATIi9fxPlP+9moMDA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.8.1.tgz",
+      "integrity": "sha512-LSCu9Ugt9NPvRfBNzAjMDLvYev9r/93OTmbIWt9iXwiCmd999I/zneRTwsFLtlQWGKwNbDHS9vXnU+KpXUb1qg==",
       "dev": true
     },
     "lilconfig": {
@@ -13104,12 +12973,6 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-      "dev": true
-    },
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -13120,6 +12983,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "dev": true
     },
     "mute-stdout": {
@@ -13189,15 +13058,6 @@
       "requires": {
         "has": "^1.0.3",
         "is": "^3.2.1"
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -13463,18 +13323,18 @@
       "dev": true
     },
     "pa11y": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-6.1.1.tgz",
-      "integrity": "sha512-2NzqA3D9CUlDWj8WuOI4fM2P0qM1d/IUxsRRpzCOfDT5eMR1oEgmUwW2TAk+f90ff/GVck0BewdYT4et4BANew==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-6.2.3.tgz",
+      "integrity": "sha512-69JoUlfW2QVmrgQAm+17XBxIvmd1u0ImFBYIHPyjC61CzAkmxO3kkbqDVxIcl0OKLvAMYSMbvfCH8kMFE9xsbg==",
       "dev": true,
       "requires": {
-        "axe-core": "^4.0.2",
+        "axe-core": "~4.2.1",
         "bfj": "~7.0.2",
         "commander": "~8.0.0",
         "envinfo": "~7.8.1",
-        "hogan.js": "^3.0.2",
-        "html_codesniffer": "^2.5.1",
+        "html_codesniffer": "~2.5.1",
         "kleur": "~4.1.4",
+        "mustache": "~4.2.0",
         "node.extend": "~2.0.2",
         "p-timeout": "~4.1.0",
         "puppeteer": "~9.1.1",
@@ -13488,9 +13348,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -15327,10 +15187,8 @@
     },
     "uswds-gulp": {
       "version": "git+ssh://git@github.com/uswds/uswds-gulp.git#0896d3be9681541f200e45309d183fdae837d737",
-      "integrity": "sha512-ZWnjP0IkfX3ydWBhElf8Goddux+ZAO9BylrZwtFkrSGqnl6NXT1L9HUkubCSSrjiRfzfizGNWVqd75iRR1Yi1Q==",
       "dev": true,
-      "from": "uswds-gulp@github:uswds/uswds-gulp",
-      "requires": {}
+      "from": "uswds-gulp@github:uswds/uswds-gulp"
     },
     "util-deprecate": {
       "version": "1.0.2",


### PR DESCRIPTION
@ryangeorgeharvey and @kcherukupalli noticed that they were getting npm install errors for the query tool project. I was not getting any issues until I downgraded to node version 14.19.1, which is the same version that they were on and what Azure CloudShell was using.

## What’s changing?

The package-lock file was rebuilt with node version 14.19.1, and no longer has any issues.

## Why?

Build issues described above

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
