### PR TITLE
Creating role-based authorization for the query tool

### DIFF
--- a/query-tool/docs/query-tool.md
+++ b/query-tool/docs/query-tool.md
@@ -54,6 +54,12 @@ Gulp will then watch for changes to the SCSS and compile them into the main CSS 
 
 [Instructions for updating Node dependencies](../../docs/node.md)
 
+## Authorization
+
+The app will restrict anyone with an appropriate role and location claim from accessing the app. For local development, you can change your role and location by editing the mock_user.json file. The location is defaulted to EA in the mock_user file, but simply update the location to "National" or a different location to have access to different states.
+
+Any users that are authenticated but not authorized to view the app will be redirected to a "Not Authenticated" page to let them know their role or location is not valid for the page.
+
 ## Testing
 
 Tests will be run on the continuous integration server, but

--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -17,8 +17,8 @@ namespace Piipan.QueryTool.Pages
 
         public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
         {
-            if ((string.IsNullOrEmpty(State) || string.IsNullOrEmpty(NACRole)) &&
-                (!context.HandlerMethod?.MethodInfo.CustomAttributes.Any(n => n.AttributeType == typeof(IgnoreNACAuthorizationAttribute)) ?? false))
+            if ((string.IsNullOrEmpty(State) || string.IsNullOrEmpty(Role)) &&
+                (!context.HandlerMethod?.MethodInfo.CustomAttributes.Any(n => n.AttributeType == typeof(IgnoreAuthorizationAttribute)) ?? false))
             {
                 context.HttpContext.Response.StatusCode = 403;
                 context.Result = RedirectToPage("/NotAuthorized");
@@ -35,9 +35,9 @@ namespace Piipan.QueryTool.Pages
             get { return _claimsProvider.GetState(User); }
         }
 
-        public string NACRole
+        public string Role
         {
-            get { return _claimsProvider.GetNACRole(User); }
+            get { return _claimsProvider.GetRole(User); }
         }
         public string BaseUrl
         {

--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -1,5 +1,8 @@
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
+using System.Linq;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -12,9 +15,29 @@ namespace Piipan.QueryTool.Pages
             _claimsProvider = claimsProvider;
         }
 
+        public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+        {
+            if ((string.IsNullOrEmpty(State) || string.IsNullOrEmpty(NACRole)) &&
+                (!context.HandlerMethod?.MethodInfo.CustomAttributes.Any(n => n.AttributeType == typeof(IgnoreNACAuthorizationAttribute)) ?? false))
+            {
+                context.HttpContext.Response.StatusCode = 403;
+                context.Result = RedirectToPage("/NotAuthorized");
+            }
+        }
+
         public string Email
         {
             get { return _claimsProvider.GetEmail(User); }
+        }
+
+        public string State
+        {
+            get { return _claimsProvider.GetState(User); }
+        }
+
+        public string NACRole
+        {
+            get { return _claimsProvider.GetNACRole(User); }
         }
         public string BaseUrl
         {

--- a/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
 
@@ -5,16 +6,20 @@ namespace Piipan.QueryTool.Pages
 {
     public class ErrorModel : BasePageModel
     {
+        private readonly ILogger<ErrorModel> _logger;
         public string Message = "";
 
-        public ErrorModel(IClaimsProvider claimsProvider)
+        public ErrorModel(ILogger<ErrorModel> logger,
+            IClaimsProvider claimsProvider)
                           : base(claimsProvider)
         {
+            _logger = logger;
         }
 
-        [IgnoreNACAuthorization]
+        [IgnoreAuthorization]
         public void OnGet(string message)
         {
+            _logger.LogError($"Arrived at error page with message {message}");
             if (message != null)
             {
                 Message = message;

--- a/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
@@ -1,38 +1,22 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using Piipan.Match.Api;
-using Piipan.Match.Api.Models;
+using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
-using Piipan.Shared.Deidentification;
 
 namespace Piipan.QueryTool.Pages
 {
     public class ErrorModel : BasePageModel
     {
-        private readonly ILogger<ErrorModel> _logger;
-        private readonly ILdsDeidentifier _ldsDeidentifier;
-        private readonly IMatchApi _matchApi;
-
         public string Message = "";
 
-        public ErrorModel(ILogger<ErrorModel> logger,
-                          IClaimsProvider claimsProvider,
-                          ILdsDeidentifier ldsDeidentifier,
-                          IMatchApi matchApi)
+        public ErrorModel(IClaimsProvider claimsProvider)
                           : base(claimsProvider)
         {
-            _logger = logger;
-            _ldsDeidentifier = ldsDeidentifier;
-            _matchApi = matchApi;
         }
 
+        [IgnoreNACAuthorization]
         public void OnGet(string message)
         {
-            if(message != null) {
+            if (message != null)
+            {
                 Message = message;
             }
         }

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
@@ -4,7 +4,6 @@ using Piipan.Match.Api;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
 using Piipan.Shared.Claims;
-using Piipan.Shared.Deidentification;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -16,7 +15,6 @@ namespace Piipan.QueryTool.Pages
     {
 
         private readonly ILogger<MatchModel> _logger;
-        private readonly ILdsDeidentifier _ldsDeidentifier;
         private readonly IMatchResolutionApi _matchResolutionApi;
 
         [BindProperty]
@@ -28,13 +26,11 @@ namespace Piipan.QueryTool.Pages
 
         public MatchModel(ILogger<MatchModel> logger
                            , IClaimsProvider claimsProvider
-                           , ILdsDeidentifier ldsDeidentifier
                            , IMatchResolutionApi matchResolutionApi)
                            : base(claimsProvider)
 
         {
             _logger = logger;
-            _ldsDeidentifier = ldsDeidentifier;
             _matchResolutionApi = matchResolutionApi;
         }
 

--- a/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml
@@ -1,0 +1,17 @@
+﻿@page
+@model Piipan.QueryTool.Pages.NotAuthorizedModel
+@{
+    ViewData["Title"] = "Not Authorized";
+}
+
+<div class="grid-container">
+    <div id="error-message" class="grid-row margin-top-1">
+        <div class="tablet:grid-col-12">
+            <div class="usa-alert usa-alert--warning">
+                <div class="usa-alert__body">
+                    <h4 class="usa-alert__heading">@Model.Message</h4>
+                </div>
+            </div>
+        </div>
+    </div>
+</div> 

--- a/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
@@ -12,10 +12,10 @@ namespace Piipan.QueryTool.Pages
         {
         }
 
-        [IgnoreNACAuthorization]
+        [IgnoreAuthorization]
         public void OnGet()
         {
-            Message = "You do not have sufficient NAC roles or a NAC Location associated with your account";
+            Message = "You do not have sufficient roles or a location associated with your account";
         }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
@@ -1,0 +1,21 @@
+using Piipan.Shared.Authorization;
+using Piipan.Shared.Claims;
+
+namespace Piipan.QueryTool.Pages
+{
+    public class NotAuthorizedModel : BasePageModel
+    {
+        public string Message = "";
+
+        public NotAuthorizedModel(IClaimsProvider claimsProvider)
+                          : base(claimsProvider)
+        {
+        }
+
+        [IgnoreNACAuthorization]
+        public void OnGet()
+        {
+            Message = "You do not have sufficient NAC roles or a NAC Location associated with your account";
+        }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool/appsettings.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.json
@@ -6,9 +6,12 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "Claims": {
-    "Email": "email"
-  },
+    "Claims": {
+        "Email": "email",
+        "Role": "role",
+        "NACLocationPrefix": "Location-",
+        "NACRolePrefix": "Role-"
+    },
   "AuthorizationPolicy": {
     "RequiredClaims": []
   },

--- a/query-tool/src/Piipan.QueryTool/appsettings.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.json
@@ -9,8 +9,8 @@
     "Claims": {
         "Email": "email",
         "Role": "role",
-        "NACLocationPrefix": "Location-",
-        "NACRolePrefix": "Role-"
+        "LocationPrefix": "Location-",
+        "RolePrefix": "Role-"
     },
   "AuthorizationPolicy": {
     "RequiredClaims": []

--- a/query-tool/src/Piipan.QueryTool/mock_user.json
+++ b/query-tool/src/Piipan.QueryTool/mock_user.json
@@ -25,7 +25,15 @@
       {
         "typ": "name",
         "val": "John Doe"
-      }
+      },
+        {
+            "typ": "role",
+            "val": "Location-EA"
+        },
+        {
+            "typ": "role",
+            "val": "Role-Worker"
+        }
     ]
   }
 ]

--- a/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
@@ -17,7 +17,7 @@ namespace Piipan.QueryTool.Tests
     public class BasePageTest
     {
         public static IClaimsProvider claimsProviderMock(string email = "noreply@tts.test",
-            string state = "IA", string nacRole = "Worker")
+            string state = "IA", string role = "Worker")
         {
             var claimsProviderMock = new Mock<IClaimsProvider>();
             claimsProviderMock
@@ -27,8 +27,8 @@ namespace Piipan.QueryTool.Tests
                 .Setup(c => c.GetState(It.IsAny<ClaimsPrincipal>()))
                 .Returns(state);
             claimsProviderMock
-                .Setup(c => c.GetNACRole(It.IsAny<ClaimsPrincipal>()))
-                .Returns(nacRole);
+                .Setup(c => c.GetRole(It.IsAny<ClaimsPrincipal>()))
+                .Returns(role);
             return claimsProviderMock.Object;
         }
 

--- a/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Piipan.QueryTool.Pages;
+using Piipan.Shared.Claims;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Piipan.QueryTool.Tests
+{
+    public class BasePageTest
+    {
+        public static IClaimsProvider claimsProviderMock(string email = "noreply@tts.test",
+            string state = "IA", string nacRole = "Worker")
+        {
+            var claimsProviderMock = new Mock<IClaimsProvider>();
+            claimsProviderMock
+                .Setup(c => c.GetEmail(It.IsAny<ClaimsPrincipal>()))
+                .Returns(email);
+            claimsProviderMock
+                .Setup(c => c.GetState(It.IsAny<ClaimsPrincipal>()))
+                .Returns(state);
+            claimsProviderMock
+                .Setup(c => c.GetNACRole(It.IsAny<ClaimsPrincipal>()))
+                .Returns(nacRole);
+            return claimsProviderMock.Object;
+        }
+
+        protected static HttpContext contextMock()
+        {
+            var request = new Mock<HttpRequest>();
+            var defaultHttpContext = new DefaultHttpContext();
+
+            request
+                .Setup(m => m.Scheme)
+                .Returns("https");
+
+            request
+                .Setup(m => m.Host)
+                .Returns(new HostString("tts.test"));
+
+
+            var context = new Mock<HttpContext>();
+            context.Setup(m => m.Request).Returns(request.Object);
+            context.Setup(m => m.Response).Returns(defaultHttpContext.Response);
+
+            return context.Object;
+        }
+
+        protected PageHandlerExecutingContext GetPageHandlerExecutingContext<T>(T pageModel, string methodName) where T : BasePageModel
+        {
+            pageModel.PageContext.HttpContext = contextMock();
+
+            var pageContext = new PageContext(new ActionContext(
+                pageModel.PageContext.HttpContext,
+                new RouteData(),
+                new PageActionDescriptor(),
+                new ModelStateDictionary()));
+            var model = new Mock<PageModel>();
+
+            var pageHandlerExecutingContext = new PageHandlerExecutingContext(
+               pageContext,
+               Array.Empty<IFilterMetadata>(),
+               new HandlerMethodDescriptor() { MethodInfo = typeof(T).GetMethod(methodName) },
+               new Dictionary<string, object>(),
+               model.Object);
+
+            pageModel.OnPageHandlerExecuting(pageHandlerExecutingContext);
+
+            return pageHandlerExecutingContext;
+
+        }
+    }
+}

--- a/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging.Abstractions;
 using Piipan.QueryTool.Pages;
 using Piipan.Shared.Claims;
 using Xunit;
@@ -13,7 +14,7 @@ namespace Piipan.QueryTool.Tests
         {
             // arrange
             var mockClaimsProvider = claimsProviderMock();
-            var pageModel = new ErrorModel(mockClaimsProvider);
+            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), mockClaimsProvider);
 
             // act
 
@@ -26,7 +27,7 @@ namespace Piipan.QueryTool.Tests
         {
             // arrange
             var mockClaimsProvider = claimsProviderMock();
-            var pageModel = new ErrorModel(mockClaimsProvider);
+            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), mockClaimsProvider);
 
             // act
             string message = "test message";
@@ -45,7 +46,7 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(ErrorModel.OnGet), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, nacRole: role);
+            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
 
             var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
 
@@ -62,7 +63,7 @@ namespace Piipan.QueryTool.Tests
 
         private PageHandlerExecutingContext GetPageHandlerExecutingContext(IClaimsProvider claimsProvider, string methodName)
         {
-            var pageModel = new ErrorModel(claimsProvider);
+            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), claimsProvider);
 
             return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -273,7 +273,7 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(IndexModel.OnPostAsync), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, nacRole: role);
+            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
 
             var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
 

--- a/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -8,47 +9,20 @@ using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Pages;
 using Piipan.Shared.Claims;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests
 {
-    public class ListPageTests
+    public class ListPageTests : BasePageTest
     {
         private string[] matchIds = new string[] { "m123456", "m654321" };
-        public static IClaimsProvider claimsProviderMock(string email)
-        {
-            var claimsProviderMock = new Mock<IClaimsProvider>();
-            claimsProviderMock
-                .Setup(c => c.GetEmail(It.IsAny<ClaimsPrincipal>()))
-                .Returns(email);
-            return claimsProviderMock.Object;
-        }
-
-        public static HttpContext contextMock()
-        {
-            var request = new Mock<HttpRequest>();
-
-            request
-                .Setup(m => m.Scheme)
-                .Returns("https");
-
-            request
-                .Setup(m => m.Host)
-                .Returns(new HostString("tts.test"));
-
-            var context = new Mock<HttpContext>();
-            context.Setup(m => m.Request).Returns(request.Object);
-
-            return context.Object;
-        }
 
         [Fact]
         public void TestBeforeOnGet()
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockClaimsProvider = claimsProviderMock();
             var mockMatchApi = Mock.Of<IMatchResolutionApi>();
             var pageModel = new ListModel(
                 new NullLogger<ListModel>(),
@@ -109,7 +83,7 @@ namespace Piipan.QueryTool.Tests
         private ListModel SetupMatchModel(Mock<IMatchResolutionApi> mockMatchApi = null)
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock("noreply@tts.test");
+            var mockClaimsProvider = claimsProviderMock();
             mockMatchApi ??= SetupMatchResolutionApi();
             var pageModel = new ListModel(
                 new NullLogger<ListModel>(),
@@ -117,6 +91,40 @@ namespace Piipan.QueryTool.Tests
                 mockMatchApi.Object
             );
             return pageModel;
+        }
+
+        [Theory]
+        [InlineData(nameof(ListModel.OnGet), null, null, false)]
+        [InlineData(nameof(ListModel.OnGet), "IA", null, false)]
+        [InlineData(nameof(ListModel.OnGet), null, "Worker", false)]
+        [InlineData(nameof(ListModel.OnGet), "IA", "Worker", true)]
+        public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
+        {
+            var mockClaimsProvider = claimsProviderMock(state: location, nacRole: role);
+
+            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
+
+            if (!isAuthorized)
+            {
+                Assert.Equal(403, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
+                Assert.IsType<RedirectToPageResult>(pageHandlerExecutingContext.Result);
+            }
+            else
+            {
+                Assert.Equal(200, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
+            }
+        }
+
+        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IClaimsProvider claimsProvider, string methodName)
+        {
+            var mockMatchApi = Mock.Of<IMatchResolutionApi>();
+            var pageModel = new ListModel(
+                new NullLogger<ListModel>(),
+                claimsProvider,
+                mockMatchApi
+            );
+
+            return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }
     }
 }

--- a/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
@@ -100,7 +100,7 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(ListModel.OnGet), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, nacRole: role);
+            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
 
             var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
 

--- a/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
@@ -236,7 +236,7 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(MatchModel.OnPost), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, nacRole: role);
+            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
 
             var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
 

--- a/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Piipan.QueryTool.Pages;
+using Piipan.Shared.Claims;
+using Xunit;
+
+namespace Piipan.QueryTool.Tests
+{
+    public class NotAuthorizedPageTests : BasePageTest
+    {
+        [Fact]
+        public void TestBeforeOnGet()
+        {
+            // arrange
+            var mockClaimsProvider = claimsProviderMock();
+            var pageModel = new NotAuthorizedModel(mockClaimsProvider);
+
+            // act
+
+            // assert
+            Assert.Equal("noreply@tts.test", pageModel.Email);
+        }
+
+        [Fact]
+        public void TestMessageOnGet()
+        {
+            // arrange
+            var mockClaimsProvider = claimsProviderMock();
+            var pageModel = new NotAuthorizedModel(mockClaimsProvider);
+
+            // act
+            pageModel.OnGet();
+            // assert
+            Assert.Equal("You do not have sufficient NAC roles or a NAC Location associated with your account", pageModel.Message);
+        }
+
+        /// <summary>
+        /// The not authorized page should be accessible no matter your role
+        /// </summary>
+        [Theory]
+        [InlineData(nameof(NotAuthorizedModel.OnGet), null, null, true)]
+        [InlineData(nameof(NotAuthorizedModel.OnGet), "IA", null, true)]
+        [InlineData(nameof(NotAuthorizedModel.OnGet), null, "Worker", true)]
+        [InlineData(nameof(NotAuthorizedModel.OnGet), "IA", "Worker", true)]
+        public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
+        {
+            var mockClaimsProvider = claimsProviderMock(state: location, nacRole: role);
+
+            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
+
+            if (!isAuthorized)
+            {
+                Assert.Equal(403, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
+                Assert.IsType<RedirectToPageResult>(pageHandlerExecutingContext.Result);
+            }
+            else
+            {
+                Assert.Equal(200, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
+            }
+        }
+
+        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IClaimsProvider claimsProvider, string methodName)
+        {
+            var pageModel = new NotAuthorizedModel(claimsProvider);
+
+            return base.GetPageHandlerExecutingContext(pageModel, methodName);
+        }
+    }
+}

--- a/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
@@ -31,7 +31,7 @@ namespace Piipan.QueryTool.Tests
             // act
             pageModel.OnGet();
             // assert
-            Assert.Equal("You do not have sufficient NAC roles or a NAC Location associated with your account", pageModel.Message);
+            Assert.Equal("You do not have sufficient roles or a location associated with your account", pageModel.Message);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(NotAuthorizedModel.OnGet), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, nacRole: role);
+            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
 
             var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
 

--- a/shared/src/Piipan.Shared/Authorization/IgnoreAuthorizationAttribute.cs
+++ b/shared/src/Piipan.Shared/Authorization/IgnoreAuthorizationAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Piipan.Shared.Authorization
 {
-    public class IgnoreNACAuthorizationAttribute : Attribute
+    public class IgnoreAuthorizationAttribute : Attribute
     {
 
     }

--- a/shared/src/Piipan.Shared/Authorization/IgnoreNACAuthorizationAttribute.cs
+++ b/shared/src/Piipan.Shared/Authorization/IgnoreNACAuthorizationAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Piipan.Shared.Authorization
+{
+    public class IgnoreNACAuthorizationAttribute : Attribute
+    {
+
+    }
+}

--- a/shared/src/Piipan.Shared/Claims/ClaimsOptions.cs
+++ b/shared/src/Piipan.Shared/Claims/ClaimsOptions.cs
@@ -5,7 +5,7 @@ namespace Piipan.Shared.Claims
         public const string SectionName = "Claims";
         public string Email { get; set; }
         public string Role { get; set; }
-        public string NACLocationPrefix { get; set; }
-        public string NACRolePrefix { get; set; }
+        public string LocationPrefix { get; set; }
+        public string RolePrefix { get; set; }
     }
 }

--- a/shared/src/Piipan.Shared/Claims/ClaimsOptions.cs
+++ b/shared/src/Piipan.Shared/Claims/ClaimsOptions.cs
@@ -4,5 +4,8 @@ namespace Piipan.Shared.Claims
     {
         public const string SectionName = "Claims";
         public string Email { get; set; }
+        public string Role { get; set; }
+        public string NACLocationPrefix { get; set; }
+        public string NACRolePrefix { get; set; }
     }
 }

--- a/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
+++ b/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
@@ -1,7 +1,7 @@
-using System.Linq;
-using System.Security.Claims;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Linq;
+using System.Security.Claims;
 
 namespace Piipan.Shared.Claims
 {
@@ -22,7 +22,32 @@ namespace Piipan.Shared.Claims
             return claimsPrincipal
                 .Claims
                 .SingleOrDefault(c => c.Type == _options.Email)?
-                .Value;        
+                .Value;
+        }
+
+        public string GetState(ClaimsPrincipal claimsPrincipal)
+        {
+            foreach (var identity in claimsPrincipal.Identities)
+            {
+                var stateClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.NACLocationPrefix));
+                if (stateClaim != null)
+                {
+                    return stateClaim.Value.Substring(_options.NACLocationPrefix.Length);
+                }
+            }
+            return null;
+        }
+        public string GetNACRole(ClaimsPrincipal claimsPrincipal)
+        {
+            foreach (var identity in claimsPrincipal.Identities)
+            {
+                var nacRoleClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.NACRolePrefix));
+                if (nacRoleClaim != null)
+                {
+                    return nacRoleClaim.Value.Substring(_options.NACRolePrefix.Length);
+                }
+            }
+            return null;
         }
     }
 }

