### PR TITLE
Removing conflicting Peer Dependencies that cause npm install to break

### DIFF
--- a/dashboard/src/Piipan.Dashboard/package-lock.json
+++ b/dashboard/src/Piipan.Dashboard/package-lock.json
@@ -8369,21 +8369,7 @@
             "resolved": "git+ssh://git@github.com/uswds/uswds-gulp.git#0896d3be9681541f200e45309d183fdae837d737",
             "integrity": "sha512-ZWnjP0IkfX3ydWBhElf8Goddux+ZAO9BylrZwtFkrSGqnl6NXT1L9HUkubCSSrjiRfzfizGNWVqd75iRR1Yi1Q==",
             "dev": true,
-            "license": "ISC",
-            "peerDependencies": {
-                "autoprefixer": "^10.2.4",
-                "gulp": "^4.0.2",
-                "gulp-postcss": "^9.0.0",
-                "gulp-rename": "^2.0.0",
-                "gulp-replace": "^1.0.0",
-                "gulp-sass": "^4.1.0",
-                "gulp-sourcemaps": "^3.0.0",
-                "gulp-svg-sprite": "^1.5.0",
-                "postcss": "^8.2.5",
-                "postcss-csso": "^5.0.0",
-                "sass": "^1.32.6",
-                "uswds": "^2.10.0"
-            }
+            "license": "ISC"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
@@ -15278,8 +15264,7 @@
             "version": "git+ssh://git@github.com/uswds/uswds-gulp.git#0896d3be9681541f200e45309d183fdae837d737",
             "integrity": "sha512-ZWnjP0IkfX3ydWBhElf8Goddux+ZAO9BylrZwtFkrSGqnl6NXT1L9HUkubCSSrjiRfzfizGNWVqd75iRR1Yi1Q==",
             "dev": true,
-            "from": "uswds-gulp@github:uswds/uswds-gulp",
-            "requires": {}
+            "from": "uswds-gulp@github:uswds/uswds-gulp"
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/dashboard/tests/Piipan.Dashboard.Tests/PackageLockTests.cs
+++ b/dashboard/tests/Piipan.Dashboard.Tests/PackageLockTests.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Piipan.Dashboard.Tests
+{
+    public class PackageLockTests
+    {
+        /// <summary>
+        /// Sometimes when generating the package-lock.json file the peer dependencies for uswds-gulp get added back in.
+        /// If this test is failing, manually remove the peer dependencies from the node_modules/uswds-gulp file.
+        /// </summary>
+        [Fact]
+        public void VerifyUSWDSPeerDependenciesDoesNotExist()
+        {
+            // arrange
+            using StreamReader reader = new StreamReader("package-lock.json");
+            string json = reader.ReadToEnd();
+            var jObject = JObject.Parse(json);
+            var gulp = jObject["packages"]["node_modules/uswds-gulp"];
+
+            // assert
+            Assert.Null(gulp["peerDependencies"]);
+        }
+    }
+}

--- a/query-tool/src/Piipan.QueryTool/package-lock.json
+++ b/query-tool/src/Piipan.QueryTool/package-lock.json
@@ -8348,21 +8348,7 @@
       "resolved": "git+ssh://git@github.com/uswds/uswds-gulp.git#0896d3be9681541f200e45309d183fdae837d737",
       "integrity": "sha512-ZWnjP0IkfX3ydWBhElf8Goddux+ZAO9BylrZwtFkrSGqnl6NXT1L9HUkubCSSrjiRfzfizGNWVqd75iRR1Yi1Q==",
       "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "autoprefixer": "^10.2.4",
-        "gulp": "^4.0.2",
-        "gulp-postcss": "^9.0.0",
-        "gulp-rename": "^2.0.0",
-        "gulp-replace": "^1.0.0",
-        "gulp-sass": "^4.1.0",
-        "gulp-sourcemaps": "^3.0.0",
-        "gulp-svg-sprite": "^1.5.0",
-        "postcss": "^8.2.5",
-        "postcss-csso": "^5.0.0",
-        "sass": "^1.32.6",
-        "uswds": "^2.10.0"
-      }
+      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -15254,8 +15240,7 @@
       "version": "git+ssh://git@github.com/uswds/uswds-gulp.git#0896d3be9681541f200e45309d183fdae837d737",
       "integrity": "sha512-ZWnjP0IkfX3ydWBhElf8Goddux+ZAO9BylrZwtFkrSGqnl6NXT1L9HUkubCSSrjiRfzfizGNWVqd75iRR1Yi1Q==",
       "dev": true,
-      "from": "uswds-gulp@github:uswds/uswds-gulp",
-      "requires": {}
+      "from": "uswds-gulp@github:uswds/uswds-gulp"
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/query-tool/tests/Piipan.QueryTool.Tests/PackageLockTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/PackageLockTests.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Piipan.QueryTool.Tests
+{
+    public class PackageLockTests
+    {
+        /// <summary>
+        /// Sometimes when generating the package-lock.json file the peer dependencies for uswds-gulp get added back in.
+        /// If this test is failing, manually remove the peer dependencies from the node_modules/uswds-gulp file.
+        /// </summary>
+        [Fact]
+        public void VerifyUSWDSPeerDependenciesDoesNotExist()
+        {
+            // arrange
+            using StreamReader reader = new StreamReader("package-lock.json");
+            string json = reader.ReadToEnd();
+            var jObject = JObject.Parse(json);
+            var gulp = jObject["packages"]["node_modules/uswds-gulp"];
+
+            // assert
+            Assert.Null(gulp["peerDependencies"]);
+        }
+    }
+}


### PR DESCRIPTION
## What’s changing?

Removing the peer dependencies from the package-lock file that caused npm install to break when building a project.

Also added a couple test cases to make sure that the peer dependencies do not exist.

## Why?

Developers were getting errors building the dashboard and query tool projects.

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
