### PR TITLE
Front door ARM Template changes for Security Headers

### DIFF
--- a/iac/arm-templates/front-door-app-service.json
+++ b/iac/arm-templates/front-door-app-service.json
@@ -65,7 +65,8 @@
     "variables": {
         "location": "global", /* front-door location must be global */
         "wafLocation": "global" /* waf location must be global */,
-        "eventhubName": "[concat(parameters('prefix'), '-evh-monitoring-', parameters('env'))]"
+        "eventhubName": "[concat(parameters('prefix'), '-evh-monitoring-', parameters('env'))]",
+        "securityHeaderRulesName": "SecurityHeaderRules"
     },
     "resources": [
         {
@@ -227,13 +228,13 @@
                                 }
                             },
                             "rulesEngine": {
-                                "id": "[resourceId('Microsoft.Network/frontdoors/rulesengines', parameters('frontDoorName'), 'SecurityHeaderRules')]"
+                                "id": "[resourceId('Microsoft.Network/frontdoors/rulesengines', parameters('frontDoorName'), variables('securityHeaderRulesName'))]"
                             },
                             "enabledState": "Enabled"
                         }
                     },
                     {
-                        "name": "HttpRedirect",
+                        "name": "httpRedirect",
                         "properties": {
                             "frontendEndpoints": [
                                 {
@@ -288,7 +289,7 @@
         {
             "type": "Microsoft.Network/frontdoors/rulesengines",
             "apiVersion": "2020-05-01",
-            "name": "[concat(parameters('frontDoorName'), '/SecurityHeaderRules')]",
+            "name": "[concat(parameters('frontDoorName'), '/', variables('securityHeaderRulesName'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/frontdoors', parameters('frontDoorName'))]"
             ],

--- a/iac/arm-templates/front-door-app-service.json
+++ b/iac/arm-templates/front-door-app-service.json
@@ -214,7 +214,6 @@
                                 }
                             ],
                             "acceptedProtocols": [
-                                "Http",
                                 "Https"
                             ],
                             "patternsToMatch": [
@@ -226,6 +225,31 @@
                                 "backendPool": {
                                     "id": "[resourceId('Microsoft.Network/frontDoors/backendPools', parameters('frontDoorName'), concat('backend-pool-', uniqueString(parameters('frontDoorName'))))]"
                                 }
+                            },
+                            "rulesEngine": {
+                                "id": "[resourceId('Microsoft.Network/frontdoors/rulesengines', parameters('frontDoorName'), 'StrictTransportSecurity')]"
+                            },
+                            "enabledState": "Enabled"
+                        }
+                    },
+                    {
+                        "name": "HttpRedirect",
+                        "properties": {
+                            "frontendEndpoints": [
+                                {
+                                    "id": "[resourceId('Microsoft.Network/frontDoors/frontendEndpoints', parameters('frontDoorName'), concat('azurefd-net-', uniqueString(parameters('frontDoorName'))))]"
+                                }
+                            ],
+                            "acceptedProtocols": [
+                                "Http"
+                            ],
+                            "patternsToMatch": [
+                                "/*"
+                            ],
+                            "routeConfiguration": {
+                                "redirectType": "PermanentRedirect",
+                                "redirectProtocol": "HttpsOnly",
+                                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration"
                             },
                             "enabledState": "Enabled"
                         }
@@ -257,6 +281,35 @@
                     {
                         "category": "FrontdoorWebApplicationFirewallLog",
                         "enabled": true
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/frontdoors/rulesengines",
+            "apiVersion": "2020-05-01",
+            "name": "[concat(parameters('frontDoorName'), '/StrictTransportSecurity')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/frontdoors', parameters('frontDoorName'))]"
+            ],
+            "properties": {
+                "resourceState": "Enabled",
+                "rules": [
+                    {
+                        "name": "StrictTransportSecurity",
+                        "priority": 0,
+                        "action": {
+                            "requestHeaderActions": [],
+                            "responseHeaderActions": [
+                                {
+                                    "headerActionType": "Overwrite",
+                                    "headerName": "Strict-Transport-Security",
+                                    "value": "max-age=31536000; includeSubDomains; preload"
+                                }
+                            ]
+                        },
+                        "matchConditions": [],
+                        "matchProcessingBehavior": "Continue"
                     }
                 ]
             }

--- a/iac/arm-templates/front-door-app-service.json
+++ b/iac/arm-templates/front-door-app-service.json
@@ -221,13 +221,13 @@
                             ],
                             "routeConfiguration": {
                                 "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-                                "forwardingProtocol": "MatchRequest",
+                                "forwardingProtocol": "HttpsOnly",
                                 "backendPool": {
                                     "id": "[resourceId('Microsoft.Network/frontDoors/backendPools', parameters('frontDoorName'), concat('backend-pool-', uniqueString(parameters('frontDoorName'))))]"
                                 }
                             },
                             "rulesEngine": {
-                                "id": "[resourceId('Microsoft.Network/frontdoors/rulesengines', parameters('frontDoorName'), 'StrictTransportSecurity')]"
+                                "id": "[resourceId('Microsoft.Network/frontdoors/rulesengines', parameters('frontDoorName'), 'SecurityHeaderRules')]"
                             },
                             "enabledState": "Enabled"
                         }
@@ -288,7 +288,7 @@
         {
             "type": "Microsoft.Network/frontdoors/rulesengines",
             "apiVersion": "2020-05-01",
-            "name": "[concat(parameters('frontDoorName'), '/StrictTransportSecurity')]",
+            "name": "[concat(parameters('frontDoorName'), '/SecurityHeaderRules')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/frontdoors', parameters('frontDoorName'))]"
             ],
@@ -296,7 +296,7 @@
                 "resourceState": "Enabled",
                 "rules": [
                     {
-                        "name": "StrictTransportSecurity",
+                        "name": "AddSecurityHeaders",
                         "priority": 0,
                         "action": {
                             "requestHeaderActions": [],
@@ -305,6 +305,11 @@
                                     "headerActionType": "Overwrite",
                                     "headerName": "Strict-Transport-Security",
                                     "value": "max-age=31536000; includeSubDomains; preload"
+                                },
+                                {
+                                    "headerActionType": "Overwrite",
+                                    "headerName": "X-Frame-Options",
+                                    "value": "DENY"
                                 }
                             ]
                         },


### PR DESCRIPTION
## What’s changing?

The Strict-Transport-Security and X-Frame-Options headers were sometimes missing from the query tool and dashboard application due to Front Door/EasyAuth quirks. The easiest and most straightforward solution is to make changes to Front Door itself to pass these header values in the response.

## Why?

Closes NAC-477, NAC-458, and NAC-505

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [x] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
