### PR TITLE
Expanding location roles

### DIFF
--- a/query-tool/docs/query-tool.md
+++ b/query-tool/docs/query-tool.md
@@ -58,7 +58,9 @@ Gulp will then watch for changes to the SCSS and compile them into the main CSS 
 
 The app will restrict anyone with an appropriate role and location claim from accessing the app. For local development, you can change your role and location by editing the mock_user.json file. The location is defaulted to EA in the mock_user file, but simply update the location to "National" or a different location to have access to different states.
 
-Any users that are authenticated but not authorized to view the app will be redirected to a "Not Authenticated" page to let them know their role or location is not valid for the page.
+For the "Search for Snap Participants" screen, you need to have a user that has a location that is a state. By default, the mock_user.json file sets the user's location to EA, so you should have access to search on this page. For the "List of NAC Matches" screen, you need to have a user that has a location that is set to the national office. To do this, update the mock_user.json file to have "Location-National" instead of "Location-EA". Now you will be able to see the list of matches, but you will be unable to search for snap participants.
+
+Any users that are authenticated but not authorized to view the page will be redirected to a "Not Authenticated" page to let them know their role or location is not valid for the page.
 
 ## Testing
 

--- a/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
@@ -26,6 +26,8 @@
         {
             serverErrorList = new(QueryFormData.ServerErrors.Select(n => (n.Property, n.Error)));
         }
+
+        // Only locations with length 2, which are states, can perform a search.
         canPerformSearch = QueryFormData.Location?.Length == 2;
     }
     private Task SubmitForm(bool valid)

--- a/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
@@ -11,27 +11,22 @@
 
 
 @code {
-    [Parameter] public PiiRecord Query { get; set; } = new();
+    [Parameter] public QueryFormModel QueryFormData { get; set; } = new();
 
-    /// <summary>
-    /// The search response that is collected after the user hits "Search" and an API call is made
-    /// </summary>
-    [Parameter] public ParameterBase<OrchMatchResponseData> QueryResult { get; set; }
-    [Parameter] public string Token { get; set; }
-    [Parameter] public List<ServerError> ServerErrors { get; set; }
-
-    private bool NoResults => QueryResult?.Data != null &&
-        (QueryResult?.Data.Results.Count == 0 || QueryResult?.Data.Results[0].Matches.Count() == 0);
+    private bool NoResults => QueryFormData.QueryResult != null &&
+        (QueryFormData.QueryResult.Results.Count == 0 || QueryFormData.QueryResult.Results[0].Matches.Count() == 0);
     private bool showNoResultsAlert = true;
     private bool searching = false;
+    private bool canPerformSearch = false;
     List<(string Property, string Error)> serverErrorList;
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        if (ServerErrors?.Count > 0)
+        if (QueryFormData.ServerErrors?.Count > 0)
         {
-            serverErrorList = new(ServerErrors.Select(n => (n.Property, n.Error)));
+            serverErrorList = new(QueryFormData.ServerErrors.Select(n => (n.Property, n.Error)));
         }
+        canPerformSearch = QueryFormData.Location?.Length == 2;
     }
     private Task SubmitForm(bool valid)
     {
@@ -56,35 +51,35 @@
         <p>This participant does not have a matching record in any other states.</p>
     </UsaAlertBox>
 }
-@if (Query != null)
+@if (QueryFormData.Query != null)
 {
-    <UsaForm Id="snap-participants-query-form" InitialErrors="serverErrorList" Model="Query" method="post" OnBeforeSubmit="SubmitForm">
-        <input type="hidden" name="__RequestVerificationToken" value="@Token" />
+    <UsaForm Id="snap-participants-query-form" InitialErrors="serverErrorList" Model="QueryFormData.Query" method="post" OnBeforeSubmit="SubmitForm">
+        <input type="hidden" name="__RequestVerificationToken" value="@QueryFormData.Token" />
         <legend class="usa-sr-only">participant information</legend>
         <UsaFormGroup>
-            <UsaInputText @bind-Value="Query.LastName" />
+            <UsaInputText @bind-Value="QueryFormData.Query.LastName" />
         </UsaFormGroup>
         <UsaFormGroup>
-            <UsaInputDate @bind-Value="Query.DateOfBirth" />
+            <UsaInputDate @bind-Value="QueryFormData.Query.DateOfBirth" />
         </UsaFormGroup>
         <UsaFormGroup>
             <HintContent>###-##-####</HintContent>
             <ChildContent>
-                <UsaInputSSN @bind-Value="Query.SocialSecurityNum" />
+                <UsaInputSSN @bind-Value="QueryFormData.Query.SocialSecurityNum" />
             </ChildContent>
         </UsaFormGroup>
         <UsaFormGroup>
-            <UsaInputText @bind-Value="Query.ParticipantId" Width="118" />
+            <UsaInputText @bind-Value="QueryFormData.Query.ParticipantId" Width="118" />
         </UsaFormGroup>
         <UsaFormGroup>
-            <UsaInputText @bind-Value="Query.CaseId" Width="143" />
+            <UsaInputText @bind-Value="QueryFormData.Query.CaseId" Width="143" />
         </UsaFormGroup>
-        <button class="usa-button" type="submit" id="query-form-search-btn" disabled="@searching">@(searching ? "Searching..." : "Search")</button>
+        <button class="usa-button" type="submit" id="query-form-search-btn" disabled="@(searching || !canPerformSearch)">@(searching ? "Searching..." : "Search")</button>
     </UsaForm>
 }