--- a/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
+++ b/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
@@ -29,22 +29,22 @@ namespace Piipan.Shared.Claims
         {
             foreach (var identity in claimsPrincipal.Identities)
             {
-                var stateClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.NACLocationPrefix));
+                var stateClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.LocationPrefix));
                 if (stateClaim != null)
                 {
-                    return stateClaim.Value.Substring(_options.NACLocationPrefix.Length);
+                    return stateClaim.Value.Substring(_options.LocationPrefix.Length);
                 }
             }
             return null;
         }
-        public string GetNACRole(ClaimsPrincipal claimsPrincipal)
+        public string GetRole(ClaimsPrincipal claimsPrincipal)
         {
             foreach (var identity in claimsPrincipal.Identities)
             {
-                var nacRoleClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.NACRolePrefix));
-                if (nacRoleClaim != null)
+                var roleClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.RolePrefix));
+                if (roleClaim != null)
                 {
-                    return nacRoleClaim.Value.Substring(_options.NACRolePrefix.Length);
+                    return roleClaim.Value.Substring(_options.RolePrefix.Length);
                 }
             }
             return null;

--- a/shared/src/Piipan.Shared/Claims/IClaimsProvider.cs
+++ b/shared/src/Piipan.Shared/Claims/IClaimsProvider.cs
@@ -6,6 +6,6 @@ namespace Piipan.Shared.Claims
     {
         string GetEmail(ClaimsPrincipal claimsPrincipal);
         string GetState(ClaimsPrincipal claimsPrincipal);
-        string GetNACRole(ClaimsPrincipal claimsPrincipal);
+        string GetRole(ClaimsPrincipal claimsPrincipal);
     }
 }

