### PR TITLE
Commenting out pa11y tests that depend on API calls

### DIFF
--- a/query-tool/src/Piipan.QueryTool/cypress/integration/match-list.spec.js
+++ b/query-tool/src/Piipan.QueryTool/cypress/integration/match-list.spec.js
@@ -1,24 +1,26 @@
-﻿let pa11yOptions = {};
+﻿// Commented out for now. We need a long-term solution for end-to-end testing before these tests will work.
 
-describe('query tool match query', () => {
-    beforeEach(() => {
-        pa11yOptions = {
-            actions: [
-                'wait for element h1 to be added'
-            ],
-            standard: 'WCAG2AA',
-            runners: [
-                'htmlcs'
-            ],
-        };
-        cy.visit('/list');
-        cy.get('h1', { timeout: 10000 }).should('be.visible');
-    })
+//let pa11yOptions = {};
 
-    it("shows results table", () => {
-        cy.contains('Match ID').should('be.visible');
-        cy.contains('Matching States').should('be.visible');
+//describe('query tool match query', () => {
+//    beforeEach(() => {
+//        pa11yOptions = {
+//            actions: [
+//                'wait for element h1 to be added'
+//            ],
+//            standard: 'WCAG2AA',
+//            runners: [
+//                'htmlcs'
+//            ],
+//        };
+//        cy.visit('/list');
+//        cy.get('h1', { timeout: 10000 }).should('be.visible');
+//    })
 
-        cy.pa11y(pa11yOptions);
-    });
-})
+//    it("shows results table", () => {
+//        cy.contains('Match ID').should('be.visible');
+//        cy.contains('Matching States').should('be.visible');
+
+//        cy.pa11y(pa11yOptions);
+//    });
+//})

--- a/query-tool/src/Piipan.QueryTool/cypress/integration/match-query.spec.js
+++ b/query-tool/src/Piipan.QueryTool/cypress/integration/match-query.spec.js
@@ -34,6 +34,13 @@ describe('query tool match query', () => {
         cy.get('.usa-alert').contains('Match ID must be 7 characters').should('be.visible');
     });
 
