### PR TITLE
Eth/nac 942

### DIFF
--- a/iac/create-core-databases.bash
+++ b/iac/create-core-databases.bash
@@ -67,6 +67,7 @@ main () {
   echo "Creating $COLLAB_DB_NAME database and applying DDL"
   db_init "$COLLAB_DB_NAME" "$SUPERUSER"
   db_apply_ddl "$COLLAB_DB_NAME" ../match/ddl/match-record.sql
+  db_apply_ddl "$COLLAB_DB_NAME" ../match/ddl/state-info.sql
 
   echo "Inserting state info data"
   db_apply_ddl "$COLLAB_DB_NAME" ../match/dml/insert-state-info.sql

--- a/iac/create-core-databases.bash
+++ b/iac/create-core-databases.bash
@@ -68,6 +68,9 @@ main () {
   db_init "$COLLAB_DB_NAME" "$SUPERUSER"
   db_apply_ddl "$COLLAB_DB_NAME" ../match/ddl/match-record.sql
 
+  echo "Inserting state info data"
+  db_apply_ddl "$COLLAB_DB_NAME" ../match/dml/insert-state-info.sql
+
   db_config_aad "$RESOURCE_GROUP" "$CORE_DB_SERVER_NAME" "$PG_AAD_ADMIN"
   db_use_aad "$CORE_DB_SERVER_NAME" "$PG_AAD_ADMIN"
 

--- a/match/ddl/match-record.sql
+++ b/match/ddl/match-record.sql
@@ -46,20 +46,4 @@ COMMENT ON COLUMN match_res_events.actor IS 'the person or automated system perf
 COMMENT ON COLUMN match_res_events.actor_state IS 'indicates if the actor is associated with a state involved in the match';
 COMMENT ON COLUMN match_res_events.delta IS 'json object representing data changes submitted by states, as well as stateful domain data like match status';
 
-CREATE TABLE IF NOT EXISTS state_info(
-    id text UNIQUE PRIMARY KEY,
-    state text UNIQUE NOT NULL,
-    state_abbreviation text NOT NULL,
-    email text NOT NULL,
-    phone text,
-	region text NOT NULL
-);
-
-COMMENT ON COLUMN state_info.id IS 'Unique number for each state. Will be alphabetical - Alabama = 1, Alaska = 2 etc';
-COMMENT ON COLUMN state_info.phone IS 'The phone number contact';
-COMMENT ON COLUMN state_info.email IS 'The email to contact that state';
-COMMENT ON COLUMN state_info.state IS 'State/territory full name';
-COMMENT ON COLUMN state_info.state_abbreviation IS 'State/territorys two letter abbreviation';
-COMMENT ON COLUMN state_info.region IS 'The region the specified state belongs to';
-
 COMMIT;

--- a/match/ddl/match-record.sql
+++ b/match/ddl/match-record.sql
@@ -62,39 +62,4 @@ COMMENT ON COLUMN state_info.state IS 'State/territory full name';
 COMMENT ON COLUMN state_info.state_abbreviation IS 'State/territorys two letter abbreviation';
 COMMENT ON COLUMN state_info.region IS 'The region the specified state belongs to';
 
-INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
-select * from (select '15' as id, 'Iowa' as state, 'IA' as state_abbreviation, 'IA-test@usda.gov' as email, '1234567890' as phone, 'MWRO' AS region) as temp
-WHERE NOT EXISTS 
-(select id from state_info where id = '15') limit 1;
-
-INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
-select * from (select '18' as id, 'Louisiana' as state, 'LA' as state_abbreviation, 'LA-test@usda.gov' as email, '1234567890' as phone, 'SWRO' AS region) as temp
-WHERE NOT EXISTS 
-(select id from state_info where id = '18') limit 1;
-
-INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
-select * from (select '21' as id, 'Massachusetts' as state, 'MA' as state_abbreviation, 'MA-test@usda.gov' as email, '1234567890' as phone, 'NERO' AS region) as temp
-WHERE NOT EXISTS 
-(select id from state_info where id = '21') limit 1;
-
-INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
-select * from (select '26' as id, 'Montana' as state, 'MT' as state_abbreviation, 'MT-test@usda.gov' as email, '1234567890' as phone, 'MPRO' AS region) as temp
-WHERE NOT EXISTS 
-(select id from state_info where id = '26') limit 1;
-
-INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
-select * from (select '101' as id, 'Echo Alpha' as state, 'EA' as state_abbreviation, 'EA-test@usda.gov' as email, '1234567890' as phone, 'EA-MPRO' AS region) as temp
-WHERE NOT EXISTS 
-(select id from state_info where id = '101') limit 1;
-
-INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
-select * from (select '102' as id, 'Echo Bravo' as state, 'EB' as state_abbreviation, 'EB-test@usda.gov' as email, '1234567890' as phone, 'EB-MPRO' AS region) as temp
-WHERE NOT EXISTS 
-(select id from state_info where id = '102') limit 1;
-
-INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
-select * from (select '103' as id, 'Echo Charlie' as state, 'EC' as state_abbreviation, 'EC-test@usda.gov' as email, '1234567890' as phone, 'EC-MPRO' AS region) as temp
-WHERE NOT EXISTS 
-(select id from state_info where id = '103') limit 1;
-
 COMMIT;

--- a/match/ddl/state-info.sql
+++ b/match/ddl/state-info.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS state_info(
+    id text UNIQUE PRIMARY KEY,
+    state text UNIQUE NOT NULL,
+    state_abbreviation text NOT NULL,
+    email text NOT NULL,
+    phone text,
+	region text NOT NULL
+);
+
+COMMENT ON COLUMN state_info.id IS 'Unique number for each state. Will be alphabetical - Alabama = 1, Alaska = 2 etc';
+COMMENT ON COLUMN state_info.phone IS 'The phone number contact';
+COMMENT ON COLUMN state_info.email IS 'The email to contact that state';
+COMMENT ON COLUMN state_info.state IS 'State/territory full name';
+COMMENT ON COLUMN state_info.state_abbreviation IS 'State/territorys two letter abbreviation';
+COMMENT ON COLUMN state_info.region IS 'The region the specified state belongs to';
+
+COMMIT;

--- a/match/dml/insert-state-info.sql
+++ b/match/dml/insert-state-info.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
+select * from (select '15' as id, 'Iowa' as state, 'IA' as state_abbreviation, 'IA-test@usda.gov' as email, '1234567890' as phone, 'MWRO' AS region) as temp
+WHERE NOT EXISTS 
+(select id from state_info where id = '15') limit 1;
+
+INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
+select * from (select '18' as id, 'Louisiana' as state, 'LA' as state_abbreviation, 'LA-test@usda.gov' as email, '1234567890' as phone, 'SWRO' AS region) as temp
+WHERE NOT EXISTS 
+(select id from state_info where id = '18') limit 1;
+
+INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
+select * from (select '21' as id, 'Massachusetts' as state, 'MA' as state_abbreviation, 'MA-test@usda.gov' as email, '1234567890' as phone, 'NERO' AS region) as temp
+WHERE NOT EXISTS 
+(select id from state_info where id = '21') limit 1;
+
+INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
+select * from (select '26' as id, 'Montana' as state, 'MT' as state_abbreviation, 'MT-test@usda.gov' as email, '1234567890' as phone, 'MPRO' AS region) as temp
+WHERE NOT EXISTS 
+(select id from state_info where id = '26') limit 1;
+
+INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
+select * from (select '101' as id, 'Echo Alpha' as state, 'EA' as state_abbreviation, 'EA-test@usda.gov' as email, '1234567890' as phone, 'EA-MPRO' AS region) as temp
+WHERE NOT EXISTS 
+(select id from state_info where id = '101') limit 1;
+
+INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
+select * from (select '102' as id, 'Echo Bravo' as state, 'EB' as state_abbreviation, 'EB-test@usda.gov' as email, '1234567890' as phone, 'EB-MPRO' AS region) as temp
+WHERE NOT EXISTS 
+(select id from state_info where id = '102') limit 1;
+
+INSERT INTO state_info(id, state, state_abbreviation, email, phone, region)
+select * from (select '103' as id, 'Echo Charlie' as state, 'EC' as state_abbreviation, 'EC-test@usda.gov' as email, '1234567890' as phone, 'EC-MPRO' AS region) as temp
+WHERE NOT EXISTS 
+(select id from state_info where id = '103') limit 1;
+
+COMMIT;

--- a/shared/src/Piipan.Shared.TestFixtures/MatchesDbFixture.cs
+++ b/shared/src/Piipan.Shared.TestFixtures/MatchesDbFixture.cs
@@ -76,6 +76,7 @@ namespace Piipan.Shared.TestFixtures
         private void ApplySchema()
         {
             string sqltext = System.IO.File.ReadAllText("match-record.sql", System.Text.Encoding.UTF8);
+            string insertStateInfo = System.IO.File.ReadAllText("insert-state-info.sql", System.Text.Encoding.UTF8);
 
             using (var conn = Factory.CreateConnection())
             {
@@ -87,6 +88,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Execute("DROP TYPE IF EXISTS hash_type");
                 conn.Execute(sqltext);
+                conn.Execute(insertStateInfo);
 
                 conn.Close();
             }

--- a/shared/src/Piipan.Shared.TestFixtures/MatchesDbFixture.cs
+++ b/shared/src/Piipan.Shared.TestFixtures/MatchesDbFixture.cs
@@ -76,6 +76,7 @@ namespace Piipan.Shared.TestFixtures
         private void ApplySchema()
         {
             string sqltext = System.IO.File.ReadAllText("match-record.sql", System.Text.Encoding.UTF8);
+            string createStateInfo = System.IO.File.ReadAllText("state-info.sql", System.Text.Encoding.UTF8);
             string insertStateInfo = System.IO.File.ReadAllText("insert-state-info.sql", System.Text.Encoding.UTF8);
 
             using (var conn = Factory.CreateConnection())
@@ -88,6 +89,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Execute("DROP TYPE IF EXISTS hash_type");
                 conn.Execute(sqltext);
+                conn.Execute(createStateInfo);
                 conn.Execute(insertStateInfo);
 
                 conn.Close();

--- a/shared/src/Piipan.Shared.TestFixtures/MatchesDbFixture.cs
+++ b/shared/src/Piipan.Shared.TestFixtures/MatchesDbFixture.cs
@@ -66,6 +66,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
+                conn.Execute("DROP TABLE IF EXISTS state_info");
                 conn.Execute("DROP TYPE IF EXISTS hash_type");
 
                 conn.Close();
@@ -87,6 +88,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
+                conn.Execute("DROP TABLE IF EXISTS state_info");
                 conn.Execute("DROP TYPE IF EXISTS hash_type");
                 conn.Execute(sqltext);
                 conn.Execute(createStateInfo);

--- a/shared/src/Piipan.Shared.TestFixtures/OrchestratorDbFixture.cs
+++ b/shared/src/Piipan.Shared.TestFixtures/OrchestratorDbFixture.cs
@@ -84,6 +84,7 @@ namespace Piipan.Shared.TestFixtures
         {
             string perstateSql = System.IO.File.ReadAllText("per-state.sql", System.Text.Encoding.UTF8);
             string matchesSql = System.IO.File.ReadAllText("match-record.sql", System.Text.Encoding.UTF8);
+            string createStateInfo = System.IO.File.ReadAllText("state-info.sql", System.Text.Encoding.UTF8);
             string insertStateInfo = System.IO.File.ReadAllText("insert-state-info.sql", System.Text.Encoding.UTF8);
 
             // Participants DB
@@ -110,6 +111,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Execute(matchesSql);
+                conn.Execute(createStateInfo);   
                 conn.Execute(insertStateInfo);   
                 conn.Close();
             }

--- a/shared/src/Piipan.Shared.TestFixtures/OrchestratorDbFixture.cs
+++ b/shared/src/Piipan.Shared.TestFixtures/OrchestratorDbFixture.cs
@@ -75,6 +75,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
+                conn.Execute("DROP TABLE IF EXISTS state_info");
                 conn.Close();
             }
 
@@ -110,6 +111,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP INDEX IF EXISTS index_match_id_on_match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
+                conn.Execute("DROP TABLE IF EXISTS state_info");
                 conn.Execute(matchesSql);
                 conn.Execute(createStateInfo);   
                 conn.Execute(insertStateInfo);   

--- a/shared/src/Piipan.Shared.TestFixtures/OrchestratorDbFixture.cs
+++ b/shared/src/Piipan.Shared.TestFixtures/OrchestratorDbFixture.cs
@@ -84,6 +84,7 @@ namespace Piipan.Shared.TestFixtures
         {
             string perstateSql = System.IO.File.ReadAllText("per-state.sql", System.Text.Encoding.UTF8);
             string matchesSql = System.IO.File.ReadAllText("match-record.sql", System.Text.Encoding.UTF8);
+            string insertStateInfo = System.IO.File.ReadAllText("insert-state-info.sql", System.Text.Encoding.UTF8);
 
             // Participants DB
             using (var conn = Factory.CreateConnection())
@@ -109,7 +110,7 @@ namespace Piipan.Shared.TestFixtures
                 conn.Execute("DROP TABLE IF EXISTS match_res_events");
                 conn.Execute("DROP TABLE IF EXISTS matches");
                 conn.Execute(matchesSql);
-
+                conn.Execute(insertStateInfo);   
                 conn.Close();
             }
         }

--- a/shared/src/Piipan.Shared.TestFixtures/Piipan.Shared.TestFixtures.csproj
+++ b/shared/src/Piipan.Shared.TestFixtures/Piipan.Shared.TestFixtures.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\match\ddl\match-record.sql" Link="match-record.sql" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\..\match\ddl\state-info.sql" Link="state-info.sql" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\..\..\match\dml\insert-state-info.sql" Link="insert-state-info.sql" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\..\..\metrics\ddl\metrics.sql" Link="metrics.sql" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\..\..\ddl\per-state.sql" Link="per-state.sql" CopyToOutputDirectory="PreserveNewest" />

--- a/shared/src/Piipan.Shared.TestFixtures/Piipan.Shared.TestFixtures.csproj
+++ b/shared/src/Piipan.Shared.TestFixtures/Piipan.Shared.TestFixtures.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\match\ddl\match-record.sql" Link="match-record.sql" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\..\..\match\dml\insert-state-info.sql" Link="insert-state-info.sql" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\..\..\metrics\ddl\metrics.sql" Link="metrics.sql" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\..\..\ddl\per-state.sql" Link="per-state.sql" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
## What’s changing?

Pull state metadata SQL inserts out of march-record.sql DDL

## Why?

The SQL insert commands that add state metadata like email address and phone number to the state_info table are part of the match-records.sql DDL file. This change pull these inserts into their own SQL file and keep the DDL file strictly for defining the database/table structure. 

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [X] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