-@if (QueryResult?.Data?.Results?.Count > 0 && QueryResult.Data.Results[0].Matches?.Count() > 0)
+@if (QueryFormData.QueryResult?.Results?.Count > 0 && QueryFormData.QueryResult.Results[0].Matches?.Count() > 0)
 {
-    <QueryResults QueryResult="QueryResult.Data" />
+    <QueryResults QueryResult="QueryFormData.QueryResult" />
 }
 else {
     <section class="border-top-1px border-base-light margin-top-6"></section>

--- a/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
@@ -22,6 +22,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
+        QueryFormData ??= new();
         if (QueryFormData.ServerErrors?.Count > 0)
         {
             serverErrorList = new(QueryFormData.ServerErrors.Select(n => (n.Property, n.Error)));

--- a/query-tool/src/Piipan.QueryTool.Client/Models/MatchSearchRequest.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Models/MatchSearchRequest.cs
@@ -1,5 +1,5 @@
-﻿using Piipan.Components.Validation;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
+using Piipan.Components.Validation;
 using static Piipan.Components.Validation.ValidationConstants;
 
 namespace Piipan.QueryTool.Client.Models

--- a/query-tool/src/Piipan.QueryTool.Client/Models/PiiRecord.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Models/PiiRecord.cs
@@ -1,7 +1,7 @@
-﻿using Piipan.Components.Validation;
-using System;
+﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Piipan.Components.Validation;
 using static Piipan.Components.Validation.ValidationConstants;
 namespace Piipan.QueryTool.Client.Models
 {

--- a/query-tool/src/Piipan.QueryTool.Client/Models/QueryFormModel.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Models/QueryFormModel.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Piipan.Match.Api.Models;
+
+namespace Piipan.QueryTool.Client.Models
+{
+    public class QueryFormModel
+    {
+        public PiiRecord Query { get; set; } = new();
+
+        /// <summary>
+        /// The search response that is collected after the user hits "Search" and an API call is made
+        /// </summary>
+        public OrchMatchResponseData QueryResult { get; set; }
+        public string Token { get; set; }
+        public List<ServerError> ServerErrors { get; set; } = new();
+        public string Location { get; set; }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool.Client/Program.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Program.cs
@@ -1,7 +1,7 @@
-using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net.Http;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 

--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -5,8 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
 using Piipan.Shared.Locations;
-using System;
-using System.Linq;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -28,7 +28,7 @@ namespace Piipan.QueryTool.Pages
                 (!context.HandlerMethod?.MethodInfo.CustomAttributes.Any(n => n.AttributeType == typeof(IgnoreAuthorizationAttribute)) ?? false))
             {
                 context.HttpContext.Response.StatusCode = 403;
-                context.Result = RedirectToPage(NotAuthorizedPageName);
+                context.Result = RedirectToUnauthorized();
             }
         }
 

--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -52,6 +52,8 @@ namespace Piipan.QueryTool.Pages
             get { return _locationsProvider.GetStates(Location); }
         }
 
+        public bool IsNationalOffice => States?.Contains("*") ?? false;
+
         public string Role
         {
             get { return _claimsProvider.GetRole(User); }

--- a/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Piipan.Shared.Authorization;
-using Piipan.Shared.Claims;
+using System;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -10,8 +10,8 @@ namespace Piipan.QueryTool.Pages
         public string Message = "";
 
         public ErrorModel(ILogger<ErrorModel> logger,
-            IClaimsProvider claimsProvider)
-                          : base(claimsProvider)
+            IServiceProvider serviceProvider)
+                          : base(serviceProvider)
         {
             _logger = logger;
         }

--- a/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
@@ -1,6 +1,6 @@
+using System;
 using Microsoft.Extensions.Logging;
 using Piipan.Shared.Authorization;
-using System;
 
 namespace Piipan.QueryTool.Pages
 {

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
@@ -7,11 +7,11 @@
 @inject IAntiforgery antiforgery
 @{
     ViewData["Title"] = "NAC Participant Search";
+
+    Model.QueryFormData.Token = antiforgery.GetAndStoreTokens(HttpContext).RequestToken;
+    Model.QueryFormData.Location = Model.Location;
 }
 <section class="grid-container">
     <component type="typeof(QueryTool.Client.Components.QueryForm)" render-mode="WebAssembly"
-        param-Query="Model.Query"
-        param-QueryResult="ParameterBase<OrchMatchResponseData>.FromObject(Model.QueryResult?.Data)" 
-        param-Token="antiforgery.GetAndStoreTokens(HttpContext).RequestToken"
-        param-ServerErrors="Model.RequestErrors" />
+        param-QueryFormData="Model.QueryFormData" />
 </section>

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml
@@ -8,6 +8,7 @@
 @{
     ViewData["Title"] = "NAC Participant Search";
 
+    Model.QueryFormData ??= new();
     Model.QueryFormData.Token = antiforgery.GetAndStoreTokens(HttpContext).RequestToken;
     Model.QueryFormData.Location = Model.Location;
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -28,10 +28,11 @@ namespace Piipan.QueryTool.Pages
         }
 
         [BindProperty]
-        public QueryFormModel QueryFormData { get; set; } = new QueryFormModel();
+        public QueryFormModel QueryFormData { get; } = new QueryFormModel();
 
         public async Task<IActionResult> OnPostAsync()
         {
+            // Only locations with length 2, which are states, can perform a search.
             if (Location.Length != 2 || States?.Length != 1)
             {
                 QueryFormData.ServerErrors.Add(new("", "Search performed with an invalid location"));

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -1,14 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.QueryTool.Client.Models;
-using Piipan.Shared.Claims;
 using Piipan.Shared.Deidentification;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -19,10 +17,10 @@ namespace Piipan.QueryTool.Pages
         private readonly IMatchApi _matchApi;
 
         public IndexModel(ILogger<IndexModel> logger,
-                          IClaimsProvider claimsProvider,
                           ILdsDeidentifier ldsDeidentifier,
-                          IMatchApi matchApi)
-                          : base(claimsProvider)
+                          IMatchApi matchApi,
+                          IServiceProvider serviceProvider)
+                          : base(serviceProvider)
         {
             _logger = logger;
             _ldsDeidentifier = ldsDeidentifier;
@@ -30,38 +28,43 @@ namespace Piipan.QueryTool.Pages
         }
 
         [BindProperty]
-        public PiiRecord Query { get; set; } = new PiiRecord();
-        public OrchMatchResponse QueryResult { get; private set; }
-        public List<ServerError> RequestErrors { get; } = new();
-        public bool NoResults = false;
+        public QueryFormModel QueryFormData { get; set; } = new QueryFormModel();
 
         public async Task<IActionResult> OnPostAsync()
         {
-            if (ModelState.IsValid)
+            if (Location.Length != 2 || States?.Length != 1)
+            {
+                QueryFormData.ServerErrors.Add(new("", "Search performed with an invalid location"));
+            }
+            else if (ModelState.IsValid)
             {
                 try
                 {
                     _logger.LogInformation("Query form submitted");
 
                     string digest = _ldsDeidentifier.Run(
-                        Query.LastName,
-                        Query.DateOfBirth.Value.ToString("yyyy-MM-dd"),
-                        Query.SocialSecurityNum
+                        QueryFormData.Query.LastName,
+                        QueryFormData.Query.DateOfBirth.Value.ToString("yyyy-MM-dd"),
+                        QueryFormData.Query.SocialSecurityNum
                     );
 
                     var request = new OrchMatchRequest
                     {
                         Data = new List<RequestPerson>
                         {
-                            new RequestPerson { LdsHash = digest, CaseId = Query.CaseId, ParticipantId = Query.ParticipantId, SearchReason = "other" }
+                            new RequestPerson
+                            {
+                                LdsHash = digest,
+                                CaseId = QueryFormData.Query.CaseId,
+                                ParticipantId = QueryFormData.Query.ParticipantId,
+                                SearchReason = "other"
+                            }
                         }
                     };
 
-                    var response = await _matchApi.FindMatches(request, "ea");
+                    var response = await _matchApi.FindMatches(request, States[0].ToLower());
 
-                    QueryResult = response;
-                    NoResults = QueryResult.Data.Results.Count == 0 ||
-                        QueryResult.Data.Results[0].Matches.Count() == 0;
+                    QueryFormData.QueryResult = response?.Data;
 
                     Title = "NAC Query Results";
                 }
@@ -70,17 +73,17 @@ namespace Piipan.QueryTool.Pages
                     _logger.LogError(ex, ex.Message);
                     if (ex.Message.ToLower().Contains("gregorian"))
                     {
-                        RequestErrors.Add(new("", "Date of birth must be a real date."));
+                        QueryFormData.ServerErrors.Add(new("", "Date of birth must be a real date."));
                     }
                     else
                     {
-                        RequestErrors.Add(new("", ex.Message));
+                        QueryFormData.ServerErrors.Add(new("", ex.Message));
                     }
                 }
                 catch (Exception exception)
                 {
                     _logger.LogError(exception, exception.Message);
-                    RequestErrors.Add(new("", "There was an error running your search. Please try again."));
+                    QueryFormData.ServerErrors.Add(new("", "There was an error running your search. Please try again."));
                 }
             }
             else
@@ -91,7 +94,7 @@ namespace Piipan.QueryTool.Pages
                     if (ModelState[key]?.Errors?.Count > 0)
                     {
                         var error = ModelState[key].Errors[0];
-                        RequestErrors.Add(new(key, error.ErrorMessage));
+                        QueryFormData.ServerErrors.Add(new(key, error.ErrorMessage));
                     }
                 }
             }

--- a/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Index.cshtml.cs
@@ -28,7 +28,7 @@ namespace Piipan.QueryTool.Pages
         }
 
         [BindProperty]
-        public QueryFormModel QueryFormData { get; } = new QueryFormModel();
+        public QueryFormModel QueryFormData { get; set; } = new QueryFormModel();
 
         public async Task<IActionResult> OnPostAsync()
         {

--- a/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Piipan.QueryTool.Pages
 {

--- a/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -31,7 +30,7 @@ namespace Piipan.QueryTool.Pages
 
         public async Task<IActionResult> OnGet()
         {
-            if (!States?.Contains("*") ?? true)
+            if (!IsNationalOffice)
             {
                 return RedirectToUnauthorized();
             }

--- a/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/List.cshtml.cs
@@ -3,8 +3,9 @@ using Microsoft.Extensions.Logging;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
-using Piipan.Shared.Claims;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Piipan.QueryTool.Pages
@@ -19,9 +20,9 @@ namespace Piipan.QueryTool.Pages
         public List<ServerError> RequestErrors { get; private set; } = new();
 
         public ListModel(ILogger<ListModel> logger
-                           , IClaimsProvider claimsProvider
-                           , IMatchResolutionApi matchResolutionApi)
-                           : base(claimsProvider)
+                           , IMatchResolutionApi matchResolutionApi
+                           , IServiceProvider serviceProvider)
+                          : base(serviceProvider)
 
         {
             _logger = logger;
@@ -30,6 +31,10 @@ namespace Piipan.QueryTool.Pages
 
         public async Task<IActionResult> OnGet()
         {
+            if (!States?.Contains("*") ?? true)
+            {
+                return RedirectToUnauthorized();
+            }
             AvailableMatches = await _matchResolutionApi.GetMatches();
 
             return Page();

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
-using Piipan.Shared.Claims;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -25,9 +24,9 @@ namespace Piipan.QueryTool.Pages
         public List<ServerError> RequestErrors { get; private set; } = new();
 
         public MatchModel(ILogger<MatchModel> logger
-                           , IClaimsProvider claimsProvider
-                           , IMatchResolutionApi matchResolutionApi)
-                           : base(claimsProvider)
+                           , IMatchResolutionApi matchResolutionApi
+                           , IServiceProvider serviceProvider)
+                          : base(serviceProvider)
 
         {
             _logger = logger;

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
@@ -1,12 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
-using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Piipan.QueryTool.Pages
 {

--- a/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Piipan.Shared.Authorization;
-using Piipan.Shared.Claims;
+using System;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -7,15 +9,17 @@ namespace Piipan.QueryTool.Pages
     {
         public string Message = "";
 
-        public NotAuthorizedModel(IClaimsProvider claimsProvider)
-                          : base(claimsProvider)
+        public NotAuthorizedModel(IServiceProvider serviceProvider)
+                          : base(serviceProvider)
         {
         }
 
         [IgnoreAuthorization]
-        public void OnGet()
+        public IActionResult OnGet()
         {
-            Message = "You do not have sufficient roles or a location associated with your account";
+            Message = "You do not have a sufficient role or location to access this page";
+            return new PageResult { StatusCode = 403 };
+
         }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
@@ -1,7 +1,7 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Piipan.Shared.Authorization;
-using System;
 
 namespace Piipan.QueryTool.Pages
 {

--- a/query-tool/src/Piipan.QueryTool/Pages/SignedOut.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/SignedOut.cshtml.cs
@@ -1,11 +1,11 @@
-using Piipan.Shared.Claims;
+using System;
 
 namespace Piipan.QueryTool.Pages
 {
     public class SignedOutModel : BasePageModel
     {
-        public SignedOutModel(IClaimsProvider claimsProvider)
-            : base(claimsProvider)
+        public SignedOutModel(IServiceProvider serviceProvider)
+                          : base(serviceProvider)
         {
 
         }

--- a/query-tool/src/Piipan.QueryTool/Program.cs
+++ b/query-tool/src/Piipan.QueryTool/Program.cs
@@ -1,13 +1,8 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.AzureAppServices;
 
 namespace Piipan.QueryTool

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -13,8 +15,6 @@ using Piipan.Shared.Claims;
 using Piipan.Shared.Deidentification;
 using Piipan.Shared.Locations;
 using Piipan.Shared.Logging;
-using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Piipan.QueryTool
 {

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -11,6 +11,7 @@ using Piipan.QueryTool.Binders;
 using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
 using Piipan.Shared.Deidentification;
+using Piipan.Shared.Locations;
 using Piipan.Shared.Logging;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -32,7 +33,9 @@ namespace Piipan.QueryTool
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<LocationOptions>(Configuration.GetSection(LocationOptions.SectionName));
             services.Configure<ClaimsOptions>(Configuration.GetSection(ClaimsOptions.SectionName));
+
 
             services.Configure<ForwardedHeadersOptions>(options =>
             {
@@ -59,6 +62,7 @@ namespace Piipan.QueryTool
             });
 
             services.AddTransient<IClaimsProvider, ClaimsProvider>();
+            services.AddTransient<ILocationsProvider, LocationsProvider>();
 
             services.AddSingleton<INameNormalizer, NameNormalizer>();
             services.AddSingleton<IDobNormalizer, DobNormalizer>();

--- a/query-tool/src/Piipan.QueryTool/appsettings.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.json
@@ -12,6 +12,18 @@
         "LocationPrefix": "Location-",
         "RolePrefix": "Role-"
     },
+    "Locations": {
+        "Map": [
+            {
+                "Name": "National",
+                "States": [ "*" ]
+            },
+            {
+                "Name": "Midwest",
+                "States": [ "WI", "IA", "MN" ]
+            }
+        ]
+    },
   "AuthorizationPolicy": {
     "RequiredClaims": []
   },

--- a/query-tool/src/Piipan.QueryTool/cypress/integration/match-list.spec.js
+++ b/query-tool/src/Piipan.QueryTool/cypress/integration/match-list.spec.js
@@ -19,7 +19,6 @@ describe('query tool match query', () => {
         cy.contains('Match ID').should('be.visible');
         cy.contains('Matching States').should('be.visible');
 
-        setupPa11yPost();
         cy.pa11y(pa11yOptions);
     });
 })

--- a/query-tool/src/Piipan.QueryTool/cypress/integration/match-query.spec.js
+++ b/query-tool/src/Piipan.QueryTool/cypress/integration/match-query.spec.js
@@ -64,9 +64,9 @@ describe('query tool match query', () => {
     it("shows results table on successful submission with a match", () => {
         cy.visit('/');
         cy.get('#query-form-search-btn', { timeout: 10000 }).should('be.visible');
-        setValue('#Query_LastName', 'Farrington');
-        setValue('#Query_DateOfBirth', '1931-10-13');
-        setValue('#Query_SocialSecurityNum', '425-46-5417');
+        setValue('#QueryFormData_Query_LastName', 'Farrington');
+        setValue('#QueryFormData_Query_DateOfBirth', '1931-10-13');
+        setValue('#QueryFormData_Query_SocialSecurityNum', '425-46-5417');
         cy.get('#query-form-search-btn').click();
 
         cy.get('#query-results-area tbody tr td a').invoke('text').then(matchId => {

--- a/query-tool/src/Piipan.QueryTool/cypress/integration/participant-query.spec.js
+++ b/query-tool/src/Piipan.QueryTool/cypress/integration/participant-query.spec.js
@@ -4,7 +4,7 @@ describe('query tool match query', () => {
     beforeEach(() => {
         pa11yOptions = {
             actions: [
-                'wait for element #Query_SocialSecurityNum to be added'
+                'wait for element #QueryFormData_Query_SocialSecurityNum to be added'
             ],
             standard: 'WCAG2AA',
             runners: [
@@ -18,9 +18,9 @@ describe('query tool match query', () => {
     it('shows required field errors when form is submitted with no data', () => {
         cy.get('form').submit();
 
-        cy.get('#Query_LastName-message').contains('Last Name is required').should('be.visible');
-        cy.get('#Query_DateOfBirth-message').contains('Date of Birth is required').should('be.visible');
-        cy.get('#Query_SocialSecurityNum-message').contains('Social Security Number is required').should('be.visible');
+        cy.get('#QueryFormData_Query_LastName-message').contains('Last Name is required').should('be.visible');
+        cy.get('#QueryFormData_Query_DateOfBirth-message').contains('Date of Birth is required').should('be.visible');
+        cy.get('#QueryFormData_Query_SocialSecurityNum-message').contains('Social Security Number is required').should('be.visible');
 
         // make sure pa11y runs successfully when errors are shown
         pa11yOptions.actions.push('click element #query-form-search-btn');
@@ -28,8 +28,8 @@ describe('query tool match query', () => {
     });
 
     it("shows formatting error for incorrect SSN", () => {
-        cy.get('#Query_SocialSecurityNum').type("12345").blur();
-        cy.get('#Query_SocialSecurityNum-message').contains('Social Security Number must have the form ###-##-####').should('be.visible');
+        cy.get('#QueryFormData_Query_SocialSecurityNum').type("12345").blur();
+        cy.get('#QueryFormData_Query_SocialSecurityNum-message').contains('Social Security Number must have the form ###-##-####').should('be.visible');
 
         cy.get('form').submit();
 
@@ -37,25 +37,25 @@ describe('query tool match query', () => {
     });
 
     it("shows proper error for too old dates of birth", () => {
-        cy.get('#Query_DateOfBirth').type("1899-12-31").blur();
-        cy.get('#Query_DateOfBirth-message').contains('Date of Birth must be between 01-01-1900 and today\'s date').should('be.visible');
+        cy.get('#QueryFormData_Query_DateOfBirth').type("1899-12-31").blur();
+        cy.get('#QueryFormData_Query_DateOfBirth-message').contains('Date of Birth must be between 01-01-1900 and today\'s date').should('be.visible');
         cy.get('form').submit();
 
         cy.get('.usa-alert').contains('Date of Birth must be between 01-01-1900 and today\'s date').should('be.visible');
     });
 
     it("shows proper error for non-ascii characters in last name", () => {
-        cy.get('#Query_LastName').type("garcía").blur();
-        cy.get('#Query_LastName-message').contains('Change í in garcía').should('be.visible');
+        cy.get('#QueryFormData_Query_LastName').type("garcía").blur();
+        cy.get('#QueryFormData_Query_LastName-message').contains('Change í in garcía').should('be.visible');
         cy.get('form').submit();
 
         cy.get('.usa-alert').contains('Change í in garcía').should('be.visible');
     });
 
     it("shows an empty state on successful submission without match", () => {
-        cy.get('#Query_LastName').type("schmo");
-        cy.get('#Query_DateOfBirth').type("1997-01-01");
-        cy.get('#Query_SocialSecurityNum').type("550-01-6981");
+        cy.get('#QueryFormData_Query_LastName').type("schmo");
+        cy.get('#QueryFormData_Query_DateOfBirth').type("1997-01-01");
+        cy.get('#QueryFormData_Query_SocialSecurityNum').type("550-01-6981");
 
         cy.get('form').submit();
 
@@ -66,9 +66,9 @@ describe('query tool match query', () => {
     });
 
     it("shows results table on successful submission with a match", () => {
-        setValue('#Query_LastName', 'Farrington');
-        setValue('#Query_DateOfBirth', '1931-10-13');
-        setValue('#Query_SocialSecurityNum', '425-46-5417');
+        setValue('#QueryFormData_Query_LastName', 'Farrington');
+        setValue('#QueryFormData_Query_DateOfBirth', '1931-10-13');
+        setValue('#QueryFormData_Query_SocialSecurityNum', '425-46-5417');
         cy.get('#query-form-search-btn').click();
 
         cy.contains('Match ID').should('be.visible');

--- a/query-tool/tests/Piipan.QueryTool.Tests/BaseComponentTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/BaseComponentTest.cs
@@ -1,7 +1,7 @@
-﻿using Bunit;
-using Microsoft.AspNetCore.Components;
-using System;
+﻿using System;
 using System.Linq.Expressions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
 
 namespace Piipan.QueryTool.Tests
 {

--- a/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Moq;
 using Piipan.QueryTool.Pages;
 using Piipan.Shared.Claims;
+using Piipan.Shared.Locations;
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
@@ -16,20 +17,28 @@ namespace Piipan.QueryTool.Tests
 {
     public class BasePageTest
     {
-        public static IClaimsProvider claimsProviderMock(string email = "noreply@tts.test",
-            string state = "IA", string role = "Worker")
+        public static IServiceProvider serviceProviderMock(string email = "noreply@tts.test",
+            string location = "IA", string role = "Worker", string[] states = null)
         {
+            var serviceProviderMock = new Mock<IServiceProvider>();
+
             var claimsProviderMock = new Mock<IClaimsProvider>();
             claimsProviderMock
                 .Setup(c => c.GetEmail(It.IsAny<ClaimsPrincipal>()))
                 .Returns(email);
             claimsProviderMock
-                .Setup(c => c.GetState(It.IsAny<ClaimsPrincipal>()))
-                .Returns(state);
+                .Setup(c => c.GetLocation(It.IsAny<ClaimsPrincipal>()))
+                .Returns(location);
             claimsProviderMock
                 .Setup(c => c.GetRole(It.IsAny<ClaimsPrincipal>()))
                 .Returns(role);
-            return claimsProviderMock.Object;
+
+            var locationProviderMock = new Mock<ILocationsProvider>();
+            locationProviderMock.Setup(c => c.GetStates(It.IsAny<string>())).Returns(states ?? new string[] { location });
+
+            serviceProviderMock.Setup(c => c.GetService(typeof(IClaimsProvider))).Returns(claimsProviderMock.Object);
+            serviceProviderMock.Setup(c => c.GetService(typeof(ILocationsProvider))).Returns(locationProviderMock.Object);
+            return serviceProviderMock.Object;
         }
 
         protected static HttpContext contextMock()

--- a/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -9,9 +12,6 @@ using Moq;
 using Piipan.QueryTool.Pages;
 using Piipan.Shared.Claims;
 using Piipan.Shared.Locations;
-using System;
-using System.Collections.Generic;
-using System.Security.Claims;
 
 namespace Piipan.QueryTool.Tests
 {

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchFormTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchFormTests.cs
@@ -1,12 +1,12 @@
-﻿using Bunit;
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Bunit;
 using Piipan.Components.Alerts;
 using Piipan.Components.Forms;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Components;
 using Piipan.QueryTool.Client.Models;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Xunit;
 using static Piipan.Components.Forms.FormConstants;
 using static Piipan.Components.Validation.ValidationConstants;

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
@@ -205,7 +205,7 @@ namespace Piipan.QueryTool.Tests.Components
         }
 
         /// <summary>
-        /// Verify that when searching an invalid form that the button text does not change to "Searching..."
+        /// Verify that when you don't have a state location that the button is disabled
         /// </summary>
         [Fact]
         public void Button_Should_Not_Be_Enabled_When_Location_Is_Not_A_State()

--- a/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging.Abstractions;
 using Piipan.QueryTool.Pages;
-using Piipan.Shared.Claims;
+using System;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests
@@ -13,8 +13,8 @@ namespace Piipan.QueryTool.Tests
         public void TestBeforeOnGet()
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock();
-            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), mockClaimsProvider);
+            var mockServiceProvider = serviceProviderMock();
+            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), mockServiceProvider);
 
             // act
 
@@ -26,8 +26,8 @@ namespace Piipan.QueryTool.Tests
         public void TestMessageOnGet()
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock();
-            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), mockClaimsProvider);
+            var mockServiceProvider = serviceProviderMock();
+            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), mockServiceProvider);
 
             // act
             string message = "test message";
@@ -46,9 +46,9 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(ErrorModel.OnGet), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
+            var mockServiceProvider = serviceProviderMock(location: location, role: role);
 
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
+            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockServiceProvider, method);
 
             if (!isAuthorized)
             {
@@ -61,9 +61,9 @@ namespace Piipan.QueryTool.Tests
             }
         }
 
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IClaimsProvider claimsProvider, string methodName)
+        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider serviceProvider, string methodName)
         {
-            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), claimsProvider);
+            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), serviceProvider);
 
             return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }

--- a/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
@@ -1,8 +1,8 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging.Abstractions;
 using Piipan.QueryTool.Pages;
-using System;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests

--- a/query-tool/tests/Piipan.QueryTool.Tests/Extensions/ModelStateExtensions.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Extensions/ModelStateExtensions.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Piipan.QueryTool.Tests.Extensions
 {

--- a/query-tool/tests/Piipan.QueryTool.Tests/Extensions/ParticipantExtensionsTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Extensions/ParticipantExtensionsTests.cs
@@ -1,9 +1,9 @@
+using System;
+using System.Collections.Generic;
 using Moq;
 using Piipan.Participants.Api.Models;
 using Piipan.QueryTool.Extensions;
 using Piipan.Shared.API.Utilities;
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 #nullable enable

--- a/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -7,9 +10,6 @@ using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Pages;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests

--- a/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
@@ -7,7 +7,7 @@ using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Pages;
-using Piipan.Shared.Claims;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -22,12 +22,12 @@ namespace Piipan.QueryTool.Tests
         public void TestBeforeOnGet()
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock();
+            var mockServiceProvider = serviceProviderMock();
             var mockMatchApi = Mock.Of<IMatchResolutionApi>();
             var pageModel = new ListModel(
                 new NullLogger<ListModel>(),
-                mockClaimsProvider,
-                mockMatchApi
+                mockMatchApi,
+                mockServiceProvider
             );
 
             // act
@@ -37,10 +37,10 @@ namespace Piipan.QueryTool.Tests
         }
 
         [Fact]
-        public async Task Test_Get()
+        public async Task Test_Get_Accessible()
         {
             // arrange
-            var pageModel = SetupMatchModel();
+            var pageModel = SetupMatchModel("National", new string[] { "*" });
             pageModel.PageContext.HttpContext = contextMock();
 
             // act
@@ -59,6 +59,20 @@ namespace Piipan.QueryTool.Tests
                 Assert.Empty(list[i].Participants);
                 Assert.Equal(new string[] { "ea", "eb" }, list[i].States);
             }
+        }
+
+        [Fact]
+        public async Task Test_Get_Unauthorized_Location()
+        {
+            // arrange
+            var pageModel = SetupMatchModel("IA");
+            pageModel.PageContext.HttpContext = contextMock();
+
+            // act
+            var result = await pageModel.OnGet();
+
+            // assert
+            Assert.IsType<RedirectToPageResult>(result);
         }
 
         private Mock<IMatchResolutionApi> SetupMatchResolutionApi()
@@ -80,15 +94,15 @@ namespace Piipan.QueryTool.Tests
             return mockMatchApi;
         }
 
-        private ListModel SetupMatchModel(Mock<IMatchResolutionApi> mockMatchApi = null)
+        private ListModel SetupMatchModel(string location, string[] states = null, Mock<IMatchResolutionApi> mockMatchApi = null)
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock();
+            var mockServiceProvider = serviceProviderMock(location: location, states: states);
             mockMatchApi ??= SetupMatchResolutionApi();
             var pageModel = new ListModel(
                 new NullLogger<ListModel>(),
-                mockClaimsProvider,
-                mockMatchApi.Object
+                mockMatchApi.Object,
+                mockServiceProvider
             );
             return pageModel;
         }
@@ -100,9 +114,9 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(ListModel.OnGet), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
+            var mockServiceProvider = serviceProviderMock(location: location, role: role);
 
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
+            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockServiceProvider, method);
 
             if (!isAuthorized)
             {
@@ -115,13 +129,13 @@ namespace Piipan.QueryTool.Tests
             }
         }
 
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IClaimsProvider claimsProvider, string methodName)
+        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider mockServiceProvider, string methodName)
         {
             var mockMatchApi = Mock.Of<IMatchResolutionApi>();
             var pageModel = new ListModel(
                 new NullLogger<ListModel>(),
-                claimsProvider,
-                mockMatchApi
+                mockMatchApi,
+                mockServiceProvider
             );
 
             return base.GetPageHandlerExecutingContext(pageModel, methodName);

--- a/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
@@ -9,7 +9,7 @@ using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
 using Piipan.QueryTool.Pages;
 using Piipan.QueryTool.Tests.Extensions;
-using Piipan.Shared.Claims;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
@@ -236,7 +236,7 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(MatchModel.OnPost), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
+            var mockClaimsProvider = serviceProviderMock(location: location, role: role);
 
             var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
 
@@ -251,22 +251,22 @@ namespace Piipan.QueryTool.Tests
             }
         }
 
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IClaimsProvider claimsProvider, string methodName)
+        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider serviceProvider, string methodName)
         {
-            var pageModel = SetupMatchModel(mockClaimsProvider: claimsProvider);
+            var pageModel = SetupMatchModel(mockServiceProvider: serviceProvider);
 
             return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }
 
-        private MatchModel SetupMatchModel(Mock<IMatchResolutionApi> mockMatchApi = null, IClaimsProvider mockClaimsProvider = null)
+        private MatchModel SetupMatchModel(Mock<IMatchResolutionApi> mockMatchApi = null, IServiceProvider mockServiceProvider = null)
         {
             // arrange
-            mockClaimsProvider ??= claimsProviderMock();
+            mockServiceProvider ??= serviceProviderMock();
             mockMatchApi ??= SetupMatchResolutionApi();
             var pageModel = new MatchModel(
                 new NullLogger<MatchModel>(),
-                mockClaimsProvider,
-                mockMatchApi.Object
+                mockMatchApi.Object,
+                mockServiceProvider
             );
             return pageModel;
         }

--- a/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -9,9 +12,6 @@ using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
 using Piipan.QueryTool.Pages;
 using Piipan.QueryTool.Tests.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Xunit;
 using static Piipan.Components.Validation.ValidationConstants;
 

--- a/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Piipan.QueryTool.Pages;
-using System;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests

--- a/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Piipan.QueryTool.Pages;
-using Piipan.Shared.Claims;
+using System;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests
@@ -12,8 +12,8 @@ namespace Piipan.QueryTool.Tests
         public void TestBeforeOnGet()
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock();
-            var pageModel = new NotAuthorizedModel(mockClaimsProvider);
+            var mockServiceProvider = serviceProviderMock();
+            var pageModel = new NotAuthorizedModel(mockServiceProvider);
 
             // act
 
@@ -25,13 +25,13 @@ namespace Piipan.QueryTool.Tests
         public void TestMessageOnGet()
         {
             // arrange
-            var mockClaimsProvider = claimsProviderMock();
-            var pageModel = new NotAuthorizedModel(mockClaimsProvider);
+            var mockServiceProvider = serviceProviderMock();
+            var pageModel = new NotAuthorizedModel(mockServiceProvider);
 
             // act
             pageModel.OnGet();
             // assert
-            Assert.Equal("You do not have sufficient roles or a location associated with your account", pageModel.Message);
+            Assert.Equal("You do not have a sufficient role or location to access this page", pageModel.Message);
         }
 
         /// <summary>
@@ -44,9 +44,9 @@ namespace Piipan.QueryTool.Tests
         [InlineData(nameof(NotAuthorizedModel.OnGet), "IA", "Worker", true)]
         public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
         {
-            var mockClaimsProvider = claimsProviderMock(state: location, role: role);
+            var mockServiceProvider = serviceProviderMock(location: location, role: role);
 
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
+            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockServiceProvider, method);
 
             if (!isAuthorized)
             {
@@ -59,9 +59,9 @@ namespace Piipan.QueryTool.Tests
             }
         }
 
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IClaimsProvider claimsProvider, string methodName)
+        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider serviceProvider, string methodName)
         {
-            var pageModel = new NotAuthorizedModel(claimsProvider);
+            var pageModel = new NotAuthorizedModel(serviceProvider);
 
             return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }

--- a/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
+++ b/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
@@ -25,14 +25,14 @@ namespace Piipan.Shared.Claims
                 .Value;
         }
 
-        public string GetState(ClaimsPrincipal claimsPrincipal)
+        public string GetLocation(ClaimsPrincipal claimsPrincipal)
         {
             foreach (var identity in claimsPrincipal.Identities)
             {
-                var stateClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.LocationPrefix));
-                if (stateClaim != null)
+                var locationClaim = identity.Claims.FirstOrDefault(c => c.Type == _options.Role && c.Value.StartsWith(_options.LocationPrefix));
+                if (locationClaim != null)
                 {
-                    return stateClaim.Value.Substring(_options.LocationPrefix.Length);
+                    return locationClaim.Value.Substring(_options.LocationPrefix.Length);
                 }
             }
             return null;

--- a/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
+++ b/shared/src/Piipan.Shared/Claims/ClaimsProvider.cs
@@ -1,7 +1,7 @@
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System.Linq;
 using System.Security.Claims;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Piipan.Shared.Claims
 {

--- a/shared/src/Piipan.Shared/Claims/IClaimsProvider.cs
+++ b/shared/src/Piipan.Shared/Claims/IClaimsProvider.cs
@@ -5,7 +5,7 @@ namespace Piipan.Shared.Claims
     public interface IClaimsProvider
     {
         string GetEmail(ClaimsPrincipal claimsPrincipal);
-        string GetState(ClaimsPrincipal claimsPrincipal);
+        string GetLocation(ClaimsPrincipal claimsPrincipal);
         string GetRole(ClaimsPrincipal claimsPrincipal);
     }
 }

--- a/shared/src/Piipan.Shared/Locations/ILocationsProvider.cs
+++ b/shared/src/Piipan.Shared/Locations/ILocationsProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Piipan.Shared.Locations
+{
+    public interface ILocationsProvider
+    {
+        string[] GetStates(string location);
+    }
+}

--- a/shared/src/Piipan.Shared/Locations/LocationOptions.cs
+++ b/shared/src/Piipan.Shared/Locations/LocationOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Piipan.Shared.Locations
+{
+    public class LocationOptions
+    {
+        public const string SectionName = "Locations";
+        public LocationMapping[] Map { get; set; }
+    }
+    public class LocationMapping
+    {
+        public string Name { get; set; }
+        public string[] States { get; set; }
+    }
+}

--- a/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
+++ b/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Options;
-using System.Linq;
+﻿using System.Linq;
+using Microsoft.Extensions.Options;
 
 namespace Piipan.Shared.Locations
 {

--- a/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
+++ b/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Options;
+using System.Linq;
+
+namespace Piipan.Shared.Locations
+{
+    public class LocationsProvider : ILocationsProvider
+    {
+        private readonly LocationOptions _options;
+
+        public LocationsProvider(IOptions<LocationOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        public string[] GetStates(string location)
+        {
+            var stateArray = _options.Map?.FirstOrDefault(n => n.Name == location)?.States?.ToArray();
+            if (stateArray == null && !string.IsNullOrEmpty(location))
+            {
+                return new string[] { location };
+            }
+            return stateArray;
+        }
+    }
+}

--- a/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
+++ b/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.Extensions.Options;
 
 namespace Piipan.Shared.Locations
@@ -19,7 +20,7 @@ namespace Piipan.Shared.Locations
             {
                 return new string[] { location };
             }
-            return stateArray;
+            return stateArray ?? Array.Empty<string>();
         }
     }
 }

--- a/shared/tests/Piipan.Shared.Tests/Claims/ClaimsProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Claims/ClaimsProviderTests.cs
@@ -61,7 +61,7 @@ namespace Piipan.Shared.Claims.Tests
         /// Verify we can grab the location from the roles claim
         /// </summary>
         [Fact]
-        public void GetState()
+        public void GetLocation()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -74,17 +74,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var state = claimsProvider.GetState(claimsPrincipal);
+            var location = claimsProvider.GetLocation(claimsPrincipal);
 
             // Assert
-            Assert.Equal("IA", state);
+            Assert.Equal("IA", location);
         }
 
         /// <summary>
         /// Verify that if the roles claim is not found, we do not grab a location
         /// </summary>
         [Fact]
