### PR TITLE
Use increased database timeout settings for ETL

### DIFF
--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -316,9 +316,6 @@ main () {
   # restrictions for the function app and storage account are added
   # in a separate step to avoid deployment and publishing issues.
   db_conn_str=$(pg_connection_string "$PG_SERVER_NAME" "$DATABASE_PLACEHOLDER" "$ORCHESTRATOR_FUNC_APP_NAME")
-  # Long-running bulk upload queries require some specific connection
-  # details that are not part of default connection string
-  db_conn_str="${db_conn_str};Tcp Keepalive=true;Tcp Keepalive Time=30000;Command Timeout=300;"
   collab_db_conn_str=$(pg_connection_string "$CORE_DB_SERVER_NAME" "$COLLAB_DB_NAME" "$ORCHESTRATOR_FUNC_APP_NAME")
   az deployment group create \
     --name orch-api \
@@ -535,6 +532,9 @@ main () {
     fi
 
     db_conn_str=$(pg_connection_string "$PG_SERVER_NAME" "$db_name" "$identity")
+    # Long-running bulk upload queries require some specific connection
+    # details that are not part of the default connection string
+    db_conn_str="${db_conn_str};Tcp Keepalive=true;Tcp Keepalive Time=30000;Command Timeout=300;"
     blob_conn_str=$(blob_connection_string "$RESOURCE_GROUP" "$stor_name")
     az_serv_str=$(az_connection_string "$RESOURCE_GROUP" "$identity")
     az functionapp config appsettings set \


### PR DESCRIPTION
## What’s changing?

ETL process requires increased timeout durations to avoid exceptions during long-running bulk load operations. These settings had previously been mistakenly applied to the connection string used by the Orchestrator function app rather than the ETL function app.

I re-ran IaC to confirm the ETL app is configured with the proper settings and the Orchestrator app is reverted to the default settings it used previously.

## Why?

Fixing misconfiguration introduced by #2994.

## This PR has:

- ~[ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~
- ~[ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)~
- ~[ ] **Automated unit tests** (_to maintain or increase level of code coverage_)~
- [x] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)