--- a/shared/src/Piipan.Shared/Claims/IClaimsProvider.cs
+++ b/shared/src/Piipan.Shared/Claims/IClaimsProvider.cs
@@ -5,5 +5,7 @@ namespace Piipan.Shared.Claims
     public interface IClaimsProvider
     {
         string GetEmail(ClaimsPrincipal claimsPrincipal);
+        string GetState(ClaimsPrincipal claimsPrincipal);
+        string GetNACRole(ClaimsPrincipal claimsPrincipal);
     }
 }

--- a/shared/tests/Piipan.Shared.Tests/Claims/ClaimsProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Claims/ClaimsProviderTests.cs
@@ -1,28 +1,33 @@
-using System;
-using System.Collections.Generic;
-using System.Security.Claims;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using System.Collections.Generic;
+using System.Security.Claims;
 using Xunit;
 
 namespace Piipan.Shared.Claims.Tests
 {
     public class ClaimsProviderTests
     {
+        ClaimsOptions claimsOptions = new ClaimsOptions
+        {
+            Email = "email_claim_type",
+            Role = "app_role_claim_type",
+            NACLocationPrefix = "Location-",
+            NACRolePrefix = "Role-"
+        };
+
         [Fact]
         public void GetEmail()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
 
-            var options = Options.Create<ClaimsOptions>(new ClaimsOptions {
-                Email = "email_claim_type"
-            });
+            var options = Options.Create(claimsOptions);
             var claimsProvider = new ClaimsProvider(options, logger.Object);
             var claimsPrincipal = new ClaimsPrincipal();
             claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
-                new Claim("email_claim_type", "noreply@tts.test")
+                new Claim(claimsOptions.Email, "noreply@tts.test")
             }));
 
             // Act