-        public void GetState_RoleClaimNotFound()
+        public void GetLocation_RoleClaimNotFound()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -97,17 +97,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var state = claimsProvider.GetState(claimsPrincipal);
+            var location = claimsProvider.GetLocation(claimsPrincipal);
 
             // Assert
-            Assert.Null(state);
+            Assert.Null(location);
         }
 
         /// <summary>
         /// Verify that if a roles claim does exist, but a location value does not exist, we do not grab a location
         /// </summary>
         [Fact]
-        public void GetState_RoleClaimFound_LocationNotFound()
+        public void GetLocation_RoleClaimFound_LocationNotFound()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -120,17 +120,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var state = claimsProvider.GetState(claimsPrincipal);
+            var location = claimsProvider.GetLocation(claimsPrincipal);
 
             // Assert
-            Assert.Null(state);
+            Assert.Null(location);
         }
 
         /// <summary>
         /// When multiple locations exist, we just use the first one
         /// </summary>
         [Fact]
-        public void GetStateWhenMultipleLocationsExist()
+        public void GetLocationWhenMultipleLocationsExist()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -144,17 +144,17 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var state = claimsProvider.GetState(claimsPrincipal);
+            var location = claimsProvider.GetLocation(claimsPrincipal);
 
             // Assert
-            Assert.Equal("IA", state);
+            Assert.Equal("IA", location);
         }
 
         /// <summary>
