### PR TITLE
Authorization logic for location and role to be at application level

### DIFF
--- a/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/BasePageModel.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.DependencyInjection;
-using Piipan.Shared.Authorization;
 using Piipan.Shared.Claims;
 using Piipan.Shared.Locations;
 
@@ -24,12 +23,6 @@ namespace Piipan.QueryTool.Pages
 
         public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
         {
-            if ((string.IsNullOrEmpty(Location) || string.IsNullOrEmpty(Role)) &&
-                (!context.HandlerMethod?.MethodInfo.CustomAttributes.Any(n => n.AttributeType == typeof(IgnoreAuthorizationAttribute)) ?? false))
-            {
-                context.HttpContext.Response.StatusCode = 403;
-                context.Result = RedirectToUnauthorized();
-            }
         }
 
         protected IActionResult RedirectToUnauthorized()

--- a/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Error.cshtml.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.Extensions.Logging;
-using Piipan.Shared.Authorization;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -16,7 +15,6 @@ namespace Piipan.QueryTool.Pages
             _logger = logger;
         }
 
-        [IgnoreAuthorization]
         public void OnGet(string message)
         {
             _logger.LogError($"Arrived at error page with message {message}");

--- a/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/NotAuthorized.cshtml.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Piipan.Shared.Authorization;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -14,7 +13,6 @@ namespace Piipan.QueryTool.Pages
         {
         }
 
-        [IgnoreAuthorization]
         public IActionResult OnGet()
         {
             Message = "You do not have a sufficient role or location to access this page";

--- a/query-tool/src/Piipan.QueryTool/appsettings.Development.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.Development.json
@@ -8,10 +8,18 @@
   },
   "AuthorizationPolicy": {
     "RequiredClaims": [
-      {
-        "Type": "email",
-        "Values": ["*"]
-      }
+        {
+            "Type": "email",
+            "Values": [ "*" ]
+        },
+        {
+            "Type": "role",
+            "Values": [ "Location-*" ]
+        },
+        {
+            "Type": "role",
+            "Values": [ "Role-*" ]
+        }
     ]
   }
 }

--- a/query-tool/src/Piipan.QueryTool/appsettings.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.json
@@ -13,16 +13,7 @@
         "RolePrefix": "Role-"
     },
     "Locations": {
-        "Map": [
-            {
-                "Name": "National",
-                "States": [ "*" ]
-            },
-            {
-                "Name": "Midwest",
-                "States": [ "WI", "IA", "MN" ]
-            }
-        ]
+        "NationalOfficeValue":  "National"
     },
   "AuthorizationPolicy": {
     "RequiredClaims": []

--- a/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
@@ -1,15 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
-using Microsoft.AspNetCore.Routing;
 using Moq;
-using Piipan.QueryTool.Pages;
 using Piipan.Shared.Claims;
 using Piipan.Shared.Locations;
 
@@ -60,30 +52,6 @@ namespace Piipan.QueryTool.Tests
             context.Setup(m => m.Response).Returns(defaultHttpContext.Response);
 
             return context.Object;
-        }
-
-        protected PageHandlerExecutingContext GetPageHandlerExecutingContext<T>(T pageModel, string methodName) where T : BasePageModel
-        {
-            pageModel.PageContext.HttpContext = contextMock();
-
-            var pageContext = new PageContext(new ActionContext(
-                pageModel.PageContext.HttpContext,
-                new RouteData(),
-                new PageActionDescriptor(),
-                new ModelStateDictionary()));
-            var model = new Mock<PageModel>();
-
-            var pageHandlerExecutingContext = new PageHandlerExecutingContext(
-               pageContext,
-               Array.Empty<IFilterMetadata>(),
-               new HandlerMethodDescriptor() { MethodInfo = typeof(T).GetMethod(methodName) },
-               new Dictionary<string, object>(),
-               model.Object);
-
-            pageModel.OnPageHandlerExecuting(pageHandlerExecutingContext);
-
-            return pageHandlerExecutingContext;
-
         }
     }
 }

--- a/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ErrorTest.cs
@@ -1,6 +1,3 @@
-using System;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging.Abstractions;
 using Piipan.QueryTool.Pages;
 using Xunit;
@@ -34,38 +31,6 @@ namespace Piipan.QueryTool.Tests
             pageModel.OnGet(message);
             // assert
             Assert.Equal(message, pageModel.Message);