@@ -38,9 +43,7 @@ namespace Piipan.Shared.Claims.Tests
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
 
-            var options = Options.Create<ClaimsOptions>(new ClaimsOptions {
-                Email = "email_claim_type"
-            });
+            var options = Options.Create(claimsOptions);
             var claimsProvider = new ClaimsProvider(options, logger.Object);
             var claimsPrincipal = new ClaimsPrincipal();
             claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
@@ -52,6 +55,240 @@ namespace Piipan.Shared.Claims.Tests
 
             // Assert
             Assert.Null(email);
-        }  
+        }
+
+        /// <summary>
+        /// Verify we can grab the location from the roles claim
+        /// </summary>
+        [Fact]
+        public void GetState()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "Location-IA")
+            }));
+
+            // Act
+            var state = claimsProvider.GetState(claimsPrincipal);
+
+            // Assert
+            Assert.Equal("IA", state);
+        }
+
+        /// <summary>
+        /// Verify that if the roles claim is not found, we do not grab a location
+        /// </summary>
+        [Fact]
+        public void GetState_RoleClaimNotFound()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim("app_role_claim_different", "Location-IA")
+            }));
+
+            // Act
+            var state = claimsProvider.GetState(claimsPrincipal);
+
+            // Assert
+            Assert.Null(state);
+        }
+
+        /// <summary>
+        /// Verify that if a roles claim does exist, but a location value does not exist, we do not grab a location
+        /// </summary>
+        [Fact]
+        public void GetState_RoleClaimFound_LocationNotFound()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "Different-IA")
+            }));
+
+            // Act
+            var state = claimsProvider.GetState(claimsPrincipal);
+
+            // Assert
+            Assert.Null(state);
+        }
+
+        /// <summary>
+        /// When multiple locations exist, we just use the first one
+        /// </summary>
+        [Fact]
+        public void GetStateWhenMultipleLocationsExist()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "Location-IA"),
+                new Claim(claimsOptions.Role, "Location-MT")
+            }));
+
+            // Act
+            var state = claimsProvider.GetState(claimsPrincipal);
+
+            // Assert
+            Assert.Equal("IA", state);
+        }
+
+        /// <summary>
+        /// When multiple role claims exist, we should take the state from the one that starts with the NAC Location prefix
+        /// </summary>
+        [Fact]
+        public void GetStateWhenMultipleRoleClaimsExist()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "OtherRole"),
+                new Claim(claimsOptions.Role, "Location-IA")
+            }));
+
+            // Act
+            var state = claimsProvider.GetState(claimsPrincipal);
+
+            // Assert
+            Assert.Equal("IA", state);
+        }
+
+        /// <summary>
+        /// Verify we can grab the NAC role from the claim
+        /// </summary>
+        [Fact]
+        public void GetNACRole()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "Role-Worker")
+            }));
+
+            // Act
+            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+
+            // Assert
+            Assert.Equal("Worker", nacRole);
+        }
+
+        /// <summary>
+        /// Verify if no role claim exists, we have no NAC Role
+        /// </summary>
+        [Fact]
+        public void GetNACRole_RoleClaimNotFound()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim("app_role_claim_different", "Role-Worker")
+            }));
+
+            // Act
+            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+
+            // Assert
+            Assert.Null(nacRole);
+        }
+
+        /// <summary>
+        /// Verify that if a role claim exists, but no NAC Role exists, we have no NAC Role
+        /// </summary>
+        [Fact]
+        public void GetNACRole_RoleClaimFound_LocationNotFound()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "RoleDifferent-Worker")
+            }));
+
+            // Act
+            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+
+            // Assert
+            Assert.Null(nacRole);
+        }
+
+        /// <summary>
+        /// When multiple NAC Roles exist, we just use the first one
+        /// </summary>
+        [Fact]
+        public void GetNACRoleWhenMultipleNACRolesExist()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "Role-Worker"),
+                new Claim(claimsOptions.Role, "Role-OtherWorker")
+            }));
+
+            // Act
+            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+
+            // Assert
+            Assert.Equal("Worker", nacRole);
+        }
+
+        /// <summary>
+        /// When multiple role claims exist, we should take the NAC Role from the one that starts with the NAC Role prefix
+        /// </summary>
+        [Fact]
+        public void GetNACRoleWhenMultipleRoleClaimsExist()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ClaimsProvider>>();
+
+            var options = Options.Create(claimsOptions);
+            var claimsProvider = new ClaimsProvider(options, logger.Object);
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> {
+                new Claim(claimsOptions.Role, "Location-IA"),
+                new Claim(claimsOptions.Role, "Role-Worker")
+            }));
+
+            // Act
+            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+
+            // Assert
+            Assert.Equal("Worker", nacRole);
+        }
     }
 }