-        /// When multiple role claims exist, we should take the state from the one that starts with the NAC Location prefix
+        /// When multiple role claims exist, we should take the location from the one that starts with the NAC Location prefix
         /// </summary>
         [Fact]
-        public void GetStateWhenMultipleRoleClaimsExist()
+        public void GetLocationWhenMultipleRoleClaimsExist()
         {
             // Arrange
             var logger = new Mock<ILogger<ClaimsProvider>>();
@@ -168,10 +168,10 @@ namespace Piipan.Shared.Claims.Tests
             }));
 
             // Act
-            var state = claimsProvider.GetState(claimsPrincipal);
+            var location = claimsProvider.GetLocation(claimsPrincipal);
 
             // Assert
-            Assert.Equal("IA", state);
+            Assert.Equal("IA", location);
         }
 
         /// <summary>

--- a/shared/tests/Piipan.Shared.Tests/Locations/LocationProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Locations/LocationProviderTests.cs
@@ -70,7 +70,7 @@ namespace Piipan.Shared.Locations.Tests
             var states = locationProvider.GetStates(null);
 
             // Assert
-            Assert.Null(states);
+            Assert.Empty(states);
         }
     }
 }

--- a/shared/tests/Piipan.Shared.Tests/Locations/LocationProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Locations/LocationProviderTests.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Piipan.Shared.Locations.Tests
+{
+    public class LocationProviderTests
+    {
+        LocationOptions locationOptions = new LocationOptions
+        {
+            Map = new LocationMapping[]
+            {
+                new LocationMapping { Name = "National", States = new[] { "*" }},
+                new LocationMapping { Name = "Midwest", States = new[] { "WI", "IA", "MN" }},
+            }
+        };
+
+        /// <summary>
+        /// Get the
+        /// </summary>
+        [Fact]
+        public void GetNationalStates()
+        {
+            // Arrange
+            var options = Options.Create(locationOptions);
+            var locationProvider = new LocationsProvider(options);
+
+            // Act
+            var states = locationProvider.GetStates("National");
+
+            // Assert
+            Assert.Equal(new string[] { "*" }, states);
+        }
+
+        [Fact]
+        public void GetMidwestStates()
+        {
+            // Arrange
+            var options = Options.Create(locationOptions);
+            var locationProvider = new LocationsProvider(options);
+
+            // Act
+            var states = locationProvider.GetStates("Midwest");
+
+            // Assert
+            Assert.Equal(new string[] { "WI", "IA", "MN" }, states);
+        }
+
+        [Fact]
+        public void GetSingleState()
+        {
+            // Arrange
+            var options = Options.Create(locationOptions);
+            var locationProvider = new LocationsProvider(options);
+
+            // Act
+            var states = locationProvider.GetStates("IA");
+
+            // Assert
+            Assert.Equal(new string[] { "IA" }, states);
+        }
+
+        [Fact]
+        public void GetNullState()
+        {
+            // Arrange
+            var options = Options.Create(locationOptions);
+            var locationProvider = new LocationsProvider(options);
+
+            // Act
+            var states = locationProvider.GetStates(null);
+
+            // Assert
+            Assert.Null(states);
+        }
+    }
+}


### PR DESCRIPTION
## What’s changing?

We are going to use the location claims to restrict access to a couple areas of the web application:

1. The search screen. The user will only be able to search if their location is a state, not a region or national office. That state will then be passed down to the API as their initiating state.
2. The match list screen. Only the national office will be able to view the match list screen.

Another small but purposeful change that was made to the view's model constructors was to accept a IServiceProvider instead of injecting everything as separate parameters. This makes code maintainability easier, as each subclass only needs to call `base(serviceProvider)` instead of passing in each injected instance. When new types are injected we no longer have to update each file, but instead only the base class.

## Why?

Closes 679 and 787

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
