### PR TITLE
Participant upload error logging

### DIFF
--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/BulkUpload.cs
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/BulkUpload.cs
@@ -1,20 +1,12 @@
 // Default URL for triggering event grid function in the local environment.
 // http://localhost:7071/runtime/webhooks/EventGrid?functionName={functionname}
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using Azure.Messaging.EventGrid;
-using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Models;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.EventGrid;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Piipan.Etl.Func.BulkUpload.Parsers;
 using Piipan.Participants.Api;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace Piipan.Etl.Func.BulkUpload
 {
@@ -74,10 +66,10 @@ namespace Piipan.Etl.Func.BulkUpload
                     if (input != null)
                     {
                         var participants = _participantParser.Parse(input);
-                        await _participantApi.AddParticipants(participants, blobProperties.ETag.ToString())
+                        await _participantApi.AddParticipants(participants, blobProperties.ETag.ToString(), blockBlobClient.Name)
                                 .ContinueWith(t => _blobStream.DeleteBlobAfterProcessing(t, blockBlobClient, log))
                                 .ContinueWith(t => _participantApi.DeleteOldParticpants());
-                       
+
                     }
                 }
             }

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Parsers/ParticipantStreamCsvParser.cs
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Parsers/ParticipantStreamCsvParser.cs
@@ -44,7 +44,7 @@ namespace Piipan.Etl.Func.BulkUpload.Parsers
                 {
                     if (String.IsNullOrEmpty(field.Field)) return true;
 
-                    string[] formats = { "yyyy-MM-dd"};
+                    string[] formats = { "yyyy-MM-dd" };
                     DateTime dateValue;
                     var result = DateTime.TryParseExact(
                         field.Field,
@@ -94,21 +94,21 @@ namespace Piipan.Etl.Func.BulkUpload.Parsers
 
         }
     }
-   
+
     /// <summary>
     /// Converts list of month-only dates to last day of month when as DateTimes
     /// and to ISO 8601 year-months when as a string
     /// </summary>
-  	public class ToMonthEndArrayConverter : DefaultTypeConverter
-  	{
-      	public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
-      	{
-			if (text == "") return new List<DateTime>();
-			string[] allElements = text.Split(' ');
-			DateTime[] elementsAsDateTimes = allElements.Select(s => MonthEndDateTime.Parse(s)).ToArray();
-			return new List<DateTime>(elementsAsDateTimes);
-      	}
-  	}
+    public class ToMonthEndArrayConverter : DefaultTypeConverter
+    {
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        {
+            if (text == "") return new List<DateTime>();
+            string[] allElements = text.Split(' ');
+            DateTime[] elementsAsDateTimes = allElements.Select(s => MonthEndDateTime.Parse(s)).ToArray();
+            return new List<DateTime>(elementsAsDateTimes);
+        }
+    }
 
     /// <summary>
     /// Converts ISO 8601 year-months-date to DateTime
@@ -117,7 +117,7 @@ namespace Piipan.Etl.Func.BulkUpload.Parsers
     {
         public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
         {
-            if(string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text))
             {
                 return null;
             }
@@ -150,7 +150,7 @@ namespace Piipan.Etl.Func.BulkUpload.Parsers
             if (text == "") return new List<DateRange>();
             string[] allElements = text.Split(' ');
             List<DateRange> range = new List<DateRange>();
-            foreach ( string strRange in allElements)
+            foreach (string strRange in allElements)
             {
                 DateTime[] elementsAsDateTimes = strRange.Split('/').Select(s => DateTime.Parse(s)).ToArray();
                 range.Add(new DateRange(elementsAsDateTimes[0], elementsAsDateTimes[1]));

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,6 +6,8 @@ using Piipan.Etl.Func.BulkUpload.Parsers;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Extensions;
 using Piipan.Shared.Database;
+using Piipan.Shared.Deidentification;
+using System;
 
 [assembly: FunctionsStartup(typeof(Piipan.Etl.Func.BulkUpload.Startup))]
 
@@ -29,9 +30,10 @@ namespace Piipan.Etl.Func.BulkUpload
             });
             builder.Services.AddTransient<IParticipantStreamParser, ParticipantCsvStreamParser>();
 