-        }
-
-        /// <summary>
-        /// The error page should be accessible no matter your role
-        /// </summary>
-        [Theory]
-        [InlineData(nameof(ErrorModel.OnGet), null, null, true)]
-        [InlineData(nameof(ErrorModel.OnGet), "IA", null, true)]
-        [InlineData(nameof(ErrorModel.OnGet), null, "Worker", true)]
-        [InlineData(nameof(ErrorModel.OnGet), "IA", "Worker", true)]
-        public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
-        {
-            var mockServiceProvider = serviceProviderMock(location: location, role: role);
-
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockServiceProvider, method);
-
-            if (!isAuthorized)
-            {
-                Assert.Equal(403, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-                Assert.IsType<RedirectToPageResult>(pageHandlerExecutingContext.Result);
-            }
-            else
-            {
-                Assert.Equal(200, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-            }
-        }
-
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider serviceProvider, string methodName)
-        {
-            var pageModel = new ErrorModel(new NullLogger<ErrorModel>(), serviceProvider);
-
-            return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }
     }
 }

--- a/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/IndexTest.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Piipan.Match.Api;
@@ -291,45 +289,6 @@ namespace Piipan.QueryTool.Tests
             Assert.NotNull(pageModel.QueryFormData.ServerErrors);
             Assert.Equal(new List<ServerError> {
                 new ServerError("", expectedErrorMessage) }, pageModel.QueryFormData.ServerErrors);
-        }
-
-        [Theory]
-        [InlineData(nameof(IndexModel.OnGet), null, null, false)]
-        [InlineData(nameof(IndexModel.OnGet), "IA", null, false)]
-        [InlineData(nameof(IndexModel.OnGet), null, "Worker", false)]
-        [InlineData(nameof(IndexModel.OnGet), "IA", "Worker", true)]
-        [InlineData(nameof(IndexModel.OnPostAsync), null, null, false)]
-        [InlineData(nameof(IndexModel.OnPostAsync), "IA", null, false)]
-        [InlineData(nameof(IndexModel.OnPostAsync), null, "Worker", false)]
-        [InlineData(nameof(IndexModel.OnPostAsync), "IA", "Worker", true)]
-        public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
-        {
-            var mockServiceProvider = serviceProviderMock(location: location, role: role);
-
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockServiceProvider, method);
-
-            if (!isAuthorized)
-            {
-                Assert.Equal(403, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-                Assert.IsType<RedirectToPageResult>(pageHandlerExecutingContext.Result);
-            }
-            else
-            {
-                Assert.Equal(200, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-            }
-        }
-
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider serviceProvider, string methodName)
-        {
-            var mockLdsDeidentifier = Mock.Of<ILdsDeidentifier>();
-            var mockMatchApi = Mock.Of<IMatchApi>();
-            var pageModel = new IndexModel(
-                new NullLogger<IndexModel>(),
-                mockLdsDeidentifier,
-                mockMatchApi,
-                serviceProvider
-            );
-            return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }
     }
 }

--- a/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/ListTest.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -105,40 +103,6 @@ namespace Piipan.QueryTool.Tests
                 mockServiceProvider
             );
             return pageModel;
-        }
-
-        [Theory]
-        [InlineData(nameof(ListModel.OnGet), null, null, false)]
-        [InlineData(nameof(ListModel.OnGet), "IA", null, false)]
-        [InlineData(nameof(ListModel.OnGet), null, "Worker", false)]
-        [InlineData(nameof(ListModel.OnGet), "IA", "Worker", true)]
-        public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
-        {
-            var mockServiceProvider = serviceProviderMock(location: location, role: role);
-
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockServiceProvider, method);
-
-            if (!isAuthorized)
-            {
-                Assert.Equal(403, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-                Assert.IsType<RedirectToPageResult>(pageHandlerExecutingContext.Result);
-            }
-            else
-            {
-                Assert.Equal(200, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-            }
-        }
-
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider mockServiceProvider, string methodName)
-        {
-            var mockMatchApi = Mock.Of<IMatchResolutionApi>();
-            var pageModel = new ListModel(
-                new NullLogger<ListModel>(),
-                mockMatchApi,
-                mockServiceProvider
-            );
-
-            return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }
     }
 }

--- a/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/MatchTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -223,39 +222,6 @@ namespace Piipan.QueryTool.Tests
 
             // assert
             Assert.Equal(new List<ServerError> { new("", "There was an error running your search. Please try again.") }, pageModel.RequestErrors);