--- a/shared/tests/Piipan.Shared.Tests/Claims/ClaimsProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Claims/ClaimsProviderTests.cs
@@ -13,8 +13,8 @@ namespace Piipan.Shared.Claims.Tests
         {
             Email = "email_claim_type",
             Role = "app_role_claim_type",
-            NACLocationPrefix = "Location-",
-            NACRolePrefix = "Role-"
+            LocationPrefix = "Location-",
+            RolePrefix = "Role-"
         };
 
         [Fact]
@@ -175,10 +175,10 @@ namespace Piipan.Shared.Claims.Tests
         }
 
         /// <summary>
-        /// Verify we can grab the NAC role from the claim
+        /// Verify we can grab the role from the claim
         /// </summary>
         [Fact]
-        public void GetNACRole()
+        public void GetRole()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -191,17 +191,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+            var role = claimsProvider.GetRole(claimsPrincipal);
 
             // Assert
-            Assert.Equal("Worker", nacRole);
+            Assert.Equal("Worker", role);
         }
 
         /// <summary>
-        /// Verify if no role claim exists, we have no NAC Role
+        /// Verify if no role claim exists, we have no role
         /// </summary>
         [Fact]
-        public void GetNACRole_RoleClaimNotFound()
+        public void GetRole_RoleClaimNotFound()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -214,17 +214,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+            var role = claimsProvider.GetRole(claimsPrincipal);
 
             // Assert
