### PR TITLE
Updated Participant Service tests to include a better exception test with the redaction serve

### DIFF
--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
@@ -88,11 +88,13 @@ namespace Piipan.Participants.Core.Services
 
             string[] redactedStrings = new string[3];
 
+            int redactionIndex = 0;
             try
             {
                 // for each participant, redact out their information from the current error string
                 foreach (var participant in participants)
                 {
+                    redactionIndex++;
                     redactedStrings[0] = participant.LdsHash;
                     redactedStrings[1] = participant.ParticipantId;
                     redactedStrings[2] = participant.CaseId;
@@ -103,6 +105,7 @@ namespace Piipan.Participants.Core.Services
             {
                 // If it still errors in here, nothing we can do to redact it or any of the following records.
                 // But we need to continue on and redact everything else.
+                _logger.LogError($"Error parsing participant at index {redactionIndex}");
             }
 
             _logger.LogError($"Error uploading participants: {uploadErrorString}");

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
@@ -87,13 +87,21 @@ namespace Piipan.Participants.Core.Services
             string uploadErrorString = errorDetails.ToString();
 
             string[] redactedStrings = new string[3];
-            // for each participant, redact out their information from the current error string
-            foreach (var participant in participants)
+
+            try
             {
-                redactedStrings[0] = participant.LdsHash;
-                redactedStrings[1] = participant.ParticipantId;
-                redactedStrings[2] = participant.CaseId;
-                uploadErrorString = _redactionService.Redact(uploadErrorString, redactedStrings);
+                // for each participant, redact out their information from the current error string
+                foreach (var participant in participants)
+                {
+                    redactedStrings[0] = participant.LdsHash;
+                    redactedStrings[1] = participant.ParticipantId;
+                    redactedStrings[2] = participant.CaseId;
+                    uploadErrorString = _redactionService.Redact(uploadErrorString, redactedStrings);
+                }
+            }
+            catch
+            {
+                // If it still errors in here, nothing we can do to redact it. But we need to continue on and redact everything else.
             }
 
             _logger.LogError($"Error uploading participants: {uploadErrorString}");

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
@@ -101,7 +101,8 @@ namespace Piipan.Participants.Core.Services
             }
             catch
             {
-                // If it still errors in here, nothing we can do to redact it. But we need to continue on and redact everything else.
+                // If it still errors in here, nothing we can do to redact it or any of the following records.
+                // But we need to continue on and redact everything else.
             }
 
             _logger.LogError($"Error uploading participants: {uploadErrorString}");

--- a/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
+++ b/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
@@ -43,6 +43,27 @@ namespace Piipan.Participants.Core.Tests.Services
             return result;
         }
 
+        private IEnumerable<ParticipantDbo> RandomParticipantsWithError(int n)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                if (i == 1)
+                {
+                    throw new Exception("Some parsing exception");
+                }
+                yield return new ParticipantDbo
+                {
+                    LdsHash = Guid.NewGuid().ToString(),
+                    CaseId = Guid.NewGuid().ToString(),
+                    ParticipantId = Guid.NewGuid().ToString(),
+                    ParticipantClosingDate = DateTime.UtcNow.Date,
+                    RecentBenefitIssuanceDates = new List<DateRange>(),
+                    VulnerableIndividual = (new Random()).Next(2) == 0,
+                    UploadId = (new Random()).Next()
+                };
+            }
+        }
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
@@ -262,6 +283,53 @@ namespace Piipan.Participants.Core.Tests.Services
             // Arrange
             var logger = new Mock<ILogger<ParticipantService>>();
             var participants = RandomParticipants(10);
+            var uploadId = (new Random()).Next();
+            var participantDao = new Mock<IParticipantDao>();
+
+            var uploadDao = new Mock<IUploadDao>();
+            uploadDao
+                .Setup(m => m.AddUpload("test-etag"))
+                .ReturnsAsync(new UploadDbo
+                {
+                    Id = uploadId,
+                    CreatedAt = DateTime.UtcNow,
+                    Publisher = "me"
+                });
+
+            var stateService = Mock.Of<IStateService>();
+            var redactionService = new RedactionService();
+
+            var service = new ParticipantService(
+                participantDao.Object,
+                uploadDao.Object,
+                stateService,
+                redactionService,
+                logger.Object);
+
+            var uploadDetails = new ParticipantUploadErrorDetails("EA", DateTime.UtcNow, DateTime.UtcNow, new Exception("Exception with first participant: " + participants.First().LdsHash), "test.csv");
+
+            // Act
+            service.LogParticipantsUploadError(uploadDetails, participants);
+
+            // Assert
+            logger.Verify(n => n.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((object v, Type _) => v.ToString() == $"Error uploading participants: {uploadDetails.ToString().Replace(participants.First().LdsHash, "REDACTED")}"),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                  Times.Once());
+        }
+
+        /// <summary>
+        /// When Add Participants has an error, the error is logged with the value of the redaction service.
+        /// </summary>
+        [Fact]
+        public void LogParticipantsUploadError_LogsRedactedErrorEvenAfterException()
+        {
+            // Arrange
+            var logger = new Mock<ILogger<ParticipantService>>();
+            var participants = RandomParticipantsWithError(10);
             var uploadId = (new Random()).Next();
             var participantDao = new Mock<IParticipantDao>();
 

--- a/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
+++ b/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
@@ -367,6 +367,15 @@ namespace Piipan.Participants.Core.Tests.Services
                     It.IsAny<Exception>(),
                     (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
                   Times.Once());
+
+            // Assert that we wrote an error log stating which row we failed to redact
+            logger.Verify(n => n.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((object v, Type _) => v.ToString() == $"Error parsing participant at index 1"),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                  Times.Once());
         }
 
         [Fact]

--- a/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
+++ b/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
@@ -323,6 +323,7 @@ namespace Piipan.Participants.Core.Tests.Services
 
         /// <summary>
         /// When Add Participants has an error, the error is logged with the value of the redaction service.
+        /// In the event that there's a parsing error, we should still attempt to redact the entries prior to the parsing error.
         /// </summary>
         [Fact]
         public void LogParticipantsUploadError_LogsRedactedErrorEvenAfterException()


### PR DESCRIPTION
## What’s changing?

Per comments made by @kingcomma, we should have a better test in the participant service tests that shows we can handle the actual redaction of an exception instead of just a mock.

Also after our discussion we noticed that if the error was due to the parsing and not the upload, that the parsing would continue to fail in the error logging. Thus we should catch any parsing errors and still redact the information that we were previously able to parse.

## Why?

Fixes concerns for NAC-577

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
