### PR TITLE
CJC-639

### DIFF
--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/OrchMatchRequestParser.cs
@@ -58,21 +58,6 @@ namespace Piipan.Match.Core.Parsers
                 {
                     throw new ValidationException("request validation failed", validationResult.Errors);
                 }
-                ///Checking search_reason for valid reason. If reason given is not 
-                ///in allowed list of search reasons then setting reason to null
-                for (int i = 0; i < request.Data.Count; i++)
-                {
-                    if (request.Data[i].SearchReason != null)
-                    {
-                        request.Data[i].SearchReason = request.Data[i].SearchReason.ToLower();
-                        if (!Enum.IsDefined(typeof(ValidSearchReasons), request.Data[i].SearchReason))
-                        {
-                            var validValues = Enum.GetNames(typeof(ValidSearchReasons));
-                            string validOptionsString = string.Join(", ", validValues.Select(n => validValues.Last() == n ? $"or '{n}'" : $"'{n}'"));
-                            throw new Exception($"Submitted option for 'search_reason' is not valid. Valid options are {validOptionsString}.");
-                        }
-                    }
-                }
 
                 return request;
             }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Services/MatchService.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Services/MatchService.cs
@@ -5,6 +5,8 @@ using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Extensions;
 using Piipan.Participants.Api;
+using Piipan.Match.Core.Enums;
+using System;
 
 namespace Piipan.Match.Core.Services
 {
@@ -39,6 +41,20 @@ namespace Piipan.Match.Core.Services
             {
                 var person = request.Data[i];
                 var personValidation = await _requestPersonValidator.ValidateAsync(person);
+                //If given Search Reason is not in the list of valid reasons, add the
+                //error and continue with next request.Data
+                person.SearchReason = person.SearchReason.ToLower();
+                if (!Enum.IsDefined(typeof(ValidSearchReasons), person.SearchReason))
+                {
+                    response.Data.Errors.Add(
+                        new OrchMatchError
+                        {
+                            Index = i,
+                            Code = "Invalid Search Reason",
+                            Detail = "Search Reason: " + person.SearchReason.ToString()
+                        });
+                    continue;
+                }
                 if (personValidation.IsValid)
                 {
                     var result = await PersonMatch(request.Data[i], i, initiatingState);


### PR DESCRIPTION
## What’s changing?

Making the search reason validation add to the list of errors on the participant level instead of failing the entire match request

## Why?

NAC ticket 639

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