-            builder.Services.AddTransient<IBlobClientStream, BlobClientStream>(); 
+            builder.Services.AddTransient<IBlobClientStream, BlobClientStream>();
 
             builder.Services.RegisterParticipantsServices();
+            builder.Services.AddSingleton<IRedactionService, RedactionService>();
         }
     }
 }

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
@@ -6,7 +6,6 @@ using Piipan.Etl.Func.BulkUpload.Parsers;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Extensions;
 using Piipan.Shared.Database;
-using Piipan.Shared.Deidentification;
 using System;
 
 [assembly: FunctionsStartup(typeof(Piipan.Etl.Func.BulkUpload.Startup))]
@@ -33,7 +32,6 @@ namespace Piipan.Etl.Func.BulkUpload
             builder.Services.AddTransient<IBlobClientStream, BlobClientStream>();
 
             builder.Services.RegisterParticipantsServices();
-            builder.Services.AddSingleton<IRedactionService, RedactionService>();
         }
     }
 }

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,7 +7,6 @@ using Piipan.Etl.Func.BulkUpload.Parsers;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Extensions;
 using Piipan.Shared.Database;
-using System;
 
 [assembly: FunctionsStartup(typeof(Piipan.Etl.Func.BulkUpload.Startup))]
 

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/BulkUploadTests.cs
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/BulkUploadTests.cs
@@ -1,12 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.IO;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure;
-using Azure.Messaging.EventGrid;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
@@ -17,6 +9,11 @@ using Piipan.Etl.Func.BulkUpload.Parsers;
 using Piipan.Participants.Api;
 using Piipan.Participants.Api.Models;
 using Piipan.Shared.API.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Piipan.Etl.Func.BulkUpload.Tests
@@ -76,7 +73,7 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
 
             // Act 
             await function.Run("", logger.Object);
-            
+
             // Assert
             VerifyLogError(logger, "No input stream was provided");
         }
@@ -95,7 +92,7 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
             var logger = new Mock<ILogger>();
 
             var responseMock = new Mock<Response>();
-            
+
             var blockBlobClient = new Mock<BlockBlobClient>();
             blockBlobClient
                 .Setup(m => m.GetProperties(null, CancellationToken.None))
@@ -106,9 +103,9 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
                     .Returns(Task.FromResult(new MemoryStream(File.ReadAllBytes("example.csv")) as Stream));
 
             var blobClientStream = new Mock<IBlobClientStream>();
-                blobClientStream
-                    .Setup(m => m.Parse(It.IsAny<string>(), logger.Object))
-                    .Returns(blockBlobClient.Object);
+            blobClientStream
+                .Setup(m => m.Parse(It.IsAny<string>(), logger.Object))
+                .Returns(blockBlobClient.Object);
 
             var function = new BulkUpload(participantApi, participantStreamParser.Object, blobClientStream.Object);
 