-            Assert.Null(nacRole);
+            Assert.Null(role);
         }
 
         /// <summary>
-        /// Verify that if a role claim exists, but no NAC Role exists, we have no NAC Role
+        /// Verify that if a role claim exists, but no Role exists, we have no Role
         /// </summary>
         [Fact]
-        public void GetNACRole_RoleClaimFound_LocationNotFound()
+        public void GetRole_RoleClaimFound_LocationNotFound()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -237,17 +237,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+            var role = claimsProvider.GetRole(claimsPrincipal);
 
             // Assert
-            Assert.Null(nacRole);
+            Assert.Null(role);
         }
 
         /// <summary>
-        /// When multiple NAC Roles exist, we just use the first one
+        /// When multiple Roles exist, we just use the first one
         /// </summary>
         [Fact]
-        public void GetNACRoleWhenMultipleNACRolesExist()
+        public void GetRoleWhenMultipleRolesExist()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -261,17 +261,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+            var role = claimsProvider.GetRole(claimsPrincipal);
 
             // Assert
-            Assert.Equal("Worker", nacRole);
+            Assert.Equal("Worker", role);
         }
 
         /// <summary>
-        /// When multiple role claims exist, we should take the NAC Role from the one that starts with the NAC Role prefix
+        /// When multiple role claims exist, we should take the Role from the one that starts with the Role prefix
         /// </summary>
         [Fact]
-        public void GetNACRoleWhenMultipleRoleClaimsExist()
+        public void GetRoleWhenMultipleRoleClaimsExist()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -285,10 +285,10 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var nacRole = claimsProvider.GetNACRole(claimsPrincipal);
+            var role = claimsProvider.GetRole(claimsPrincipal);
 
             // Assert
-            Assert.Equal("Worker", nacRole);
+            Assert.Equal("Worker", role);
         }
     }
 }


### PR DESCRIPTION
## What’s changing?

We are adding basic role and location based authorization to the Query Tool. After logging in, the logged in user must have a value for the location and also a value for their role in the NAC. If they don't we will redirect them to an unauthorized page.

In the future we will use the values of these claims to show/hide certain portions of the app based on these values, or when searching for a match we will pull in the initiating state from their location.

## Why?

Closes NAC-413

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
