### PR TITLE
Decrypt lds hash in ParticipantService before returning

### DIFF
--- a/match/tests/Piipan.Match.Func.Api.IntegrationTests/ApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.Api.IntegrationTests/ApiIntegrationTests.cs
@@ -373,15 +373,18 @@ namespace Piipan.Match.Func.Api.IntegrationTests
             var result = response as JsonResult;
             var resultObject = result.Value as OrchMatchResponse;
 
+            AzureAesCryptographyClient cryptoClient = new AzureAesCryptographyClient(base64EncodedKey);
+
             // Assert
             Assert.All(resultObject.Data.Results, result =>
             {
                 var match = result.Matches.First();
                 var record = GetMatchRecord(match.MatchId);
 
+                string encryptedLdsHashOfMatch = cryptoClient.EncryptToBase64String(match.LdsHash);
                 Assert.Equal(InitiatingState, record.Initiator);
                 Assert.True(record.States.SequenceEqual(new string[] { InitiatingState, state[0] }));
-                Assert.Equal(match.LdsHash, record.Hash);
+                Assert.Equal(encryptedLdsHashOfMatch, record.Hash);
                 Assert.Equal("ldshash", record.HashType);
             });
         }

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Services/ParticipantService.cs
@@ -53,11 +53,12 @@ namespace Piipan.Participants.Core.Services
                 var participants = await _participantDao.GetParticipants(state, ldsHash, upload.Id);
 
                 // Set the participant State before returning
-                return participants.Select(p => new ParticipantDto(p) { 
+                return participants.Select(p => new ParticipantDto(p) {
                     State = state,
+                    LdsHash = _cryptographyClient.DecryptFromBase64String(p.LdsHash),
                     ParticipantId = _cryptographyClient.DecryptFromBase64String(p.ParticipantId),
                     CaseId = _cryptographyClient.DecryptFromBase64String(p.CaseId)
-                });
+                }) ;
             }
             catch (InvalidOperationException)
             {

--- a/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
+++ b/participants/tests/Piipan.Participants.Core.Tests/Services/ParticipantServiceTests.cs
@@ -121,6 +121,7 @@ namespace Piipan.Participants.Core.Tests.Services
             // results should have the State set
             var expected = participants.Select(p => new ParticipantDto(p) { 
                 State = randomState,
+                LdsHash = cryptographyClient.DecryptFromBase64String(p.LdsHash),
                 ParticipantId = cryptographyClient.DecryptFromBase64String(p.ParticipantId),
                 CaseId = cryptographyClient.DecryptFromBase64String(p.CaseId),
             });


### PR DESCRIPTION
## What’s changing?

Decrypt the lds hash before returning matches to states

## Why?

States desire the lds hash for iteration purposes

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