@@ -123,18 +120,18 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
         {
             // Arrange
             var blobClient = new Mock<BlobClient>();
-        
+
             var participantApi = new Mock<IParticipantApi>();
             participantApi
-                .Setup(m => m.AddParticipants(It.IsAny<IEnumerable<IParticipant>>(), It.IsAny<string>()))
+                .Setup(m => m.AddParticipants(It.IsAny<IEnumerable<IParticipant>>(), It.IsAny<string>(), It.IsAny<string>()))
                  .Throws(new Exception("the api broke"));
-                
+
 
             var participantStreamParser = Mock.Of<IParticipantStreamParser>();
 
             var logger = new Mock<ILogger>();
 
-             var responseMock = new Mock<Response>();
+            var responseMock = new Mock<Response>();
 
             var blockBlobClient = new Mock<BlockBlobClient>();
             blockBlobClient
@@ -146,9 +143,9 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
                     .Returns(Task.FromResult(new MemoryStream(File.ReadAllBytes("example.csv")) as Stream));
 
             var blobClientStream = new Mock<IBlobClientStream>();
-                blobClientStream
-                    .Setup(m => m.Parse(It.IsAny<string>(), logger.Object))
-                    .Returns(blockBlobClient.Object);
+            blobClientStream
+                .Setup(m => m.Parse(It.IsAny<string>(), logger.Object))
+                .Returns(blockBlobClient.Object);
 
             var function = new BulkUpload(participantApi.Object, participantStreamParser, blobClientStream.Object);
 
@@ -163,7 +160,7 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
         {
 
             // Arrange
-            
+
             var responseMock = new Mock<Response>();
 
             var blockBlobClient = new Mock<BlockBlobClient>();
@@ -174,7 +171,7 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
             blockBlobClient
                     .Setup(m => m.OpenReadAsync(0, null, null, default))
                     .Returns(Task.FromResult(new MemoryStream(File.ReadAllBytes("example.csv")) as Stream));
-            
+
             var participants = new List<Participant>
             {
                 new Participant
@@ -198,9 +195,9 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
             var logger = new Mock<ILogger>();
 
             var blobClientStream = new Mock<IBlobClientStream>();
-                blobClientStream
-                    .Setup(m => m.Parse(It.IsAny<string>(), logger.Object))
-                    .Returns(blockBlobClient.Object);
+            blobClientStream
+                .Setup(m => m.Parse(It.IsAny<string>(), logger.Object))
+                .Returns(blockBlobClient.Object);
 
             var function = new BulkUpload(participantApi.Object, participantStreamParser.Object, blobClientStream.Object);
 
@@ -208,7 +205,7 @@ namespace Piipan.Etl.Func.BulkUpload.Tests
             await function.Run("Event Grid Event String", logger.Object);
 
             // Assert
-            participantApi.Verify(m => m.AddParticipants(participants, It.IsAny<string>()), Times.Once);
+            participantApi.Verify(m => m.AddParticipants(participants, It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             participantApi.Verify(m => m.DeleteOldParticpants(It.IsAny<string>()), Times.Once);
         }
     }

--- a/iac/create-resources.bash
+++ b/iac/create-resources.bash
@@ -545,6 +545,7 @@ main () {
         $AZ_SERV_STR_KEY="$az_serv_str" \
         $BLOB_CONN_STR_KEY="$blob_conn_str" \
         $CLOUD_NAME_STR_KEY="$CLOUD_NAME" \
+        $STATE_STR_KEY="$abbr" \
       --output none
 
     event_grid_system_topic_id=$(\

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -46,7 +46,7 @@ CLOUD_NAME_STR_KEY=CloudName
 
 # Name of the environment variable used to indicate the current state. This is
 # used in the bulk upload Azure Function.
-STATE_STR_KEY=CloudName
+STATE_STR_KEY=State
 
 # For connection strings, our established placeholder values
 PASSWORD_PLACEHOLDER='{password}'

--- a/iac/iac-common.bash
+++ b/iac/iac-common.bash
@@ -44,6 +44,10 @@ AZ_SERV_STR_KEY=AzureServicesAuthConnectionString
 # so that application code can use the appropriate, cloud-specific domain
 CLOUD_NAME_STR_KEY=CloudName
 
+# Name of the environment variable used to indicate the current state. This is
+# used in the bulk upload Azure Function.
+STATE_STR_KEY=CloudName
+
 # For connection strings, our established placeholder values
 PASSWORD_PLACEHOLDER='{password}'
 DATABASE_PLACEHOLDER='{database}'

--- a/participants/src/Piipan.Participants/Piipan.Participants.Api/IParticipantApi.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Api/IParticipantApi.cs
@@ -1,13 +1,13 @@
+using Piipan.Participants.Api.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Piipan.Participants.Api.Models;
 
 namespace Piipan.Participants.Api
 {
     public interface IParticipantApi
     {
         Task<IEnumerable<IParticipant>> GetParticipants(string state, string ldsHash);
-        Task AddParticipants(IEnumerable<IParticipant> participants, string uploadIdentifier);
+        Task AddParticipants(IEnumerable<IParticipant> participants, string uploadIdentifier, string fileName);
         Task<IEnumerable<string>> GetStates();
         Task DeleteOldParticpants(string state = null);
     }

--- a/participants/src/Piipan.Participants/Piipan.Participants.Api/IParticipantApi.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Api/IParticipantApi.cs
@@ -1,14 +1,17 @@
-using Piipan.Participants.Api.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Piipan.Participants.Api.Models;
 
 namespace Piipan.Participants.Api
 {
     public interface IParticipantApi
     {
         Task<IEnumerable<IParticipant>> GetParticipants(string state, string ldsHash);
-        Task AddParticipants(IEnumerable<IParticipant> participants, string uploadIdentifier, string fileName);
+        Task AddParticipants(IEnumerable<IParticipant> participants, string uploadIdentifier, Action<Exception> errorCallback);
         Task<IEnumerable<string>> GetStates();
         Task DeleteOldParticpants(string state = null);
+
+        void LogParticipantsUploadError(ParticipantUploadErrorDetails errorDetails, IEnumerable<IParticipant> participants);
     }
 }

--- a/participants/src/Piipan.Participants/Piipan.Participants.Api/Models/ParticipantUploadErrorDetails.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Api/Models/ParticipantUploadErrorDetails.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Piipan.Participants.Core.Models
+namespace Piipan.Participants.Api.Models
 {
     public record ParticipantUploadErrorDetails(string State, DateTime StartTime, DateTime EndTime, Exception Exception, string FileName);
 }

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Piipan.Participants.Api;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Services;
+using Piipan.Shared.Deidentification;
 
 namespace Piipan.Participants.Core.Extensions
 {
@@ -9,6 +10,7 @@ namespace Piipan.Participants.Core.Extensions
     {
         public static void RegisterParticipantsServices(this IServiceCollection serviceCollection)
         {
+            serviceCollection.AddTransient<IRedactionService, RedactionService>();
             serviceCollection.AddTransient<IParticipantBulkInsertHandler, ParticipantBulkInsertHandler>();
             serviceCollection.AddTransient<IParticipantDao, ParticipantDao>();
             serviceCollection.AddTransient<IUploadDao, UploadDao>();

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Models/ParticipantUploadErrorDetails.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Models/ParticipantUploadErrorDetails.cs
@@ -1,0 +1,6 @@
+﻿using System;
+
+namespace Piipan.Participants.Core.Models
+{
+    public record ParticipantUploadErrorDetails(string State, DateTime StartTime, DateTime EndTime, Exception Exception, string FileName);
+}

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantServiceTests.cs
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantServiceTests.cs
@@ -1,9 +1,10 @@
-using System;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Services;
+using Piipan.Shared.Deidentification;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace Piipan.Participants.Core.IntegrationTests
@@ -25,18 +26,19 @@ namespace Piipan.Participants.Core.IntegrationTests
                 ClearParticipants();
 
                 var logger = Mock.Of<ILogger<ParticipantDao>>();
+                var redactionService = Mock.Of<IRedactionService>();
                 var serviceLogger = Mock.Of<ILogger<ParticipantService>>();
                 var bulkLogger = Mock.Of<ILogger<ParticipantBulkInsertHandler>>();
                 var bulkInserter = new ParticipantBulkInsertHandler(bulkLogger);
                 var participantDao = new ParticipantDao(helper.DbConnFactory(Factory, ConnectionString), bulkInserter, logger);
                 var uploadDao = new UploadDao(helper.DbConnFactory(Factory, ConnectionString));
 
-                ParticipantService service = new ParticipantService(participantDao, uploadDao, null, serviceLogger);
+                ParticipantService service = new ParticipantService(participantDao, uploadDao, null, redactionService, serviceLogger);
 
                 var participants = helper.RandomParticipants(nParticipants, GetLastUploadId());
 
                 // Act
-                await service.AddParticipants(participants,"test-etag");
+                await service.AddParticipants(participants, "test-etag", "test-file");
 
                 long lastUploadId = GetLastUploadId();
 
@@ -62,13 +64,14 @@ namespace Piipan.Participants.Core.IntegrationTests
                 ClearParticipants();
 
                 var logger = Mock.Of<ILogger<ParticipantDao>>();
+                var redactionService = Mock.Of<IRedactionService>();
                 var serviceLogger = Mock.Of<ILogger<ParticipantService>>();
                 var bulkLogger = Mock.Of<ILogger<ParticipantBulkInsertHandler>>();
                 var bulkInserter = new ParticipantBulkInsertHandler(bulkLogger);
                 var participantDao = new ParticipantDao(helper.DbConnFactory(Factory, ConnectionString), bulkInserter, logger);
                 var uploadDao = new UploadDao(helper.DbConnFactory(Factory, ConnectionString));
 
-                ParticipantService service = new ParticipantService(participantDao, uploadDao, null, serviceLogger);
+                ParticipantService service = new ParticipantService(participantDao, uploadDao, null, redactionService, serviceLogger);
 
                 var participants = helper.RandomParticipants(nParticipants, GetLastUploadId());
                 participants.Last().LdsHash = null; //Cause the db commit to fail due to a null hash value
@@ -78,7 +81,7 @@ namespace Piipan.Participants.Core.IntegrationTests
                 try
                 {
                     // Act
-                    await service.AddParticipants(participants, "test-etag");
+                    await service.AddParticipants(participants, "test-etag", "test-file");
                     throw new Exception("Test should have failed because of participant with null ldsHash value");
                 }
                 catch (Exception)

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantServiceTests.cs
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/ParticipantServiceTests.cs
@@ -1,10 +1,10 @@
+using System;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Services;
 using Piipan.Shared.Deidentification;
-using System;
-using System.Linq;
 using Xunit;
 
 namespace Piipan.Participants.Core.IntegrationTests
@@ -38,7 +38,7 @@ namespace Piipan.Participants.Core.IntegrationTests
                 var participants = helper.RandomParticipants(nParticipants, GetLastUploadId());
 
                 // Act
-                await service.AddParticipants(participants, "test-etag", "test-file");
+                await service.AddParticipants(participants, "test-etag", null);
 
                 long lastUploadId = GetLastUploadId();
 
@@ -81,7 +81,7 @@ namespace Piipan.Participants.Core.IntegrationTests
                 try
                 {
                     // Act
-                    await service.AddParticipants(participants, "test-etag", "test-file");
+                    await service.AddParticipants(participants, "test-etag", null);
                     throw new Exception("Test should have failed because of participant with null ldsHash value");
                 }
                 catch (Exception)

--- a/participants/tests/Piipan.Participants.Core.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/participants/tests/Piipan.Participants.Core.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,10 +1,10 @@
-using System.Data;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Piipan.Participants.Api;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Extensions;
 using Piipan.Shared.Database;
+using Piipan.Shared.Deidentification;
 using Xunit;
 
 namespace Piipan.Participants.Core.Tests.Extensions
@@ -28,6 +28,7 @@ namespace Piipan.Participants.Core.Tests.Extensions
             Assert.NotNull(provider.GetService<IUploadDao>());
             Assert.NotNull(provider.GetService<IParticipantApi>());
             Assert.NotNull(provider.GetService<IParticipantBulkInsertHandler>());
+            Assert.NotNull(provider.GetService<IRedactionService>());
 
         }
     }

--- a/shared/src/Piipan.Shared/Deidentification/IRedactionService.cs
+++ b/shared/src/Piipan.Shared/Deidentification/IRedactionService.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Piipan.Shared.Deidentification
+{
+    public interface IRedactionService
+    {
+        /// <summary>
+        /// Return a string with redactions
+        /// </summary>
+        /// <param name="originalValue">The input string to check for redactions</param>
+        /// <param name="redactStrings">All of the values that need to be redacted</param>
+        /// <returns></returns>
+        public string Redact(string originalValue, IEnumerable<string> redactStrings);
+    }
+}

--- a/shared/src/Piipan.Shared/Deidentification/RedactionService.cs
+++ b/shared/src/Piipan.Shared/Deidentification/RedactionService.cs
@@ -12,6 +12,10 @@ namespace Piipan.Shared.Deidentification
         /// <returns></returns>
         public string Redact(string originalValue, IEnumerable<string> redactStrings)
         {
+            if (redactStrings == null)
+            {
+                return originalValue;
+            }
             var redactedString = originalValue;
             foreach (var redactString in redactStrings)
             {

--- a/shared/src/Piipan.Shared/Deidentification/RedactionService.cs
+++ b/shared/src/Piipan.Shared/Deidentification/RedactionService.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace Piipan.Shared.Deidentification
+{
+    public class RedactionService : IRedactionService
+    {
+        /// <summary>
+        /// Return a string with redactions
+        /// </summary>
+        /// <param name="originalValue">The input string to check for redactions</param>
+        /// <param name="redactStrings">All of the values that need to be redacted</param>
+        /// <returns></returns>
+        public string Redact(string originalValue, IEnumerable<string> redactStrings)
+        {
+            var redactedString = originalValue;
+            foreach (var redactString in redactStrings)
+            {
+                if (!string.IsNullOrEmpty(redactString))
+                {
+                    redactedString = redactedString.Replace(redactString, "REDACTED", System.StringComparison.InvariantCultureIgnoreCase);
+                }
+            }
+            return redactedString;
+        }
+
+    }
+}

--- a/shared/tests/Piipan.Shared.Tests/Deidentification/RedactionServiceTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Deidentification/RedactionServiceTests.cs
@@ -11,6 +11,7 @@ namespace Piipan.Shared.Tests.Deidentification
         /// <summary>
         /// When the list of items to redact is null, nothing is redacted and the original string is returned.
         /// </summary>
+        [Fact]
         public void RedactsNothingWhenNullList()
         {
             // Arrange
@@ -26,6 +27,7 @@ namespace Piipan.Shared.Tests.Deidentification
         /// <summary>
         /// When the list of items to redact is empty, nothing is redacted and the original string is returned.
         /// </summary>
+        [Fact]
         public void RedactsNothingWhenEmptyList()
         {
             // Arrange
@@ -42,6 +44,7 @@ namespace Piipan.Shared.Tests.Deidentification
         /// When the list of items doesn't have any strings in it that matches the input string,
         /// nothing is redacted and the original string is returned.
         /// </summary>
+        [Fact]
         public void RedactsNothingWhenNotFound()
         {
             // Arrange
@@ -57,6 +60,7 @@ namespace Piipan.Shared.Tests.Deidentification
         /// <summary>
         /// When the list of items has a string that matches a string in the input value, the original string is returned but with a redaction
         /// </summary>
+        [Fact]
         public void RedactsStringWhenFound()
         {
             // Arrange
@@ -73,6 +77,7 @@ namespace Piipan.Shared.Tests.Deidentification
         /// When the list of items has multiple strings that match strings in the input value, 
         /// the original string is returned but with all of the redactions
         /// </summary>
+        [Fact]
         public void RedactsMultipleStringsWhenFound()
         {
             // Arrange
@@ -89,6 +94,7 @@ namespace Piipan.Shared.Tests.Deidentification
         /// When the list of items has a string that matches a string in the input value, 
         /// the original string is returned but with a redaction even if the casing is not the same
         /// </summary>
+        [Fact]
         public void RedactsStringWhenCaseInsensitiveFound()
         {
             // Arrange

--- a/shared/tests/Piipan.Shared.Tests/Deidentification/RedactionServiceTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Deidentification/RedactionServiceTests.cs
@@ -1,0 +1,104 @@
+﻿using Piipan.Shared.Deidentification;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Piipan.Shared.Tests.Deidentification
+{
+    public class RedactionServiceTests
+    {
+        private readonly RedactionService redactionService = new();
+
+        /// <summary>
+        /// When the list of items to redact is null, nothing is redacted and the original string is returned.
+        /// </summary>
+        public void RedactsNothingWhenNullList()
+        {
+            // Arrange
+            string stringToEvaluate = "This is a plain-text string ABCDEFG";
+
+            // Act
+            string redactedString = redactionService.Redact(stringToEvaluate, null);
+
+            // Assert
+            Assert.Equal(stringToEvaluate, redactedString);
+        }
+
+        /// <summary>
+        /// When the list of items to redact is empty, nothing is redacted and the original string is returned.
+        /// </summary>
+        public void RedactsNothingWhenEmptyList()
+        {
+            // Arrange
+            string stringToEvaluate = "This is a plain-text string ABCDEFG";
+
+            // Act
+            string redactedString = redactionService.Redact(stringToEvaluate, new List<string>());
+
+            // Assert
+            Assert.Equal(stringToEvaluate, redactedString);
+        }
+
+        /// <summary>
+        /// When the list of items doesn't have any strings in it that matches the input string,
+        /// nothing is redacted and the original string is returned.
+        /// </summary>
+        public void RedactsNothingWhenNotFound()
+        {
+            // Arrange
+            string stringToEvaluate = "This is a plain-text string ABCDEFG";
+
+            // Act
+            string redactedString = redactionService.Redact(stringToEvaluate, new List<string> { "FGHIJKL" });
+
+            // Assert
+            Assert.Equal(stringToEvaluate, redactedString);
+        }
+
+        /// <summary>
+        /// When the list of items has a string that matches a string in the input value, the original string is returned but with a redaction
+        /// </summary>
+        public void RedactsStringWhenFound()
+        {
+            // Arrange
+            string stringToEvaluate = "This is a plain-text string ABCDEFG";
+
+            // Act
+            string redactedString = redactionService.Redact(stringToEvaluate, new List<string> { "ABCDEFG" });
+
+            // Assert
+            Assert.Equal("This is a plain-text string REDACTED", redactedString);
+        }
+
+        /// <summary>
+        /// When the list of items has multiple strings that match strings in the input value, 
+        /// the original string is returned but with all of the redactions
+        /// </summary>
+        public void RedactsMultipleStringsWhenFound()
+        {
+            // Arrange
+            string stringToEvaluate = "This is a ABCDEFG string ABCDEFG FGHIJK";
+
+            // Act
+            string redactedString = redactionService.Redact(stringToEvaluate, new List<string> { "ABCDEFG", "FGHIJK" });
+
+            // Assert
+            Assert.Equal("This is a REDACTED string REDACTED REDACTED", redactedString);
+        }
+
+        /// <summary>
+        /// When the list of items has a string that matches a string in the input value, 
+        /// the original string is returned but with a redaction even if the casing is not the same
+        /// </summary>
+        public void RedactsStringWhenCaseInsensitiveFound()
+        {
+            // Arrange
+            string stringToEvaluate = "This is a plain-text string ABCDEFG";
+
+            // Act
+            string redactedString = redactionService.Redact(stringToEvaluate, new List<string> { "abcdefg" });
+
+            // Assert
+            Assert.Equal("This is a plain-text string REDACTED", redactedString);
+        }
+    }
+}


### PR DESCRIPTION
## What’s changing?

When the participant upload gets changed to "Failed", we should be logging information about the file so that we can try to identify what caused the upload to fail.

Per NAC-577, that data includes:

- State that uploaded
- Timestamp of upload processing start
- Timestamp of upload processing fail
- Error and location of the error (eg. stacktrace)
- Name of failed file

We also need to redact out any PII (LDS Hash, Participant ID, Case Number) from the error text or file name. A redaction service was created for this purpose.

A small IAC change was created to add the State to the Bulk Upload Azure Function. We could have gotten this information from the database connection string, but it seemed quite hacky, so I figured adding it as a configuration setting would be the best bet.

## Why?

Closes NAC-577

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [x] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
