### PR TITLE
Adding new API endpoint for getting all of the matches and corresponding View

### DIFF
--- a/match/src/Piipan.Match/Piipan.Match.Api/IMatchResolutionApi.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/IMatchResolutionApi.cs
@@ -6,6 +6,6 @@ namespace Piipan.Match.Api
     public interface IMatchResolutionApi
     {
         Task<MatchResApiResponse> GetMatch(string matchId);
-        Task<MatchResListApiResponse> GetMatchesList();
+        Task<MatchResListApiResponse> GetMatches();
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Api/IMatchResolutionApi.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/IMatchResolutionApi.cs
@@ -6,5 +6,6 @@ namespace Piipan.Match.Api
     public interface IMatchResolutionApi
     {
         Task<MatchResApiResponse> GetMatch(string matchId);
+        Task<MatchResListApiResponse> GetMatchesList();
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Api/Models/Resolution/MatchResListApiResponse.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/Models/Resolution/MatchResListApiResponse.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Piipan.Match.Api.Models.Resolution
+{
+    public class MatchResListApiResponse
+    {
+        [JsonProperty("data", Required = Required.Always)]
+        public IEnumerable<MatchResRecord> Data { get; set; }
+    }
+}

--- a/match/src/Piipan.Match/Piipan.Match.Api/Models/Resolution/MatchResRecord.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/Models/Resolution/MatchResRecord.cs
@@ -14,6 +14,8 @@ namespace Piipan.Match.Api.Models.Resolution
         public string Initiator { get; set; }
         [JsonProperty("match_id")]
         public string MatchId { get; set; }
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
         [JsonProperty("participants")]
         public Participant[] Participants { get; set; } = Array.Empty<Participant>();
         [JsonProperty("states")]

--- a/match/src/Piipan.Match/Piipan.Match.Client/MatchResolutionClient.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Client/MatchResolutionClient.cs
@@ -37,9 +37,9 @@ namespace Piipan.Match.Client
         /// <summary>
         /// Sends a GET request to the /list endpoint using the API client's configured base URL.
         /// </summary>
-        public async Task<MatchResListApiResponse> GetMatchesList()
+        public async Task<MatchResListApiResponse> GetMatches()
         {
-            var (response, _) = await _apiClient.TryGetAsync<MatchResListApiResponse>($"list");
+            var (response, _) = await _apiClient.TryGetAsync<MatchResListApiResponse>($"matches");
             return response;
         }
     }

--- a/match/src/Piipan.Match/Piipan.Match.Client/MatchResolutionClient.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Client/MatchResolutionClient.cs
@@ -1,10 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Piipan.Match.Api;
-using Piipan.Match.Api.Models;
+﻿using Piipan.Match.Api;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.Shared.Http;
+using System.Threading.Tasks;
 
 namespace Piipan.Match.Client
 {
@@ -34,6 +31,15 @@ namespace Piipan.Match.Client
         public async Task<MatchResApiResponse> GetMatch(string matchId)
         {
             var (response, _) = await _apiClient.TryGetAsync<MatchResApiResponse>($"matches/{matchId}");
+            return response;
+        }
+
+        /// <summary>
+        /// Sends a GET request to the /list endpoint using the API client's configured base URL.
+        /// </summary>
+        public async Task<MatchResListApiResponse> GetMatchesList()
+        {
+            var (response, _) = await _apiClient.TryGetAsync<MatchResListApiResponse>($"list");
             return response;
         }
     }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Builders/MatchResAggregator.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Builders/MatchResAggregator.cs
@@ -28,6 +28,7 @@ namespace Piipan.Match.Core.Builders
             aggregate.Participants = CollectParticipantData(match);
             aggregate.MatchId = match.MatchId;
             aggregate.States = match.States;
+            aggregate.CreatedAt = match.CreatedAt;
             aggregate.Initiator = match.Initiator;
             return aggregate;
         }
