### PR TITLE
Make Bulk Upload Perf test more strongly typed

### DIFF
--- a/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/BulkUploadPerfTestRunner.cs
+++ b/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/BulkUploadPerfTestRunner.cs
@@ -51,9 +51,6 @@ namespace Etl.BulkUpload.Performance.TestRunner
                     uploadResult.Wait();
                     Console.WriteLine($"Finish upload to Azure Storage - {DateTime.Now.ToLongTimeString()}");
                 }
-
-
-
             }
         }
 
@@ -98,31 +95,6 @@ namespace Etl.BulkUpload.Performance.TestRunner
             }
 
             csvwriter.Flush();
-
-        }
-
-        private static async Task PopulateMemoryStreamWithMockRecords(string headers, StreamWriter writer, long desiredParticipantCount)
-        {
-            writer.WriteLine(headers);
-
-            for (int i = 0; i < desiredParticipantCount; i++)
-            {
-                String record = createMockRecord("EA", i + 1);
-                writer.WriteLine(record);
-            }
-
-            await writer.FlushAsync();
-        }
-
-        private static String createMockRecord(String state, int recId)
-        {
-            StringBuilder record = new StringBuilder(200);
-            var padRecId = recId.ToString("00000000");
-            record.Append(createMockHash(128));
-            record.Append(",case-" + state + "-" + padRecId);
-            record.Append(",part-" + state + "-" + padRecId);
-            record.Append(",,2021-12 2021-11 2021-10,false");
-            return record.ToString();
 
         }
 

--- a/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/Etl.BulkUpload.Performance.TestRunner.csproj
+++ b/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/Etl.BulkUpload.Performance.TestRunner.csproj
@@ -8,8 +8,13 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.6.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
+    <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\etl\src\Piipan.Etl\Piipan.Etl.Func.BulkUpload\Piipan.Etl.Func.BulkUpload.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/Program.cs
+++ b/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/Program.cs
@@ -29,11 +29,11 @@ namespace Etl.BulkUpload.Performance.TestRunner
             }
 
             BulkUploadPerfTestRunner testFileCreator = new BulkUploadPerfTestRunner(storageAccountName, storageAccountKey);
-            Console.WriteLine("Starting Test!");
+            Console.WriteLine($"Starting Test! - {DateTime.Now.ToLongTimeString()}");
 
             await testFileCreator.runTest(numberofParticipantsToUpload);
 
-            Console.WriteLine("Test Completed");
+            Console.WriteLine($"Test Completed - {DateTime.Now.ToLongTimeString()}");
         }
 
 


### PR DESCRIPTION
## What’s changing?

Fixes to Perf Test Runner to account for recent schema changes. Updated tooling to be strongly-typed to avoid schema changes unknowingly breaking it in the future.

## Why?

NAC-703

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