-        }
-
-        [Theory]
-        [InlineData(nameof(MatchModel.OnGet), null, null, false)]
-        [InlineData(nameof(MatchModel.OnGet), "IA", null, false)]
-        [InlineData(nameof(MatchModel.OnGet), null, "Worker", false)]
-        [InlineData(nameof(MatchModel.OnGet), "IA", "Worker", true)]
-        [InlineData(nameof(MatchModel.OnPost), null, null, false)]
-        [InlineData(nameof(MatchModel.OnPost), "IA", null, false)]
-        [InlineData(nameof(MatchModel.OnPost), null, "Worker", false)]
-        [InlineData(nameof(MatchModel.OnPost), "IA", "Worker", true)]
-        public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
-        {
-            var mockClaimsProvider = serviceProviderMock(location: location, role: role);
-
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockClaimsProvider, method);
-
-            if (!isAuthorized)
-            {
-                Assert.Equal(403, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-                Assert.IsType<RedirectToPageResult>(pageHandlerExecutingContext.Result);
-            }
-            else
-            {
-                Assert.Equal(200, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-            }
-        }
-
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider serviceProvider, string methodName)
-        {
-            var pageModel = SetupMatchModel(mockServiceProvider: serviceProvider);
-
-            return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }
 
         private MatchModel SetupMatchModel(Mock<IMatchResolutionApi> mockMatchApi = null, IServiceProvider mockServiceProvider = null)

--- a/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/NotAuthorizedPageTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
-using Piipan.QueryTool.Pages;
+﻿using Piipan.QueryTool.Pages;
 using Xunit;
 
 namespace Piipan.QueryTool.Tests
@@ -32,38 +29,6 @@ namespace Piipan.QueryTool.Tests
             pageModel.OnGet();
             // assert
             Assert.Equal("You do not have a sufficient role or location to access this page", pageModel.Message);
-        }
-
-        /// <summary>
-        /// The not authorized page should be accessible no matter your role
-        /// </summary>
-        [Theory]
-        [InlineData(nameof(NotAuthorizedModel.OnGet), null, null, true)]
-        [InlineData(nameof(NotAuthorizedModel.OnGet), "IA", null, true)]
-        [InlineData(nameof(NotAuthorizedModel.OnGet), null, "Worker", true)]
-        [InlineData(nameof(NotAuthorizedModel.OnGet), "IA", "Worker", true)]
-        public void IsAccessibleWhenRolesExist(string method, string role, string location, bool isAuthorized)
-        {
-            var mockServiceProvider = serviceProviderMock(location: location, role: role);
-
-            var pageHandlerExecutingContext = GetPageHandlerExecutingContext(mockServiceProvider, method);
-
-            if (!isAuthorized)
-            {
-                Assert.Equal(403, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-                Assert.IsType<RedirectToPageResult>(pageHandlerExecutingContext.Result);
-            }
-            else
-            {
-                Assert.Equal(200, pageHandlerExecutingContext.HttpContext.Response.StatusCode);
-            }
-        }
-
-        private PageHandlerExecutingContext GetPageHandlerExecutingContext(IServiceProvider serviceProvider, string methodName)
-        {
-            var pageModel = new NotAuthorizedModel(serviceProvider);
-
-            return base.GetPageHandlerExecutingContext(pageModel, methodName);
         }
     }
 }

--- a/shared/src/Piipan.Shared/Authorization/IgnoreAuthorizationAttribute.cs
+++ b/shared/src/Piipan.Shared/Authorization/IgnoreAuthorizationAttribute.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Piipan.Shared.Authorization
-{
-    public class IgnoreAuthorizationAttribute : Attribute
-    {
-
-    }
-}

--- a/shared/src/Piipan.Shared/Locations/LocationOptions.cs
+++ b/shared/src/Piipan.Shared/Locations/LocationOptions.cs
@@ -3,11 +3,6 @@
     public class LocationOptions
     {
         public const string SectionName = "Locations";
-        public LocationMapping[] Map { get; set; }
-    }
-    public class LocationMapping
-    {
-        public string Name { get; set; }
-        public string[] States { get; set; }
+        public string NationalOfficeValue { get; set; }
     }
 }