@@ -54,7 +55,8 @@ namespace Piipan.Match.Core.Builders
         {
             return match_res_events
                 .Select(mre => JObject.Parse(mre.Delta))
-                .Aggregate(JObject.Parse(@"{}"), (acc, x) => {
+                .Aggregate(JObject.Parse(@"{}"), (acc, x) =>
+                {
                     acc.Merge(x, new JsonMergeSettings
                     {
                         MergeArrayHandling = MergeArrayHandling.Union

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/IMatchRecordDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/IMatchRecordDao.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Piipan.Match.Core.DataAccessObjects
 {
@@ -10,5 +10,6 @@ namespace Piipan.Match.Core.DataAccessObjects
         Task<string> AddRecord(MatchRecordDbo record);
         Task<IEnumerable<IMatchRecord>> GetRecords(MatchRecordDbo record);
         Task<IMatchRecord> GetRecordByMatchId(string matchId);
+        Task<IEnumerable<IMatchRecord>> GetMatchesList();
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/IMatchRecordDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/IMatchRecordDao.cs
@@ -10,6 +10,6 @@ namespace Piipan.Match.Core.DataAccessObjects
         Task<string> AddRecord(MatchRecordDbo record);
         Task<IEnumerable<IMatchRecord>> GetRecords(MatchRecordDbo record);
         Task<IMatchRecord> GetRecordByMatchId(string matchId);
-        Task<IEnumerable<IMatchRecord>> GetMatchesList();
+        Task<IEnumerable<IMatchRecord>> GetMatches();
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/IMatchResEventDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/IMatchResEventDao.cs
@@ -1,8 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Piipan.Match.Core.DataAccessObjects
 {
@@ -11,6 +10,11 @@ namespace Piipan.Match.Core.DataAccessObjects
         Task<int> AddEvent(MatchResEventDbo record);
         Task<IEnumerable<IMatchResEvent>> GetEvents(
             string matchId,
+            bool sortByAsc = true
+        );
+
+        Task<IEnumerable<IMatchResEvent>> GetEventsByMatchIDs(
+            IEnumerable<string> matchIds,
             bool sortByAsc = true
         );
     }

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -7,6 +5,8 @@ using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Exceptions;
 using Piipan.Match.Core.Models;
 using Piipan.Shared.Database;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Piipan.Match.Core.DataAccessObjects
 {
@@ -114,6 +114,26 @@ namespace Piipan.Match.Core.DataAccessObjects
             }
         }
 
+        public async Task<IEnumerable<IMatchRecord>> GetMatchesList()
+        {
+            const string sql = @"
+                SELECT
+                    match_id,
+                    created_at,
+                    initiator,
+                    states,
+                    hash,
+                    hash_type::text,
+                    input::jsonb,
+                    data::jsonb
+                FROM matches;";
+
+            using (var connection = await _dbConnectionFactory.Build())
+            {
+                return await connection.QueryAsync<MatchRecordDbo>(sql);
+            }
+        }
+
         /// <summary>
         /// Finds a Match Record by Match ID
         /// </summary>
@@ -141,7 +161,8 @@ namespace Piipan.Match.Core.DataAccessObjects
 
             using (var connection = await _dbConnectionFactory.Build())
             {
-                return await connection.QuerySingleAsync<MatchRecordDbo>(sql, new MatchRecordDbo {
+                return await connection.QuerySingleAsync<MatchRecordDbo>(sql, new MatchRecordDbo
+                {
                     MatchId = matchId
                 });
             }

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchRecordDao.cs
@@ -114,7 +114,7 @@ namespace Piipan.Match.Core.DataAccessObjects
             }
         }
 
-        public async Task<IEnumerable<IMatchRecord>> GetMatchesList()
+        public async Task<IEnumerable<IMatchRecord>> GetMatches()
         {
             const string sql = @"
                 SELECT

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchResEventDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchResEventDao.cs
@@ -4,6 +4,7 @@ using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Models;
 using Piipan.Shared.Database;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Piipan.Match.Core.DataAccessObjects
@@ -124,7 +125,7 @@ namespace Piipan.Match.Core.DataAccessObjects
                     delta::jsonb
                 FROM match_res_events
                 WHERE
-                    match_id in (@MatchIds)
+                    match_id = ANY (@MatchIds)
                 ORDER BY
                 CASE
                     WHEN @SortByAsc = true THEN inserted_at
@@ -135,7 +136,7 @@ namespace Piipan.Match.Core.DataAccessObjects
                 ;";
             var parameters = new
             {
-                MatchIds = "'" + string.Join(',', matchIds) + "'",
+                MatchIds = matchIds.ToList(),
                 SortByAsc = sortByAsc
             };
 

--- a/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchResEventDao.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/DataAccessObjects/MatchResEventDao.cs
@@ -1,13 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Extensions.Logging;
-using Npgsql;
 using Piipan.Match.Api.Models;
-using Piipan.Match.Core.Exceptions;
 using Piipan.Match.Core.Models;
 using Piipan.Shared.Database;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Piipan.Match.Core.DataAccessObjects
 {
@@ -94,8 +91,51 @@ namespace Piipan.Match.Core.DataAccessObjects
                     WHEN @SortByAsc = false THEN inserted_at
                 END DESC
                 ;";
-            var parameters = new {
+            var parameters = new
+            {
                 MatchId = matchId,
+                SortByAsc = sortByAsc
+            };
+
+            using (var connection = await _dbConnectionFactory.Build())
+            {
+                return await connection.QueryAsync<MatchResEventDbo>(sql, parameters);
+            }
+        }
+
+        /// <summary>
+        /// Finds all match resolution events related to any of the specified match IDs
+        /// </summary>
+        /// <param name="matchIds">The list of match ID</param>
+        /// <param name="sortByAsc">Boolean indicating ascending sort order, defaults to true. Argument of false is descending order</param>
+        /// <returns>Task of IEnumerable of IMatchResEvents</returns>
+        public async Task<IEnumerable<IMatchResEvent>> GetEventsByMatchIDs(
+            IEnumerable<string> matchIds,
+            bool sortByAsc = true
+        )
+        {
+            const string sql = @"
+                SELECT
+                    id,
+                    match_id,
+                    inserted_at,
+                    actor,
+                    actor_state,
+                    delta::jsonb
+                FROM match_res_events
+                WHERE
+                    match_id in (@MatchIds)
+                ORDER BY
+                CASE
+                    WHEN @SortByAsc = true THEN inserted_at
+                END ASC,
+                CASE
+                    WHEN @SortByAsc = false THEN inserted_at
+                END DESC
+                ;";
+            var parameters = new
+            {
+                MatchIds = "'" + string.Join(',', matchIds) + "'",
                 SortByAsc = sortByAsc
             };
 

--- a/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/AddEventApi.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/AddEventApi.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
+using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
@@ -15,229 +11,194 @@ using Piipan.Match.Core.DataAccessObjects;
 using Piipan.Match.Core.Models;
 using Piipan.Match.Core.Parsers;
 using Piipan.Match.Func.ResolutionApi.Models;
-using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 
 #nullable enable
 
 namespace Piipan.Match.Func.ResolutionApi
 {
-        /// <summary>
-        /// Azure Function implementing Disposition Update endpoint for Match Resolution API
-        /// </summary>
-       public class AddEventApi
-       {
-            private readonly IMatchRecordDao _matchRecordDao;
-            private readonly IMatchResEventDao _matchResEventDao;
-            private readonly IMatchResAggregator _matchResAggregator;
-            private readonly IStreamParser<AddEventRequest> _requestParser;
-            public readonly string UserActor = "user";
-            public readonly string SystemActor = "system";
-            public readonly string ClosedDelta = "{\"status\": \"closed\"}";
+    /// <summary>
+    /// Azure Function implementing Disposition Update endpoint for Match Resolution API
+    /// </summary>
+    public class AddEventApi : BaseApi
+    {
+        private readonly IMatchRecordDao _matchRecordDao;
+        private readonly IMatchResEventDao _matchResEventDao;
+        private readonly IMatchResAggregator _matchResAggregator;
+        private readonly IStreamParser<AddEventRequest> _requestParser;
+        public readonly string UserActor = "user";
+        public readonly string SystemActor = "system";
+        public readonly string ClosedDelta = "{\"status\": \"closed\"}";
 
-            public AddEventApi(
-                IMatchRecordDao matchRecordDao,
-                IMatchResEventDao matchResEventDao,
-                IMatchResAggregator matchResAggregator,
-                IStreamParser<AddEventRequest> requestParser)
+        public AddEventApi(
+            IMatchRecordDao matchRecordDao,
+            IMatchResEventDao matchResEventDao,
+            IMatchResAggregator matchResAggregator,
+            IStreamParser<AddEventRequest> requestParser)
+        {
+            _matchRecordDao = matchRecordDao;
+            _matchResEventDao = matchResEventDao;
+            _matchResAggregator = matchResAggregator;
+            _requestParser = requestParser;
+        }
+
+        [FunctionName("AddEvent")]
+        public async Task<IActionResult> AddEvent(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "matches/{matchId}/disposition")] HttpRequest req,
+            string matchId,
+            ILogger logger)
+        {
+            LogRequest(logger, req);
+
+            try
             {
-                _matchRecordDao = matchRecordDao;
-                _matchResEventDao = matchResEventDao;
-                _matchResAggregator = matchResAggregator;
-                _requestParser = requestParser;
-            }
-
-            [FunctionName("AddEvent")]
-            public async Task<IActionResult> AddEvent(
-                [HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "matches/{matchId}/disposition")] HttpRequest req,
-                string matchId,
-                ILogger logger)
-            {
-                LogRequest(logger, req);
-
-                try
+                var reqObj = await _requestParser.Parse(req.Body);
+                var match = _matchRecordDao.GetRecordByMatchId(matchId);
+                var matchResEvents = _matchResEventDao.GetEvents(matchId);
+                await Task.WhenAll(match, matchResEvents);
+                // If state does not belong to match, return unauthorized
+                string state = req.Headers["X-Initiating-State"];
+                state = state.ToLower();
+                if (!match.Result.States.Contains(state))
                 {
-                    var reqObj = await _requestParser.Parse(req.Body);
-                    var match = _matchRecordDao.GetRecordByMatchId(matchId);
-                    var matchResEvents = _matchResEventDao.GetEvents(matchId);
-                    await Task.WhenAll(match, matchResEvents);
-                    // If state does not belong to match, return unauthorized
-                    string state = req.Headers["X-Initiating-State"];
-                    state = state.ToLower();
-                    if (!match.Result.States.Contains(state))
+                    return UnauthorizedErrorResponse();
+                }
+                // If match is closed, return unauthorized
+                var matchResRecord = _matchResAggregator.Build(match.Result, matchResEvents.Result);
+                if (matchResRecord.Status == MatchRecordStatus.Closed)
+                {
+                    return UnauthorizedErrorResponse();
+                }
+                // If last event is same as this event, return not allowed
+                IMatchResEvent? lastEvent = matchResEvents.Result.LastOrDefault();
+                if (lastEvent is IMatchResEvent)
+                {
+                    var deltaObj = JsonConvert.DeserializeObject<AddEventRequestData>(lastEvent.Delta);
+                    if (lastEvent.ActorState == state &&
+                        deltaObj is AddEventRequestData &&
+                        JsonConvert.SerializeObject(deltaObj) == JsonConvert.SerializeObject(reqObj.Data))
                     {
-                        return UnauthorizedErrorResponse();
+                        string message = "Duplicate action not allowed";
+                        logger.LogError(message);
+                        return UnprocessableEntityResponse(message);
                     }
-                    // If match is closed, return unauthorized
-                    var matchResRecord = _matchResAggregator.Build(match.Result, matchResEvents.Result);
-                    if (matchResRecord.Status == MatchRecordStatus.Closed)
-                    {
-                        return UnauthorizedErrorResponse();
-                    }
-                    // If last event is same as this event, return not allowed
-                    IMatchResEvent? lastEvent = matchResEvents.Result.LastOrDefault();
-                    if (lastEvent is IMatchResEvent)
-                    {
-                        var deltaObj = JsonConvert.DeserializeObject<AddEventRequestData>(lastEvent.Delta);
-                        if (lastEvent.ActorState == state &&
-                            deltaObj is AddEventRequestData &&
-                            JsonConvert.SerializeObject(deltaObj) == JsonConvert.SerializeObject(reqObj.Data))
-                        {
-                            string message = "Duplicate action not allowed";
-                            logger.LogError(message);
-                            return UnprocessableEntityResponse(message);
-                        }
-                    }
-                    // insert event
-                    var newEvent = new MatchResEventDbo() {
-                        MatchId = matchId,
-                        ActorState = state,
-                        Actor = req.Headers["From"].ToString() ?? UserActor,
-                        Delta = JsonConvert.SerializeObject(reqObj.Data)
-                    };
-                    await _matchResEventDao.AddEvent(newEvent);
-                    // determine if match should be closed
-                    await DetermineClosure(reqObj, match.Result, matchResEvents.Result);
-                    return new OkResult();
                 }
-                catch (StreamParserException ex)
+                // insert event
+                var newEvent = new MatchResEventDbo()
                 {
-                    logger.LogError(ex.Message);
-                    return DeserializationErrorResponse(ex);
-                }
-                catch (ValidationException ex)
-                {
-                    logger.LogError(ex.Message);
-                    return ValidationErrorResponse(ex);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    logger.LogError(ex.Message);
-                    return NotFoundErrorResponse(ex);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex.Message);
-                    return InternalServerErrorResponse(ex);
-                }
-            }
-
-            private async Task DetermineClosure(
-                AddEventRequest reqObj,
-                IMatchRecord match,
-                IEnumerable<IMatchResEvent> matchResEvents
-            )
-            {
-                if (String.IsNullOrEmpty(reqObj.Data.FinalDisposition)) return;
-
-                var dispositions = GetFinalDispositions(matchResEvents);
-                if (dispositions.Count() == (match.States.Count() - 1))
-                {
-                    var closedEvent = new MatchResEventDbo() {
-                        MatchId = match.MatchId,
-                        Actor = SystemActor,
-                        Delta = ClosedDelta
-                    };
-                    await _matchResEventDao.AddEvent(closedEvent);
-                }
-            }
-
-            private IEnumerable<IMatchResEvent> GetFinalDispositions(
-                IEnumerable<IMatchResEvent> matchResEvents
-            )
-            {
-                return matchResEvents.Where(e => {
-                    AddEventRequestData? delta = JsonConvert.DeserializeObject<AddEventRequestData>(e.Delta);
-                    return !String.IsNullOrEmpty(delta?.FinalDisposition);
-                });
-            }
-
-            private void LogRequest(ILogger logger, HttpRequest request)
-            {
-                logger.LogInformation("Executing request from user {User}", request.HttpContext?.User.Identity.Name);
-
-                string subscription = request.Headers["Ocp-Apim-Subscription-Name"];
-                if (subscription != null)
-                {
-                    logger.LogInformation("Using APIM subscription {Subscription}", subscription);
-                }
-
-                string username = request.Headers["From"];
-                if (username != null)
-                {
-                    logger.LogInformation("on behalf of {Username}", username);
-                }
-            }
-
-            private ActionResult NotFoundErrorResponse(Exception ex)
-            {
-                var errResponse = new ApiErrorResponse();
-                errResponse.Errors.Add(new ApiHttpError()
-                {
-                    Status = Convert.ToString((int)HttpStatusCode.NotFound),
-                    Title = "NotFoundException",
-                    Detail = "not found"
-                });
-                return (ActionResult)new NotFoundObjectResult(errResponse);
-            }
-
-            private ActionResult UnprocessableEntityResponse(string message)
-            {
-                var errResponse = new ApiErrorResponse();
-                errResponse.Errors.Add(new ApiHttpError()
-                {
-                    Status = Convert.ToString((int)HttpStatusCode.UnprocessableEntity),
-                    Title = "UnprocessableEntity",
-                    Detail = message
-                });
-                return (ActionResult)new UnprocessableEntityObjectResult(errResponse);
-            }
-
-            private ActionResult InternalServerErrorResponse(Exception ex)
-            {
-                var errResponse = new ApiErrorResponse();
-                errResponse.Errors.Add(new ApiHttpError()
-                {
-                    Status = Convert.ToString((int)HttpStatusCode.InternalServerError),
-                    Title = ex.GetType().Name,
-                    Detail = ex.Message
-                });
-                return (ActionResult)new JsonResult(errResponse)
-                {
-                    StatusCode = (int)HttpStatusCode.InternalServerError
+                    MatchId = matchId,
+                    ActorState = state,
+                    Actor = req.Headers["From"].ToString() ?? UserActor,
+                    Delta = JsonConvert.SerializeObject(reqObj.Data)
                 };
+                await _matchResEventDao.AddEvent(newEvent);
+                // determine if match should be closed
+                await DetermineClosure(reqObj, match.Result, matchResEvents.Result);
+                return new OkResult();
             }
-
-            private ActionResult UnauthorizedErrorResponse()
+            catch (StreamParserException ex)
             {
-
-                return (ActionResult)new UnauthorizedResult();
+                logger.LogError(ex.Message);
+                return DeserializationErrorResponse(ex);
             }
-
-            private ActionResult DeserializationErrorResponse(Exception ex)
+            catch (ValidationException ex)
             {
-                var errResponse = new ApiErrorResponse();
+                logger.LogError(ex.Message);
+                return ValidationErrorResponse(ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                logger.LogError(ex.Message);
+                return NotFoundErrorResponse(ex);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return InternalServerErrorResponse(ex);
+            }
+        }
+
+        private async Task DetermineClosure(
+            AddEventRequest reqObj,
+            IMatchRecord match,
+            IEnumerable<IMatchResEvent> matchResEvents
+        )
+        {
+            if (String.IsNullOrEmpty(reqObj.Data.FinalDisposition)) return;
+
+            var dispositions = GetFinalDispositions(matchResEvents);
+            if (dispositions.Count() == (match.States.Count() - 1))
+            {
+                var closedEvent = new MatchResEventDbo()
+                {
+                    MatchId = match.MatchId,
+                    Actor = SystemActor,
+                    Delta = ClosedDelta
+                };
+                await _matchResEventDao.AddEvent(closedEvent);
+            }
+        }
+
+        private IEnumerable<IMatchResEvent> GetFinalDispositions(
+            IEnumerable<IMatchResEvent> matchResEvents
+        )
+        {
+            return matchResEvents.Where(e =>
+            {
+                AddEventRequestData? delta = JsonConvert.DeserializeObject<AddEventRequestData>(e.Delta);
+                return !String.IsNullOrEmpty(delta?.FinalDisposition);
+            });
+        }
+
+
+
+        private ActionResult UnprocessableEntityResponse(string message)
+        {
+            var errResponse = new ApiErrorResponse();
+            errResponse.Errors.Add(new ApiHttpError()
+            {
+                Status = Convert.ToString((int)HttpStatusCode.UnprocessableEntity),
+                Title = "UnprocessableEntity",
+                Detail = message
+            });
+            return (ActionResult)new UnprocessableEntityObjectResult(errResponse);
+        }
+
+        private ActionResult UnauthorizedErrorResponse()
+        {
+
+            return (ActionResult)new UnauthorizedResult();
+        }
+
+        private ActionResult DeserializationErrorResponse(Exception ex)
+        {
+            var errResponse = new ApiErrorResponse();
+            errResponse.Errors.Add(new ApiHttpError()
+            {
+                Status = Convert.ToString((int)HttpStatusCode.BadRequest),
+                Title = Convert.ToString(ex.GetType()),
+                Detail = ex.Message
+            });
+            return (ActionResult)new BadRequestObjectResult(errResponse);
+        }
+
+        private ActionResult ValidationErrorResponse(ValidationException exception)
+        {
+            var errResponse = new ApiErrorResponse();
+            foreach (var failure in exception.Errors)
+            {
                 errResponse.Errors.Add(new ApiHttpError()
                 {
                     Status = Convert.ToString((int)HttpStatusCode.BadRequest),
-                    Title = Convert.ToString(ex.GetType()),
-                    Detail = ex.Message
+                    Title = failure.ErrorCode,
+                    Detail = failure.ErrorMessage
                 });
-                return (ActionResult)new BadRequestObjectResult(errResponse);
             }
-
-            private ActionResult ValidationErrorResponse(ValidationException exception)
-            {
-                var errResponse = new ApiErrorResponse();
-                foreach (var failure in exception.Errors)
-                {
-                    errResponse.Errors.Add(new ApiHttpError()
-                    {
-                        Status = Convert.ToString((int)HttpStatusCode.BadRequest),
-                        Title = failure.ErrorCode,
-                        Detail = failure.ErrorMessage
-                    });
-                }
-                return (ActionResult)new BadRequestObjectResult(errResponse);
-            }
-       }
+            return (ActionResult)new BadRequestObjectResult(errResponse);
+        }
+    }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/BaseApi.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/BaseApi.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Piipan.Match.Func.ResolutionApi.Models;
+using System;
+using System.Net;
+
+namespace Piipan.Match.Func.ResolutionApi
+{
+    public class BaseApi
+    {
+        protected void LogRequest(ILogger logger, HttpRequest request)
+        {
+            logger.LogInformation("Executing request from user {User}", request.HttpContext?.User.Identity.Name);
+
+            string subscription = request.Headers["Ocp-Apim-Subscription-Name"];
+            if (subscription != null)
+            {
+                logger.LogInformation("Using APIM subscription {Subscription}", subscription);
+            }
+
+            string username = request.Headers["From"];
+            if (username != null)
+            {
+                logger.LogInformation("on behalf of {Username}", username);
+            }
+        }
+
+        protected ActionResult NotFoundErrorResponse(Exception ex)
+        {
+            var errResponse = new ApiErrorResponse();
+            errResponse.Errors.Add(new ApiHttpError()
+            {
+                Status = Convert.ToString((int)HttpStatusCode.NotFound),
+                Title = "NotFoundException",
+                Detail = "not found"
+            });
+            return (ActionResult)new NotFoundObjectResult(errResponse);
+        }
+
+        protected ActionResult InternalServerErrorResponse(Exception ex)
+        {
+            var errResponse = new ApiErrorResponse();
+            errResponse.Errors.Add(new ApiHttpError()
+            {
+                Status = Convert.ToString((int)HttpStatusCode.InternalServerError),
+                Title = ex.GetType().Name,
+                Detail = ex.Message
+            });
+            return (ActionResult)new JsonResult(errResponse)
+            {
+                StatusCode = (int)HttpStatusCode.InternalServerError
+            };
+        }
+    }
+}

--- a/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/GetMatchApi.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/GetMatchApi.cs
@@ -6,9 +6,7 @@ using Microsoft.Extensions.Logging;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.Match.Core.Builders;
 using Piipan.Match.Core.DataAccessObjects;
-using Piipan.Match.Func.ResolutionApi.Models;
 using System;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace Piipan.Match.Func.ResolutionApi
@@ -17,7 +15,7 @@ namespace Piipan.Match.Func.ResolutionApi
     /// <summary>
     /// Azure Function implementing Get Match endpoint for Match Resolution API
     /// </summary>
-    public class GetMatchApi
+    public class GetMatchApi : BaseApi
     {
         private readonly IMatchRecordDao _matchRecordDao;
         private readonly IMatchResEventDao _matchResEventDao;
@@ -60,50 +58,6 @@ namespace Piipan.Match.Func.ResolutionApi
                 logger.LogInformation(ex.Message);
                 return InternalServerErrorResponse(ex);
             }
-        }
-
-        private void LogRequest(ILogger logger, HttpRequest request)
-        {
-            logger.LogInformation("Executing request from user {User}", request.HttpContext?.User.Identity.Name);
-
-            string subscription = request.Headers["Ocp-Apim-Subscription-Name"];
-            if (subscription != null)
-            {
-                logger.LogInformation("Using APIM subscription {Subscription}", subscription);
-            }
-
-            string username = request.Headers["From"];
-            if (username != null)
-            {
-                logger.LogInformation("on behalf of {Username}", username);
-            }
-        }
-
-        private ActionResult NotFoundErrorResponse(Exception ex)
-        {
-            var errResponse = new ApiErrorResponse();
-            errResponse.Errors.Add(new ApiHttpError()
-            {
-                Status = Convert.ToString((int)HttpStatusCode.NotFound),
-                Title = "NotFoundException",
-                Detail = "not found"
-            });
-            return (ActionResult)new NotFoundObjectResult(errResponse);
-        }
-
-        private ActionResult InternalServerErrorResponse(Exception ex)
-        {
-            var errResponse = new ApiErrorResponse();
-            errResponse.Errors.Add(new ApiHttpError()
-            {
-                Status = Convert.ToString((int)HttpStatusCode.InternalServerError),
-                Title = ex.GetType().Name,
-                Detail = ex.Message
-            });
-            return (ActionResult)new JsonResult(errResponse)
-            {
-                StatusCode = (int)HttpStatusCode.InternalServerError
-            };
         }
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/GetMatchesListApi.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/GetMatchesListApi.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using Piipan.Match.Api.Models.Resolution;
+using Piipan.Match.Core.Builders;
+using Piipan.Match.Core.DataAccessObjects;
+using Piipan.Match.Func.ResolutionApi.Models;
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Piipan.Match.Func.ResolutionApi
+{
+
+    /// <summary>
+    /// Azure Function implementing Get Match endpoint for Match Resolution API
+    /// </summary>
+    public class GetMatchesListApi
+    {
+        private readonly IMatchRecordDao _matchRecordDao;
+        private readonly IMatchResEventDao _matchResEventDao;
+
+        private readonly IMatchResAggregator _matchResAggregator;
+
+        public GetMatchesListApi(
+            IMatchRecordDao matchRecordDao,
+            IMatchResEventDao matchResEventDao,
+            IMatchResAggregator matchResAggregator)
+        {
+            _matchRecordDao = matchRecordDao;
+            _matchResEventDao = matchResEventDao;
+            _matchResAggregator = matchResAggregator;
+        }
+
+        [FunctionName("GetMatchesList")]
+        public async Task<IActionResult> GetMatchesList(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "list")] HttpRequest req,
+            ILogger logger)
+        {
+            LogRequest(logger, req);
+            try
+            {
+                var matches = await _matchRecordDao.GetMatchesList();
+                var matchResEvents = await _matchResEventDao.GetEventsByMatchIDs(matches.Select(n => n.MatchId));
+                var matchRecords = matches.Select(n => _matchResAggregator.Build(n, matchResEvents.Where(m => m.MatchId == n.MatchId)));
+                var response = new MatchResListApiResponse() { Data = matchRecords };
+                return new JsonResult(response) { StatusCode = StatusCodes.Status200OK };
+            }
+            catch (Exception ex)
+            {
+                logger.LogInformation(ex.Message);
+                return InternalServerErrorResponse(ex);
+            }
+        }
+
+        private void LogRequest(ILogger logger, HttpRequest request)
+        {
+            logger.LogInformation("Executing request from user {User}", request.HttpContext?.User.Identity.Name);
+
+            string subscription = request.Headers["Ocp-Apim-Subscription-Name"];
+            if (subscription != null)
+            {
+                logger.LogInformation("Using APIM subscription {Subscription}", subscription);
+            }
+
+            string username = request.Headers["From"];
+            if (username != null)
+            {
+                logger.LogInformation("on behalf of {Username}", username);
+            }
+        }
+
+        private ActionResult InternalServerErrorResponse(Exception ex)
+        {
+            var errResponse = new ApiErrorResponse();
+            errResponse.Errors.Add(new ApiHttpError()
+            {
+                Status = Convert.ToString((int)HttpStatusCode.InternalServerError),
+                Title = ex.GetType().Name,
+                Detail = ex.Message
+            });
+            return (ActionResult)new JsonResult(errResponse)
+            {
+                StatusCode = (int)HttpStatusCode.InternalServerError
+            };
+        }
+    }
+}

--- a/match/tests/Piipan.Match.Client.Tests/MatchResolutionClientTests.cs
+++ b/match/tests/Piipan.Match.Client.Tests/MatchResolutionClientTests.cs
@@ -42,7 +42,7 @@ namespace Piipan.Match.Client.Tests
         }
 
         [Fact]
-        public async Task GetMatchesList_ReturnsApiClientResponse()
+        public async Task GetMatches_ReturnsApiClientResponse()
         {
             // Arrange
             var expectedResponse = new MatchResListApiResponse
@@ -62,13 +62,13 @@ namespace Piipan.Match.Client.Tests
 
             var apiClient = new Mock<IAuthorizedApiClient<MatchResolutionClient>>();
             apiClient
-                .Setup(m => m.TryGetAsync<MatchResListApiResponse>("list"))
+                .Setup(m => m.TryGetAsync<MatchResListApiResponse>("matches"))
                 .ReturnsAsync((expectedResponse, 200));
 
             var client = new MatchResolutionClient(apiClient.Object);
 
             // Act
-            var response = await client.GetMatchesList();
+            var response = await client.GetMatches();
 
             // Assert
             Assert.Equal(expectedResponse, response);

--- a/match/tests/Piipan.Match.Client.Tests/MatchResolutionClientTests.cs
+++ b/match/tests/Piipan.Match.Client.Tests/MatchResolutionClientTests.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Moq;
+﻿using Moq;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.Shared.Http;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Piipan.Match.Client.Tests
@@ -37,6 +36,39 @@ namespace Piipan.Match.Client.Tests
 
             // Act
             var response = await client.GetMatch("m123456");
+
+            // Assert
+            Assert.Equal(expectedResponse, response);
+        }
+
+        [Fact]
+        public async Task GetMatchesList_ReturnsApiClientResponse()
+        {
+            // Arrange
+            var expectedResponse = new MatchResListApiResponse
+            {
+                Data = Enumerable.Range(0, 2).Select(index =>
+                    new MatchResRecord
+                    {
+                        Dispositions = new Disposition[] { Mock.Of<Disposition>() },
+                        Initiator = "ea",
+                        States = new string[] { "ea", "eb" },
+                        MatchId = new string(index.ToString()[0], 7),
+                        Participants = new Participant[] { Mock.Of<Participant>() },
+                        Status = MatchRecordStatus.Open
+                    }
+                )
+            };
+
+            var apiClient = new Mock<IAuthorizedApiClient<MatchResolutionClient>>();
+            apiClient
+                .Setup(m => m.TryGetAsync<MatchResListApiResponse>("list"))
+                .ReturnsAsync((expectedResponse, 200));
+
+            var client = new MatchResolutionClient(apiClient.Object);
+
+            // Act
+            var response = await client.GetMatchesList();
 
             // Assert
             Assert.Equal(expectedResponse, response);

--- a/match/tests/Piipan.Match.Core.IntegrationTests/MatchRecordDaoTests.cs
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/MatchRecordDaoTests.cs
@@ -293,7 +293,7 @@ namespace Piipan.Match.Core.IntegrationTests
         }
 
         [Fact]
-        public async Task GetMatchesList_ReturnsRecordsIfFound()
+        public async Task GetMatches_ReturnsRecordsIfFound()
         {
             using (var conn = Factory.CreateConnection())
             {
@@ -320,10 +320,32 @@ namespace Piipan.Match.Core.IntegrationTests
                 records.ForEach(r => Insert(r));
 
                 // Act
-                var results = await dao.GetMatchesList();
+                var results = await dao.GetMatches();
 
                 // Assert
                 Assert.Equal(records, results);
+            }
+        }
+
+        [Fact]
+        public async Task GetMatches_ReturnsNoRecordsIfNotFound()
+        {
+            using (var conn = Factory.CreateConnection())
+            {
+                // Arrange
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var logger = Mock.Of<ILogger<MatchRecordDao>>();
+                var dao = new MatchRecordDao(DbConnFactory(), logger);
+
+                ClearMatchRecords();
+
+                // Act
+                var results = await dao.GetMatches();
+
+                // Assert
+                Assert.Empty(results);
             }
         }
     }

--- a/match/tests/Piipan.Match.Core.IntegrationTests/MatchResEventDaoTests.cs
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/MatchResEventDaoTests.cs
@@ -1,16 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Npgsql;
-using Piipan.Match.Api.Models;
 using Piipan.Match.Core.DataAccessObjects;
-using Piipan.Match.Core.Exceptions;
 using Piipan.Match.Core.Models;
 using Piipan.Match.Core.Services;
 using Piipan.Shared.Database;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Piipan.Match.Core.IntegrationTests
@@ -271,6 +267,67 @@ namespace Piipan.Match.Core.IntegrationTests
                 Assert.Equal("ea", result.ActorState);
                 Assert.Equal("{\"status\": \"open\"}", result.Delta);
                 Assert.True(new DateTime() < result.InsertedAt); // greater than default datetime (1/1/0001 12:00:00 AM)
+
+                conn.Close();
+            }
+        }
+
+        [Fact]
+        public async void GetEventsByMatchIDs_ReturnsExpectedEventValues()
+        {
+            using (var conn = Factory.CreateConnection())
+            {
+                // Arrange
+                conn.ConnectionString = ConnectionString;
+                conn.Open();
+
+                var logger = Mock.Of<ILogger<MatchResEventDao>>();
+                var matchLogger = Mock.Of<ILogger<MatchRecordDao>>();
+
+                var dao = new MatchResEventDao(DbConnFactory(), logger);
+                var matchRecordDao = new MatchRecordDao(DbConnFactory(), matchLogger);
+
+                var idService = new MatchIdService();
+                var matchIds = Enumerable.Range(0, 3).Select(_ => idService.GenerateId()).ToList();
+
+                var matches = matchIds.Select(id => new MatchRecordDbo
+                {
+                    MatchId = id,
+                    Hash = "foo",
+                    HashType = "ldshash",
+                    Initiator = "ea",
+                    States = new string[] { "ea", "eb" },
+                    Data = "{}"
+                });
+                // related match events
+                var mres = matchIds.Select(id => new MatchResEventDbo
+                {
+                    MatchId = id,
+                    Actor = "noreply@example.com",
+                    ActorState = "ea",
+                    Delta = "{\"status\": \"open\"}"
+                });
+
+                // Act
+                foreach (var match in matches)
+                {
+                    await matchRecordDao.AddRecord(match);
+                }
+                foreach (var mre in mres)
+                {
+                    await dao.AddEvent(mre);
+                }
+
+                // Assert
+                var results = await dao.GetEventsByMatchIDs(matchIds, false);
+                foreach (var result in results)
+                {
+                    Assert.Contains(matchIds, id => result.MatchId == id);
+                    Assert.Equal("noreply@example.com", result.Actor);
+                    Assert.Equal("ea", result.ActorState);
+                    Assert.Equal("{\"status\": \"open\"}", result.Delta);
+                    Assert.True(new DateTime() < result.InsertedAt); // greater than default datetime (1/1/0001 12:00:00 AM)
+                }
 
                 conn.Close();
             }

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/GetMatchesApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/GetMatchesApiIntegrationTests.cs
@@ -1,0 +1,194 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Newtonsoft.Json;
+using Npgsql;
+using Piipan.Match.Api.Models.Resolution;
+using Piipan.Match.Core.Builders;
+using Piipan.Match.Core.DataAccessObjects;
+using Piipan.Match.Core.Models;
+using Piipan.Shared.Database;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Piipan.Match.Func.ResolutionApi.IntegrationTests
+{
+    [Collection("MatchResolutionApiTests")]
+    public class GetMatchesApiIntegrationTests : DbFixture
+    {
+        static GetMatchesApi Construct()
+        {
+            Environment.SetEnvironmentVariable("States", "ea");
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddTransient<IMatchRecordDao, MatchRecordDao>();
+            services.AddTransient<IMatchResEventDao, MatchResEventDao>();
+            services.AddTransient<IMatchResAggregator, MatchResAggregator>();
+
+            services.AddTransient<IDbConnectionFactory<CollaborationDb>>(s =>
+            {
+                return new BasicPgConnectionFactory<CollaborationDb>(
+                    NpgsqlFactory.Instance,
+                    Environment.GetEnvironmentVariable(Startup.CollaborationDatabaseConnectionString));
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            var api = new GetMatchesApi(
+                provider.GetService<IMatchRecordDao>(),
+                provider.GetService<IMatchResEventDao>(),
+                provider.GetService<IMatchResAggregator>()
+            );
+
+            return api;
+        }
+
+        static Mock<HttpRequest> MockGetRequest()
+        {
+            var mockRequest = new Mock<HttpRequest>();
+            var headers = new HeaderDictionary(new Dictionary<String, StringValues>
+            {
+                { "From", "foobar"}
+            }) as IHeaderDictionary;
+            mockRequest.Setup(x => x.Headers).Returns(headers);
+
+            return mockRequest;
+        }
+
+        [Fact]
+        public async void GetMatches_ReturnsEmptyListIfNotFound()
+        {
+            // Arrange
+            // clear databases
+            ClearMatchRecords();
+            ClearMatchResEvents();
+
+            var api = Construct();
+            var mockRequest = MockGetRequest();
+            var mockLogger = Mock.Of<ILogger>();
+
+            // Act
+            var response = (await api.GetMatches(mockRequest.Object, mockLogger) as JsonResult).Value as MatchResListApiResponse;
+
+            // Assert
+            Assert.Empty(response.Data);
+        }
+
+        [Fact]
+        public async void GetMatches_ReturnsCorrectSchemaIfFound()
+        {
+            // Arrange
+            // clear databases
+            ClearMatchRecords();
+            ClearMatchResEvents();
+
+            var api = Construct();
+            var mockRequest = MockGetRequest();
+            var mockLogger = Mock.Of<ILogger>();
+            var matchCreateDate = DateTime.UtcNow;
+            // insert into database
+            var match = new MatchRecordDbo()
+            {
+                CreatedAt = matchCreateDate,
+                Data = "{\"State\": \"bb\", \"CaseId\": \"GHI\", \"LdsHash\": \"foobar\", \"ParticipantId\": \"JKL\", \"ParticipantClosingDate\": \"2021-02-28\", \"VulnerableIndividual\": true, \"RecentBenefitIssuanceDates\": [{\"start\": \"2021-03-01\", \"end\":\"2021-03-31\"}]}",
+                Hash = "foo",
+                HashType = "ldshash",
+                Initiator = "ea",
+                Input = "{\"CaseId\": \"ABC\", \"LdsHash\": \"foobar\", \"ParticipantId\": \"DEF\"}",
+                MatchId = "ABC",
+                States = new string[] { "ea", "bb" }
+            };
+
+            var match2 = new MatchRecordDbo()
+            {
+                CreatedAt = matchCreateDate,
+                Data = "{\"State\": \"bb\", \"CaseId\": \"123\", \"LdsHash\": \"barbar\", \"ParticipantId\": \"456\", \"ParticipantClosingDate\": \"2021-02-28\", \"VulnerableIndividual\": true, \"RecentBenefitIssuanceDates\": [{\"start\": \"2021-03-01\", \"end\":\"2021-03-31\"}]}",
+                Hash = "foo",
+                HashType = "ldshash",
+                Initiator = "ea",
+                Input = "{\"CaseId\": \"789\", \"LdsHash\": \"foobar\", \"ParticipantId\": \"012\"}",
+                MatchId = "DEF",
+                States = new string[] { "ea", "bb" }
+            };
+            Insert(match);
+            Insert(match2);
+
+            // Act
+            var response = await api.GetMatches(mockRequest.Object, mockLogger) as JsonResult;
+            var responseRecords = (response.Value as MatchResListApiResponse).Data;
+            var createdDates = responseRecords.Select(n => n.CreatedAt).ToList();
+            string resString = JsonConvert.SerializeObject(response.Value);
+
+            // Assert
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal(2, responseRecords.Count());
+            // Assert Participant Data
+            var expected = "{\"data\":[{\"dispositions\":[{\"initial_action_at\":null,\"invalid_match\":false,\"final_disposition\":null,\"vulnerable_individual\":null,\"state\":\"ea\"},{\"initial_action_at\":null,\"invalid_match\":false,\"final_disposition\":null,\"vulnerable_individual\":null,\"state\":\"bb\"}],\"initiator\":\"ea\",\"match_id\":\"ABC\",\"created_at\":" + JsonConvert.SerializeObject(createdDates[0]) + ",\"participants\":[{\"case_id\":\"GHI\",\"participant_closing_date\":\"2021-02-28\",\"participant_id\":\"JKL\",\"recent_benefit_issuance_dates\":[{\"start\":\"2021-03-01\",\"end\":\"2021-03-31\"}],\"state\":\"bb\"},{\"case_id\":\"ABC\",\"participant_closing_date\":null,\"participant_id\":\"DEF\",\"recent_benefit_issuance_dates\":[],\"state\":\"ea\"}],\"states\":[\"ea\",\"bb\"],\"status\":\"open\"}," +
+                "{\"dispositions\":[{\"initial_action_at\":null,\"invalid_match\":false,\"final_disposition\":null,\"vulnerable_individual\":null,\"state\":\"ea\"},{\"initial_action_at\":null,\"invalid_match\":false,\"final_disposition\":null,\"vulnerable_individual\":null,\"state\":\"bb\"}],\"initiator\":\"ea\",\"match_id\":\"DEF\",\"created_at\":" + JsonConvert.SerializeObject(createdDates[1]) + ",\"participants\":[{\"case_id\":\"123\",\"participant_closing_date\":\"2021-02-28\",\"participant_id\":\"456\",\"recent_benefit_issuance_dates\":[{\"start\":\"2021-03-01\",\"end\":\"2021-03-31\"}],\"state\":\"bb\"},{\"case_id\":\"789\",\"participant_closing_date\":null,\"participant_id\":\"012\",\"recent_benefit_issuance_dates\":[],\"state\":\"ea\"}],\"states\":[\"ea\",\"bb\"],\"status\":\"open\"}]}";
+            Assert.Equal(expected, resString);
+            // Assert the created date that is returned is nearly identical to the actual current time
+            Assert.True((createdDates[0] - matchCreateDate).Value.TotalMinutes < 1);
+            Assert.True((createdDates[1] - matchCreateDate).Value.TotalMinutes < 1);
+        }
+        // When match res events are added, GetMatch response should update accordingly
+        [Fact]
+        public async void GetMatches_ShowsUpdatedData()
+        {
+            // Arrange
+            // clear databases
+            ClearMatchRecords();
+            ClearMatchResEvents();
+
+            var matchId = "ABC";
+            var api = Construct();
+            var mockRequest = MockGetRequest();
+            var mockLogger = Mock.Of<ILogger>();
+
+            // insert into database
+            var match = new MatchRecordDbo()
+            {
+                MatchId = matchId,
+                Initiator = "ea",
+                CreatedAt = DateTime.UtcNow,
+                States = new string[] { "ea", "bb" },
+                Hash = "foo",
+                HashType = "ldshash",
+                Data = "{}",
+                Input = "{}"
+            };
+            Insert(match);
+            // Act
+            var response = await api.GetMatches(mockRequest.Object, mockLogger) as JsonResult;
+
+            // Assert first request
+            Assert.Equal(200, response.StatusCode);
+            var resBody = response.Value as MatchResListApiResponse;
+            Assert.False(resBody.Data.First().Dispositions[0].InvalidMatch);
+
+            // Act again
+            // creating an "invalid match" match event results in newly pulled Match request having invalid_match = true
+            var mre = new MatchResEventDbo()
+            {
+                MatchId = matchId,
+                ActorState = "ea",
+                Actor = "user",
+                Delta = "{ \"invalid_match\": true }"
+            };
+            InsertMatchResEvent(mre);
+            var nextResponse = await api.GetMatches(mockRequest.Object, mockLogger) as JsonResult;
+
+            // Assert next request
+            var nextResBody = nextResponse.Value as MatchResListApiResponse;
+            Assert.Equal(200, nextResponse.StatusCode);
+            // now this disposition's invalid flag should be true
+            Assert.True(nextResBody.Data.First().Dispositions[0].InvalidMatch);
+        }
+    }
+}

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/GetMatchesApiTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/GetMatchesApiTests.cs
@@ -17,15 +17,15 @@ using Xunit;
 
 namespace Piipan.Match.Func.ResolutionApi.Tests
 {
-    public class GetMatchListApiTests
+    public class GetMatchesApiTests
     {
 
-        static GetMatchesListApi Construct()
+        static GetMatchesApi Construct()
         {
             var matchRecordDao = new Mock<IMatchRecordDao>();
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var matchResAggregator = new Mock<IMatchResAggregator>();
-            var api = new GetMatchesListApi(
+            var api = new GetMatchesApi(
                 matchRecordDao.Object,
                 matchResEventDao.Object,
                 matchResAggregator.Object
@@ -46,7 +46,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
         }
 
         [Fact]
-        public async Task GetMatchesList_LogsRequest()
+        public async Task GetMatches_LogsRequest()
         {
             // Arrange
             var api = Construct();
@@ -60,7 +60,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var logger = new Mock<ILogger>();
 
             // Act
-            await api.GetMatchesList(mockRequest.Object, logger.Object);
+            await api.GetMatches(mockRequest.Object, logger.Object);
 
             // Assert
             logger.Verify(x => x.Log(
@@ -73,7 +73,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
         }
 
         [Fact]
-        public async Task GetMatchesList_Returns500IfExceptionOccurs()
+        public async Task GetMatches_Returns500IfExceptionOccurs()
         {
             // Arrange
             var mockRequest = MockGetRequest();
@@ -88,20 +88,20 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchRecord = new MatchRecordDbo();
             var matchRecordDao = new Mock<IMatchRecordDao>();
             matchRecordDao
-                .Setup(r => r.GetMatchesList())
+                .Setup(r => r.GetMatches())
                 .ThrowsAsync(new Exception("Some database error"));
 
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var matchResAggregator = new Mock<IMatchResAggregator>();
 
-            var api = new GetMatchesListApi(
+            var api = new GetMatchesApi(
                 matchRecordDao.Object,
                 matchResEventDao.Object,
                 matchResAggregator.Object
             );
 
             // Act
-            var response = await api.GetMatchesList(mockRequest.Object, logger.Object);
+            var response = await api.GetMatches(mockRequest.Object, logger.Object);
 
             // Assert
             var result = response as JsonResult;
@@ -115,7 +115,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
         }
 
         [Fact]
-        public async Task GetMatchesList_ReturnsEmptyListIfNotFound()
+        public async Task GetMatches_ReturnsEmptyListIfNotFound()
         {
             // Arrange
             var mockRequest = MockGetRequest();
@@ -130,20 +130,20 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchRecord = new MatchRecordDbo();
             var matchRecordDao = new Mock<IMatchRecordDao>();
             matchRecordDao
-                .Setup(r => r.GetMatchesList())
+                .Setup(r => r.GetMatches())
                 .ReturnsAsync(new List<IMatchRecord>());
 
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var matchResAggregator = new Mock<IMatchResAggregator>();
 
-            var api = new GetMatchesListApi(
+            var api = new GetMatchesApi(
                 matchRecordDao.Object,
                 matchResEventDao.Object,
                 matchResAggregator.Object
             );
 
             // Act
-            var response = await api.GetMatchesList(mockRequest.Object, logger.Object) as JsonResult;
+            var response = await api.GetMatches(mockRequest.Object, logger.Object) as JsonResult;
 
             //Assert
             Assert.NotNull(response);
@@ -155,7 +155,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
         }
 
         [Fact]
-        public async Task GetMatchesList_ReturnsIfFound()
+        public async Task GetMatches_ReturnsIfFound()
         {
             // Arrange
             var mockRequest = MockGetRequest();
@@ -170,7 +170,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             // Mock Dao response
             var matchRecordDao = new Mock<IMatchRecordDao>();
             matchRecordDao
-                .Setup(r => r.GetMatchesList())
+                .Setup(r => r.GetMatches())
                 .ReturnsAsync(new List<MatchRecordDbo>()
                 {
                     new MatchRecordDbo() { MatchId = "m123456" },
@@ -192,14 +192,14 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
                     Status = "open"
                 });
 
-            var api = new GetMatchesListApi(
+            var api = new GetMatchesApi(
                 matchRecordDao.Object,
                 matchResEventDao.Object,
                 matchResAggregator.Object
             );
 
             // Act
-            var response = await api.GetMatchesList(mockRequest.Object, logger.Object) as JsonResult;
+            var response = await api.GetMatches(mockRequest.Object, logger.Object) as JsonResult;
 
             //Assert
             Assert.NotNull(response);

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/GetMatchesListApiTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/GetMatchesListApiTests.cs
@@ -1,0 +1,213 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Piipan.Match.Api.Models;
+using Piipan.Match.Api.Models.Resolution;
+using Piipan.Match.Core.Builders;
+using Piipan.Match.Core.DataAccessObjects;
+using Piipan.Match.Core.Models;
+using Piipan.Match.Func.ResolutionApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Piipan.Match.Func.ResolutionApi.Tests
+{
+    public class GetMatchListApiTests
+    {
+
+        static GetMatchesListApi Construct()
+        {
+            var matchRecordDao = new Mock<IMatchRecordDao>();
+            var matchResEventDao = new Mock<IMatchResEventDao>();
+            var matchResAggregator = new Mock<IMatchResAggregator>();
+            var api = new GetMatchesListApi(
+                matchRecordDao.Object,
+                matchResEventDao.Object,
+                matchResAggregator.Object
+            );
+            return api;
+        }
+
+        static Mock<HttpRequest> MockGetRequest()
+        {
+            var mockRequest = new Mock<HttpRequest>();
+            var headers = new HeaderDictionary(new Dictionary<String, StringValues>
+            {
+                { "From", "foobar"},
+            }) as IHeaderDictionary;
+            mockRequest.Setup(x => x.Headers).Returns(headers);
+
+            return mockRequest;
+        }
+
+        [Fact]
+        public async Task GetMatchesList_LogsRequest()
+        {
+            // Arrange
+            var api = Construct();
+            var mockRequest = MockGetRequest();
+            mockRequest
+                .Setup(x => x.Headers)
+                .Returns(new HeaderDictionary(new Dictionary<string, StringValues>
+                {
+                    { "Ocp-Apim-Subscription-Name", "sub-name" }
+                }));
+            var logger = new Mock<ILogger>();
+
+            // Act
+            await api.GetMatchesList(mockRequest.Object, logger.Object);
+
+            // Assert
+            logger.Verify(x => x.Log(
+                It.Is<LogLevel>(l => l == LogLevel.Information),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Using APIM subscription sub-name")),
+                It.IsAny<Exception>(),
+                It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)
+            ));
+        }
+
+        [Fact]
+        public async Task GetMatchesList_Returns500IfExceptionOccurs()
+        {
+            // Arrange
+            var mockRequest = MockGetRequest();
+            mockRequest
+                .Setup(x => x.Headers)
+                .Returns(new HeaderDictionary(new Dictionary<string, StringValues>
+                {
+                    { "Ocp-Apim-Subscription-Name", "sub-name" }
+                }));
+            var logger = new Mock<ILogger>();
+            // Mocks
+            var matchRecord = new MatchRecordDbo();
+            var matchRecordDao = new Mock<IMatchRecordDao>();
+            matchRecordDao
+                .Setup(r => r.GetMatchesList())
+                .ThrowsAsync(new Exception("Some database error"));
+
+            var matchResEventDao = new Mock<IMatchResEventDao>();
+            var matchResAggregator = new Mock<IMatchResAggregator>();
+
+            var api = new GetMatchesListApi(
+                matchRecordDao.Object,
+                matchResEventDao.Object,
+                matchResAggregator.Object
+            );
+
+            // Act
+            var response = await api.GetMatchesList(mockRequest.Object, logger.Object);
+
+            // Assert
+            var result = response as JsonResult;
+            Assert.Equal(500, result.StatusCode);
+
+            var errorResponse = result.Value as ApiErrorResponse;
+            Assert.Equal(1, (int)errorResponse.Errors.Count);
+            Assert.Equal("500", errorResponse.Errors[0].Status);
+            Assert.Equal("Some database error", errorResponse.Errors[0].Detail);
+            Assert.Contains("Exception", errorResponse.Errors[0].Title);
+        }
+
+        [Fact]
+        public async Task GetMatchesList_ReturnsEmptyListIfNotFound()
+        {
+            // Arrange
+            var mockRequest = MockGetRequest();
+            mockRequest
+                .Setup(x => x.Headers)
+                .Returns(new HeaderDictionary(new Dictionary<string, StringValues>
+                {
+                    { "Ocp-Apim-Subscription-Name", "sub-name" }
+                }));
+            var logger = new Mock<ILogger>();
+            // Mocks
+            var matchRecord = new MatchRecordDbo();
+            var matchRecordDao = new Mock<IMatchRecordDao>();
+            matchRecordDao
+                .Setup(r => r.GetMatchesList())
+                .ReturnsAsync(new List<IMatchRecord>());
+
+            var matchResEventDao = new Mock<IMatchResEventDao>();
+            var matchResAggregator = new Mock<IMatchResAggregator>();
+
+            var api = new GetMatchesListApi(
+                matchRecordDao.Object,
+                matchResEventDao.Object,
+                matchResAggregator.Object
+            );
+
+            // Act
+            var response = await api.GetMatchesList(mockRequest.Object, logger.Object) as JsonResult;
+
+            //Assert
+            Assert.NotNull(response);
+            Assert.Equal(200, response.StatusCode);
+
+            var resBody = response.Value as MatchResListApiResponse;
+            Assert.NotNull(resBody);
+            Assert.Empty(resBody.Data);
+        }
+
+        [Fact]
+        public async Task GetMatchesList_ReturnsIfFound()
+        {
+            // Arrange
+            var mockRequest = MockGetRequest();
+            mockRequest
+                .Setup(x => x.Headers)
+                .Returns(new HeaderDictionary(new Dictionary<string, StringValues>
+                {
+                    { "Ocp-Apim-Subscription-Name", "sub-name" }
+                }));
+            var logger = new Mock<ILogger>();
+
+            // Mock Dao response
+            var matchRecordDao = new Mock<IMatchRecordDao>();
+            matchRecordDao
+                .Setup(r => r.GetMatchesList())
+                .ReturnsAsync(new List<MatchRecordDbo>()
+                {
+                    new MatchRecordDbo() { MatchId = "m123456" },
+                    new MatchRecordDbo() { MatchId = "m654321" },
+                });
+            var mock = new Mock<IMatchResEventDao>();
+            var matchResEventDao = new Mock<IMatchResEventDao>();
+            matchResEventDao
+                .Setup(r => r.GetEvents(
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()
+                ))
+                .ReturnsAsync(new List<IMatchResEvent>());
+            var matchResAggregator = new Mock<IMatchResAggregator>();
+            matchResAggregator
+                .Setup(r => r.Build(It.IsAny<IMatchRecord>(), It.IsAny<IEnumerable<IMatchResEvent>>()))
+                .Returns(new MatchResRecord()
+                {
+                    Status = "open"
+                });
+
+            var api = new GetMatchesListApi(
+                matchRecordDao.Object,
+                matchResEventDao.Object,
+                matchResAggregator.Object
+            );
+
+            // Act
+            var response = await api.GetMatchesList(mockRequest.Object, logger.Object) as JsonResult;
+
+            //Assert
+            Assert.NotNull(response);
+            Assert.Equal(200, response.StatusCode);
+
+            var resBody = response.Value as MatchResListApiResponse;
+            Assert.NotNull(resBody);
+            Assert.Equal(2, resBody.Data.Count());
+        }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchesList.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchesList.razor
@@ -1,0 +1,40 @@
+﻿@using Piipan.Match.Api.Models
+@using Piipan.Match.Api.Models.Resolution
+@using Piipan.QueryTool.Client.Helpers
+
+@code {
+    [Parameter] public ParameterBase<MatchResListApiResponse> Matches { get; set; }
+}
+
+<section>
+    <h1>All NAC Matches List</h1>
+    @if (Matches.Data?.Data?.Count() > 0)
+    {
+        <table class="usa-table">
+            <thead>
+                <tr>
+                    <th scope="col">Match ID</th>
+                    <th scope="col">Matching States</th>
+                    <th scope="col">Created At</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var result in Matches.Data.Data)
+            {
+                DateTime? localDateTime = result.CreatedAt?.ToLocalTime();
+                string timeZoneAbbreviation = localDateTime != null ? TimeZoneInfo.Local.IsDaylightSavingTime(localDateTime.Value) ? TimeZoneInfo.Local.DaylightName : TimeZoneInfo.Local.StandardName : "";
+                <tr>
+                    <td><a href="/match/@result.MatchId">@result.MatchId</a></td>
+                    <td>@(string.Join(", ", result.States.OrderBy(state => state).Select(state => StateHelper.GetStateName(state))))</td>
+                    <td>@(result.CreatedAt?.ToLocalTime().ToString("M/dd/yyyy h:mm:ss tt").ToUpper() + " " + timeZoneAbbreviation)</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    }
+    else
+    {
+        <p>No matches found.</p>
+    }
+
+</section>

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchesList.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchesList.razor
@@ -26,7 +26,7 @@
                 <tr>
                     <td><a href="/match/@result.MatchId">@result.MatchId</a></td>
                     <td>@(string.Join(", ", result.States.OrderBy(state => state).Select(state => StateHelper.GetStateName(state))))</td>
-                    <td>@(result.CreatedAt?.ToLocalTime().ToString("M/dd/yyyy h:mm:ss tt").ToUpper() + " " + timeZoneAbbreviation)</td>
+                    <td>@(result.CreatedAt?.ToLocalTime().ToString("M/d/yyyy h:mm:ss tt").ToUpper() + " " + timeZoneAbbreviation)</td>
                 </tr>
             }
             </tbody>

--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -12,8 +12,8 @@ namespace Piipan.QueryTool.Pages
             _claimsProvider = claimsProvider;
         }
 
-        public string Email 
-        { 
+        public string Email
+        {
             get { return _claimsProvider.GetEmail(User); }
         }
         public string BaseUrl
@@ -21,4 +21,4 @@ namespace Piipan.QueryTool.Pages
             get { return $"{Request.Scheme}://{Request.Host}"; }
         }
     }
-} 
+}

--- a/query-tool/src/Piipan.QueryTool/Pages/List.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/List.cshtml
@@ -1,0 +1,12 @@
+﻿@page
+@using Piipan.Match.Api.Models.Resolution
+@using Piipan.QueryTool.Client.Models
+@model Piipan.QueryTool.Pages.ListModel
+@{
+    ViewData["Title"] = "NAC Matches List";
+}
+
+<div class="grid-container">
+    <component type="typeof(QueryTool.Client.Components.MatchesList)" render-mode="WebAssembly"
+        param-Matches="ParameterBase<MatchResListApiResponse>.FromObject(Model.AvailableMatches)" />
+</div>

--- a/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Piipan.Match.Api;
+using Piipan.Match.Api.Models.Resolution;
+using Piipan.QueryTool.Client.Models;
+using Piipan.Shared.Claims;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Piipan.QueryTool.Pages
+{
+    public class ListModel : BasePageModel
+    {
+
+        private readonly ILogger<ListModel> _logger;
+        private readonly IMatchResolutionApi _matchResolutionApi;
+
+        public MatchResListApiResponse AvailableMatches { get; set; } = null;
+        public List<ServerError> RequestErrors { get; private set; } = new();
+
+        public ListModel(ILogger<ListModel> logger
+                           , IClaimsProvider claimsProvider
+                           , IMatchResolutionApi matchResolutionApi)
+                           : base(claimsProvider)
+
+        {
+            _logger = logger;
+            _matchResolutionApi = matchResolutionApi;
+        }
+
+        public async Task<IActionResult> OnGet()
+        {
+            AvailableMatches = await _matchResolutionApi.GetMatchesList();
+
+            return Page();
+        }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
@@ -30,7 +30,7 @@ namespace Piipan.QueryTool.Pages
 
         public async Task<IActionResult> OnGet()
         {
-            AvailableMatches = await _matchResolutionApi.GetMatchesList();
+            AvailableMatches = await _matchResolutionApi.GetMatches();
 
             return Page();
         }

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
@@ -76,6 +76,14 @@
                                         <span data-title="@linkTitle">@linkTitle</span>
                                     </a>
                                 </li>
+                                <li class="usa-nav__primary-item">
+                                    @{
+                                        linkTitle = "List of NAC Matches";
+                                    }
+                                    <a href="/list" class="usa-nav__link @(pageName == "list" ? "usa-current" : "")">
+                                        <span data-title="@linkTitle">@linkTitle</span>
+                                    </a>
+                                </li>
                             </ul>
                         </div>
                     </nav>                   

--- a/query-tool/src/Piipan.QueryTool/cypress/integration/match-list.spec.js
+++ b/query-tool/src/Piipan.QueryTool/cypress/integration/match-list.spec.js
@@ -1,0 +1,25 @@
+﻿let pa11yOptions = {};
+
+describe('query tool match query', () => {
+    beforeEach(() => {
+        pa11yOptions = {
+            actions: [
+                'wait for element h1 to be added'
+            ],
+            standard: 'WCAG2AA',
+            runners: [
+                'htmlcs'
+            ],
+        };
+        cy.visit('/list');
+        cy.get('h1', { timeout: 10000 }).should('be.visible');
+    })
+
+    it("shows results table", () => {
+        cy.contains('Match ID').should('be.visible');
+        cy.contains('Matching States').should('be.visible');
+
+        setupPa11yPost();
+        cy.pa11y(pa11yOptions);
+    });
+})

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchesListTests.razor
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchesListTests.razor
@@ -1,0 +1,109 @@
+﻿@using Piipan.Components.Alerts
+@using Piipan.Components.Enums
+@using System.Linq.Expressions
+@using Piipan.Match.Api.Models.Resolution
+@using Piipan.QueryTool.Client.Models
+@using static Piipan.Components.Alerts.AlertConstants
+@inherits BaseComponentTest<MatchesList>
+
+@code {
+    /// <summary>
+    /// Set the default initial values for this test component
+    /// </summary>
+    public MatchesListTests() : base()
+    {
+        InitialValues = new MatchesList()
+        {
+            Matches = new ParameterBase<MatchResListApiResponse>
+            {
+                Data = new MatchResListApiResponse
+                {
+                    Data = new List<MatchResRecord>
+                    {
+                        new MatchResRecord
+                        {
+                            MatchId = "m123456",
+                            States = new string[] { "ea", "eb" },
+                            Initiator = "ea"
+                        },
+                        new MatchResRecord
+                        {
+                            MatchId = "m654321",
+                            States = new string[] { "ea", "eb" },
+                            Initiator = "ea"
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Create a matches list component
+    /// </summary>
+    protected override void CreateTestComponent()
+    {
+        Component = Render<MatchesList>(
+            @<MatchesList Matches="InitialValues.Matches">
+            </MatchesList>
+        );
+    }
+
+    #region Tests
+
+    /// <summary>
+    /// Verify the default markup of the matches list table when there are two items
+    /// </summary>
+    [Fact]
+    public void Matches_List_Should_Exist_And_Have_Correct_Markup()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Assert
+        Component!.MarkupMatches(
+            @<section>
+                <h1>All NAC Matches List</h1>
+                <table class="usa-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Match ID</th>
+                            <th scope="col">Matching States</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><a href="/match/m123456">m123456</a></td>
+                            <td>Echo Alpha, Echo Bravo</td>
+                        </tr>
+                        <tr>
+                            <td><a href="/match/m654321">m654321</a></td>
+                            <td>Echo Alpha, Echo Bravo</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+        );
+    }
+
+    /// <summary>
+    /// Verify the default markup of the matches list table when there are no items
+    /// </summary>
+    [Fact]
+    public void Matches_List_Should_Exist_And_Have_Correct_Markup_When_No_Items()
+    {
+        // Arrange
+        InitialValues.Matches.Data.Data = null;
+        CreateTestComponent();
+
+        // Assert
+        Component!.MarkupMatches(
+            @<section>
+                <h1>All NAC Matches List</h1>
+                <p>No matches found.</p>
+            </section>
+        );
+    }
+
+    #endregion
+}

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchesListTests.razor
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchesListTests.razor
@@ -69,16 +69,19 @@
                         <tr>
                             <th scope="col">Match ID</th>
                             <th scope="col">Matching States</th>
+                            <th scope="col">Created At</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr>
                             <td><a href="/match/m123456">m123456</a></td>
                             <td>Echo Alpha, Echo Bravo</td>
+                            <td></td>
                         </tr>
                         <tr>
                             <td><a href="/match/m654321">m654321</a></td>
                             <td>Echo Alpha, Echo Bravo</td>
+                            <td></td>
                         </tr>
                     </tbody>
                 </table>

--- a/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Piipan.Match.Api;
+using Piipan.Match.Api.Models;
+using Piipan.Match.Api.Models.Resolution;
+using Piipan.QueryTool.Pages;
+using Piipan.Shared.Claims;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Piipan.QueryTool.Tests
+{
+    public class ListPageTests
+    {
+        private string[] matchIds = new string[] { "m123456", "m654321" };
+        public static IClaimsProvider claimsProviderMock(string email)
+        {
+            var claimsProviderMock = new Mock<IClaimsProvider>();
+            claimsProviderMock
+                .Setup(c => c.GetEmail(It.IsAny<ClaimsPrincipal>()))
+                .Returns(email);
+            return claimsProviderMock.Object;
+        }
+
+        public static HttpContext contextMock()
+        {
+            var request = new Mock<HttpRequest>();
+
+            request
+                .Setup(m => m.Scheme)
+                .Returns("https");
+
+            request
+                .Setup(m => m.Host)
+                .Returns(new HostString("tts.test"));
+
+            var context = new Mock<HttpContext>();
+            context.Setup(m => m.Request).Returns(request.Object);
+
+            return context.Object;
+        }
+
+        [Fact]
+        public void TestBeforeOnGet()
+        {
+            // arrange
+            var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockMatchApi = Mock.Of<IMatchResolutionApi>();
+            var pageModel = new ListModel(
+                new NullLogger<ListModel>(),
+                mockClaimsProvider,
+                mockMatchApi
+            );
+
+            // act
+
+            // assert
+            Assert.Equal("noreply@tts.test", pageModel.Email);
+        }
+
+        [Fact]
+        public async Task Test_Get()
+        {
+            // arrange
+            var pageModel = SetupMatchModel();
+            pageModel.PageContext.HttpContext = contextMock();
+
+            // act
+            var result = await pageModel.OnGet();
+
+            // assert the match was set to the value returned by the match resolution API
+            Assert.IsType<PageResult>(result);
+            var list = pageModel.AvailableMatches.Data.ToList();
+            Assert.Equal(2, list.Count);
+            for (int i = 0; i < list.Count; i++)
+            {
+                Assert.Equal(matchIds[i], list[i].MatchId);
+                Assert.Equal("ea", list[i].Initiator);
+                Assert.Equal(MatchRecordStatus.Open, list[i].Status);
+                Assert.Empty(list[i].Dispositions);
+                Assert.Empty(list[i].Participants);
+                Assert.Equal(new string[] { "ea", "eb" }, list[i].States);
+            }
+        }
+
+        private Mock<IMatchResolutionApi> SetupMatchResolutionApi()
+        {
+            var matchResRecords = matchIds.Select(n => new MatchResRecord
+            {
+                States = new string[] { "ea", "eb" },
+                Initiator = "ea",
+                MatchId = n
+            });
+            var apiReturnValue = new MatchResListApiResponse
+            {
+                Data = matchResRecords
+            };
+            var mockMatchApi = new Mock<IMatchResolutionApi>();
+            mockMatchApi
+                .Setup(n => n.GetMatchesList())
+                .ReturnsAsync(apiReturnValue);
+            return mockMatchApi;
+        }
+
+        private ListModel SetupMatchModel(Mock<IMatchResolutionApi> mockMatchApi = null)
+        {
+            // arrange
+            var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            mockMatchApi ??= SetupMatchResolutionApi();
+            var pageModel = new ListModel(
+                new NullLogger<ListModel>(),
+                mockClaimsProvider,
+                mockMatchApi.Object
+            );
+            return pageModel;
+        }
+    }
+}

--- a/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
@@ -101,7 +101,7 @@ namespace Piipan.QueryTool.Tests
             };
             var mockMatchApi = new Mock<IMatchResolutionApi>();
             mockMatchApi
-                .Setup(n => n.GetMatchesList())
+                .Setup(n => n.GetMatches())
                 .ReturnsAsync(apiReturnValue);
             return mockMatchApi;
         }


### PR DESCRIPTION

## What’s changing?

We need to add an API endpoint in the Match Resolution API Azure Function to get all of the existing matches. We then need to display these matches on a page in the Query Tool web application.

## Why?

Closes NAC-169

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