+    it("server errors are shown and accessible", () => {
+        cy.get('#Query_MatchId').type("123$567").blur();
+
+        setupPa11yPost();
+        cy.pa11y(pa11yOptions);
+    });
+
     it("shows invalid characters error for match ID", () => {
         cy.get('#Query_MatchId').type("m12$345").blur();
         cy.get('#Query_MatchId-message').contains('Match ID contains invalid characters').should('be.visible');
@@ -43,45 +50,40 @@ describe('query tool match query', () => {
         cy.get('.usa-alert').contains('Match ID contains invalid characters').should('be.visible');
     });
 
-    it("shows an empty state on successful submission without match", () => {
-        cy.get('#Query_MatchId').type("1234567").blur();
+    // Commented out for now. We need a long-term solution for end-to-end testing before these tests will work.
 
-        cy.get('form').submit();
+    //it("shows an empty state on successful submission without match", () => {
+    //    cy.get('#Query_MatchId').type("1234567").blur();
 
-        cy.contains('This Match ID does not have a matching record in any other states.').should('be.visible');
+    //    cy.get('form').submit();
 
-        setupPa11yPost();
-        cy.pa11y(pa11yOptions);
-    });
+    //    cy.contains('This Match ID does not have a matching record in any other states.').should('be.visible');
 
-    it("server errors are shown and accessible", () => {
-        cy.get('#Query_MatchId').type("123$567").blur();
+    //    setupPa11yPost();
+    //    cy.pa11y(pa11yOptions);
+    //});
 
-        setupPa11yPost();
-        cy.pa11y(pa11yOptions);
-    });
+    //it("shows results table on successful submission with a match", () => {
+    //    cy.visit('/');
+    //    cy.get('#query-form-search-btn', { timeout: 10000 }).should('be.visible');
+    //    setValue('#QueryFormData_Query_LastName', 'Farrington');
+    //    setValue('#QueryFormData_Query_DateOfBirth', '1931-10-13');
+    //    setValue('#QueryFormData_Query_SocialSecurityNum', '425-46-5417');
+    //    cy.get('#query-form-search-btn').click();
 
-    it("shows results table on successful submission with a match", () => {
-        cy.visit('/');
-        cy.get('#query-form-search-btn', { timeout: 10000 }).should('be.visible');
-        setValue('#QueryFormData_Query_LastName', 'Farrington');
-        setValue('#QueryFormData_Query_DateOfBirth', '1931-10-13');
-        setValue('#QueryFormData_Query_SocialSecurityNum', '425-46-5417');
-        cy.get('#query-form-search-btn').click();
+    //    cy.get('#query-results-area tbody tr td a').invoke('text').then(matchId => {
+    //        cy.visit('/match');
+    //        cy.get('#match-form-search-btn', { timeout: 10000 }).should('be.visible');
+    //        cy.get('#Query_MatchId').type(matchId).blur();
+    //        cy.get('form').submit();
 
-        cy.get('#query-results-area tbody tr td a').invoke('text').then(matchId => {
-            cy.visit('/match');
-            cy.get('#match-form-search-btn', { timeout: 10000 }).should('be.visible');
-            cy.get('#Query_MatchId').type(matchId).blur();
-            cy.get('form').submit();
+    //        cy.contains('Match ID').should('be.visible');
+    //        cy.contains('Matching States').should('be.visible');
 
-            cy.contains('Match ID').should('be.visible');
-            cy.contains('Matching States').should('be.visible');
-
-            setupPa11yPost();
-            cy.pa11y(pa11yOptions);
-        });
-    });
+    //        setupPa11yPost();
+    //        cy.pa11y(pa11yOptions);
+    //    });
+    //});
 })
 
 function setValue(cssSelector, value) {

--- a/query-tool/src/Piipan.QueryTool/cypress/integration/participant-query.spec.js
+++ b/query-tool/src/Piipan.QueryTool/cypress/integration/participant-query.spec.js
@@ -52,31 +52,33 @@ describe('query tool match query', () => {
         cy.get('.usa-alert').contains('Change í in garcía').should('be.visible');
     });
 
-    it("shows an empty state on successful submission without match", () => {
-        cy.get('#QueryFormData_Query_LastName').type("schmo");
-        cy.get('#QueryFormData_Query_DateOfBirth').type("1997-01-01");
-        cy.get('#QueryFormData_Query_SocialSecurityNum').type("550-01-6981");
+    // Commented out for now. We need a long-term solution for end-to-end testing before these tests will work.
 
-        cy.get('form').submit();
+    //it("shows an empty state on successful submission without match", () => {
+    //    cy.get('#QueryFormData_Query_LastName').type("schmo");
+    //    cy.get('#QueryFormData_Query_DateOfBirth').type("1997-01-01");
+    //    cy.get('#QueryFormData_Query_SocialSecurityNum').type("550-01-6981");
 
-        cy.contains('This participant does not have a matching record in any other states.').should('be.visible');
+    //    cy.get('form').submit();
 
-        setupPa11yPost();
-        cy.pa11y(pa11yOptions);
-    });
+    //    cy.contains('This participant does not have a matching record in any other states.').should('be.visible');
 
-    it("shows results table on successful submission with a match", () => {
-        setValue('#QueryFormData_Query_LastName', 'Farrington');
-        setValue('#QueryFormData_Query_DateOfBirth', '1931-10-13');
-        setValue('#QueryFormData_Query_SocialSecurityNum', '425-46-5417');
-        cy.get('#query-form-search-btn').click();
+    //    setupPa11yPost();
+    //    cy.pa11y(pa11yOptions);
+    //});
 
-        cy.contains('Match ID').should('be.visible');
-        cy.contains('Matching State').should('be.visible');
+    //it("shows results table on successful submission with a match", () => {
+    //    setValue('#QueryFormData_Query_LastName', 'Farrington');
+    //    setValue('#QueryFormData_Query_DateOfBirth', '1931-10-13');
+    //    setValue('#QueryFormData_Query_SocialSecurityNum', '425-46-5417');
+    //    cy.get('#query-form-search-btn').click();
 
-        setupPa11yPost();
-        cy.pa11y(pa11yOptions);
-    });
+    //    cy.contains('Match ID').should('be.visible');
+    //    cy.contains('Matching State').should('be.visible');
+
+    //    setupPa11yPost();
+    //    cy.pa11y(pa11yOptions);
+    //});
 })
 
 function setValue(cssSelector, value) {


### PR DESCRIPTION
## What’s changing?

We don't have a way to call API calls yet from the nightly build. Full end-to-end testing is desired in the future, but will be a significant effort. Therefore we will just comment out the pa11y tests for now that rely on the API calls.

## Why?

Closes NAC-791

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