--- a/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
+++ b/shared/src/Piipan.Shared/Locations/LocationsProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.Extensions.Options;
 
 namespace Piipan.Shared.Locations
@@ -15,12 +14,16 @@ namespace Piipan.Shared.Locations
 
         public string[] GetStates(string location)
         {
-            var stateArray = _options.Map?.FirstOrDefault(n => n.Name == location)?.States?.ToArray();
-            if (stateArray == null && !string.IsNullOrEmpty(location))
+            if (location == _options.NationalOfficeValue)
+            {
+                return new string[] { "*" };
+            }
+            // TODO: Fetch states from State Func API and cache. Return string[] with the states matching our region
+            if (!string.IsNullOrEmpty(location))
             {
                 return new string[] { location };
             }
-            return stateArray ?? Array.Empty<string>();
+            return Array.Empty<string>();
         }
     }
 }

--- a/shared/tests/Piipan.Shared.Tests/Authorization/AuthorizationPolicyBuilderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Authorization/AuthorizationPolicyBuilderTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
-using Moq;
 using Xunit;
 
 namespace Piipan.Shared.Authorization.Tests
@@ -22,7 +21,8 @@ namespace Piipan.Shared.Authorization.Tests
             // Assert
             Assert.Equal(2, policy.Requirements.Count);
             AssertHasDenyAnonymousAuthorizationRequirement(policy);
-            Assert.Single(policy.Requirements, req => {
+            Assert.Single(policy.Requirements, req =>
+            {
                 return !((req as AssertionRequirement) is null);
             });
         }
@@ -33,7 +33,7 @@ namespace Piipan.Shared.Authorization.Tests
             // Arrange
             var options = new AuthorizationPolicyOptions
             {
-                RequiredClaims = new List<RequiredClaim> {}
+                RequiredClaims = new List<RequiredClaim> { }
             };
 
             // Act
@@ -48,12 +48,12 @@ namespace Piipan.Shared.Authorization.Tests
         public void Build_ClaimsRequirements_SingleValue()
         {
             // Arrange
-            var allowedValues = new List<string> {"val_1"};
+            var allowedValues = new List<string> { "val_1" };
             var options = new AuthorizationPolicyOptions
             {
                 RequiredClaims = new List<RequiredClaim>
                 {
-                    new RequiredClaim 
+                    new RequiredClaim
                     {
                         Type = "type_1",
                         Values = allowedValues
@@ -74,12 +74,12 @@ namespace Piipan.Shared.Authorization.Tests
         public void Build_ClaimsRequirements_MultiValue()
         {
             // Arrange
-            var allowedValues = new List<string> {"val_1", "val_2", "val_3"};
+            var allowedValues = new List<string> { "val_1", "val_2", "val_3" };
             var options = new AuthorizationPolicyOptions
             {
                 RequiredClaims = new List<RequiredClaim>
                 {
-                    new RequiredClaim 
+                    new RequiredClaim
                     {
                         Type = "type_1",
                         Values = allowedValues
@@ -100,7 +100,7 @@ namespace Piipan.Shared.Authorization.Tests
         public async void Build_ClaimsRequirements_AnyValue_Allow()
         {
             // Arrange
-            var allowedValues = new List<string> {"*"};
+            var allowedValues = new List<string> { "*" };
             var options = new AuthorizationPolicyOptions
             {
                 RequiredClaims = new List<RequiredClaim>
@@ -119,10 +119,11 @@ namespace Piipan.Shared.Authorization.Tests
             // Assert
             Assert.Equal(2, policy.Requirements.Count);
             AssertHasDenyAnonymousAuthorizationRequirement(policy);
-            Assert.Single(policy.Requirements, req => {
+            Assert.Single(policy.Requirements, req =>
+            {
                 return !((req as AssertionRequirement) is null);
             });
-            
+
             // we should be able to use any value for the type_1 claim
             var requirement = policy.Requirements.Single(req => !((req as AssertionRequirement) is null)) as AssertionRequirement;
             var user = UserWithClaim("type_1", "asiuhdfiasuhdfsd");
@@ -134,7 +135,7 @@ namespace Piipan.Shared.Authorization.Tests
         public async void Build_ClaimsRequirements_AnyValue_Reject()
         {
             // Arrange
-            var allowedValues = new List<string> {"*"};
+            var allowedValues = new List<string> { "*" };
             var options = new AuthorizationPolicyOptions
             {
                 RequiredClaims = new List<RequiredClaim>
@@ -153,10 +154,11 @@ namespace Piipan.Shared.Authorization.Tests
             // Assert
             Assert.Equal(2, policy.Requirements.Count);
             AssertHasDenyAnonymousAuthorizationRequirement(policy);
-            Assert.Single(policy.Requirements, req => {
+            Assert.Single(policy.Requirements, req =>
+            {
                 return !((req as AssertionRequirement) is null);
             });
-            
+
             // we should be rejected for not having a type_1 claim
             var requirement = policy.Requirements.Single(req => !((req as AssertionRequirement) is null)) as AssertionRequirement;
             var user = UserWithClaim("type_2", "isdhfiuhsdfiuhs");
@@ -164,16 +166,141 @@ namespace Piipan.Shared.Authorization.Tests
             Assert.False(await requirement.Handler.Invoke(authorizationContext));
         }
 
+        [Theory]
+        [InlineData("val_123", true)]
+        [InlineData("val_ab_234", true)]
+        [InlineData("val_", false)]
+        [InlineData("val-123", false)]
+        [InlineData("VAL_123", false)]
+        public async void Build_ClaimsRequirements_PartialWildcardValue(string testValue, bool expectAuthorized)
+        {
+            // Arrange
+            var allowedValues = new List<string> { "val_*" };
+            var options = new AuthorizationPolicyOptions
+            {
+                RequiredClaims = new List<RequiredClaim>
+                {
+                    new RequiredClaim
+                    {
+                        Type = "type_1",
+                        Values = allowedValues
+                    }
+                }
+            };
+
+            // Act
+            var policy = AuthorizationPolicyBuilder.Build(options);
+
+            // Assert
+            Assert.Equal(2, policy.Requirements.Count);
+            AssertHasDenyAnonymousAuthorizationRequirement(policy);
+            Assert.Single(policy.Requirements, req =>
+            {
+                return !((req as AssertionRequirement) is null);
+            });
+
+            // we should be able to use any value for the type_1 claim
+            var requirement = policy.Requirements.Single(req => !((req as AssertionRequirement) is null)) as AssertionRequirement;
+            var user = UserWithClaim("type_1", testValue);
+            var authorizationContext = new AuthorizationHandlerContext(policy.Requirements, user, null);
+            Assert.Equal(expectAuthorized, await requirement.Handler.Invoke(authorizationContext));
+        }
+
+        [Theory]
+        [InlineData("val_123", true)]
+        [InlineData("val_ab_234", true)]
+        [InlineData("val_", false)]
+        [InlineData("val-123", false)]
+        [InlineData("VAL_123", false)]
+        [InlineData("VAL-123", true)]
+        public async void Build_ClaimsRequirements_PartialWildcardValue_Multiple_Values(string testValue, bool expectAuthorized)
+        {
+            // Arrange
+            var allowedValues = new List<string> { "val_*", "VAL-*" };
+            var options = new AuthorizationPolicyOptions
+            {
+                RequiredClaims = new List<RequiredClaim>
+                {
+                    new RequiredClaim
+                    {
+                        Type = "type_1",
+                        Values = allowedValues
+                    }
+                }
+            };
+
+            // Act
+            var policy = AuthorizationPolicyBuilder.Build(options);
+
+            // Assert
+            Assert.Equal(2, policy.Requirements.Count);
+            AssertHasDenyAnonymousAuthorizationRequirement(policy);
+            Assert.Single(policy.Requirements, req =>
+            {
+                return !((req as AssertionRequirement) is null);
+            });
+
+            // we should be able to use any value for the type_1 claim
+            var requirement = policy.Requirements.Single(req => !((req as AssertionRequirement) is null)) as AssertionRequirement;
+            var user = UserWithClaim("type_1", testValue);
+            var authorizationContext = new AuthorizationHandlerContext(policy.Requirements, user, null);
+            Assert.Equal(expectAuthorized, await requirement.Handler.Invoke(authorizationContext));
+        }
+
+        [Theory]
+        [InlineData("val_123", true)]
+        [InlineData("val_ab_234", true)]
+        [InlineData("val_", false)]
+        [InlineData("val-123", false)]
+        [InlineData("VAL_123", false)]
+        [InlineData("testvalue", true)]
+        [InlineData("testvalues", false)]
+        public async void Build_ClaimsRequirements_PartialWildcardValue_Multiple_Values_Including_SpecificValue(string testValue, bool expectAuthorized)
+        {
+            // Arrange
+            var allowedValues = new List<string> { "val_*", "testvalue" };
+            var options = new AuthorizationPolicyOptions
+            {
+                RequiredClaims = new List<RequiredClaim>
+                {
+                    new RequiredClaim
+                    {
+                        Type = "type_1",
+                        Values = allowedValues
+                    }
+                }
+            };
+
+            // Act
+            var policy = AuthorizationPolicyBuilder.Build(options);
+
+            // Assert
+            Assert.Equal(2, policy.Requirements.Count);
+            AssertHasDenyAnonymousAuthorizationRequirement(policy);
+            Assert.Single(policy.Requirements, req =>
+            {
+                return !((req as AssertionRequirement) is null);
+            });
+
+            // we should be able to use any value for the type_1 claim
+            var requirement = policy.Requirements.Single(req => !((req as AssertionRequirement) is null)) as AssertionRequirement;
+            var user = UserWithClaim("type_1", testValue);
+            var authorizationContext = new AuthorizationHandlerContext(policy.Requirements, user, null);
+            Assert.Equal(expectAuthorized, await requirement.Handler.Invoke(authorizationContext));
+        }
+
         private void AssertHasDenyAnonymousAuthorizationRequirement(AuthorizationPolicy policy)
         {
-            Assert.Single(policy.Requirements, req => {
+            Assert.Single(policy.Requirements, req =>
+            {
                 return !((req as DenyAnonymousAuthorizationRequirement) is null);
             });
         }
 
         private void AssertHasClaimRequirement(AuthorizationPolicy policy, string type, IEnumerable<string> values)
         {
-            Assert.Single(policy.Requirements, req => {
+            Assert.Single(policy.Requirements, req =>
+            {
                 var claimsReq = req as ClaimsAuthorizationRequirement;
                 if (claimsReq is null)
                 {

--- a/shared/tests/Piipan.Shared.Tests/Locations/LocationProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Locations/LocationProviderTests.cs
@@ -7,11 +7,7 @@ namespace Piipan.Shared.Locations.Tests
     {
         LocationOptions locationOptions = new LocationOptions
         {
-            Map = new LocationMapping[]
-            {
-                new LocationMapping { Name = "National", States = new[] { "*" }},
-                new LocationMapping { Name = "Midwest", States = new[] { "WI", "IA", "MN" }},
-            }
+            NationalOfficeValue = "National"
         };
 
         /// <summary>
@@ -31,19 +27,20 @@ namespace Piipan.Shared.Locations.Tests
             Assert.Equal(new string[] { "*" }, states);
         }
 
-        [Fact]
-        public void GetMidwestStates()
-        {
-            // Arrange
-            var options = Options.Create(locationOptions);
-            var locationProvider = new LocationsProvider(options);
+        // TODO: Add regions back in after State Func API is complete
+        //[Fact]
+        //public void GetMidwestStates()
+        //{
+        //    // Arrange
+        //    var options = Options.Create(locationOptions);
+        //    var locationProvider = new LocationsProvider(options);
 
-            // Act
-            var states = locationProvider.GetStates("Midwest");
+        //    // Act
+        //    var states = locationProvider.GetStates("Midwest");
 
-            // Assert
-            Assert.Equal(new string[] { "WI", "IA", "MN" }, states);
-        }
+        //    // Assert
+        //    Assert.Equal(new string[] { "WI", "IA", "MN" }, states);
+        //}
 
         [Fact]
         public void GetSingleState()
@@ -53,10 +50,10 @@ namespace Piipan.Shared.Locations.Tests
             var locationProvider = new LocationsProvider(options);
 
             // Act
-            var states = locationProvider.GetStates("IA");
+            var states = locationProvider.GetStates("EA");
 
             // Assert
-            Assert.Equal(new string[] { "IA" }, states);
+            Assert.Equal(new string[] { "EA" }, states);
         }
 
         [Fact]


### PR DESCRIPTION
## What’s changing?

The authorization for location and role was added a few weeks back at the page level. After discussion with @kingcomma, this should be done at the application level by looking at the required claims.

The possible values for location and role are very large, but they all start with the same prefixes. So the appsettings now allows a combination of a set value and a wildcard. The AuthorizationPolicyBuilder was updated to reflect this.

## Why?

Closes NAC-857

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
