### PR TITLE
Modal and Navigation blocking behaviors

### DIFF
--- a/components/src/Piipan.Components.Demo/Components/DemoModalComponent.razor
+++ b/components/src/Piipan.Components.Demo/Components/DemoModalComponent.razor
@@ -1,0 +1,43 @@
+﻿@using Piipan.Components.Modals
+@inject IModalManager ModalManager
+
+@code {
+    [CascadingParameter] public ModalInfo ModalInfo { get; set; }
+    [Parameter] public Action ContinueCallback { get; set; }
+    private void Close()
+    {
+        ModalManager.Close(ModalInfo);
+    }
+    private void Continue()
+    {
+        ModalManager.Close(ModalInfo);
+        if (ContinueCallback != null)
+        {
+            ContinueCallback?.Invoke();    
+        }
+    }
+}
+
+
+<h2 class="usa-modal__heading" id="modal-1-heading">
+    Continue Without Saving?
+</h2>
+<div class="usa-prose">
+    <p id="modal-1-description">
+    Any unsaved changes will be lost.
+    </p>
+</div>
+<div class="usa-modal__footer">
+    <ul class="usa-button-group">
+    <li class="usa-button-group__item">
+        <button type="button" class="usa-button" @onclick="Continue">
+        Continue
+        </button>
+    </li>
+    <li class="usa-button-group__item">
+        <button type="button" class="usa-button usa-button--unstyled padding-105 text-center" @onclick="Close">
+        Cancel and return to form
+        </button>
+    </li>
+    </ul>
+</div>

--- a/components/src/Piipan.Components.Demo/Components/ModalComponent.razor
+++ b/components/src/Piipan.Components.Demo/Components/ModalComponent.razor
@@ -1,0 +1,22 @@
+﻿@using Piipan.Components.Layout
+@using Piipan.Components.Modals
+@using static Piipan.Components.Shared.CommonConstants
+@code {
+    string message = "";
+    private void OpenModal(bool forceAction)
+    {
+        ModalManager.Show(new DemoModalComponent
+        {
+            ContinueCallback = () =>
+            {
+                message = "Continue button pressed";
+                StateHasChanged();
+            }
+        }, new ModalInfo { ForceAction = forceAction });
+    }
+}
+
+<button type="button" @onclick="() => OpenModal(false)" class="@ButtonClass">Show Default Modal</button>
+<button type="button" @onclick="() => OpenModal(true)" class="@ButtonClass">Show Forced Action Modal</button>
+
+<p>@message</p>

--- a/components/src/Piipan.Components.Demo/Pages/Modal.razor
+++ b/components/src/Piipan.Components.Demo/Pages/Modal.razor
@@ -1,0 +1,18 @@
+﻿@page "/modal"
+@using Piipan.Components.Layout
+@inherits BaseComponent
+@code {
+    protected override string[] Files { get; set; } = { "components/ModalComponent.razor", "components/DemoModalComponent.razor" };
+}
+
+<h1>Modal</h1>
+
+<UsaAccordion Multiselectable="true">
+    <UsaAccordionItem StartsExpanded="true">
+        <HeadingContent>Component Demo</HeadingContent>
+        <BodyContent>
+            <ModalComponent />
+        </BodyContent>
+    </UsaAccordionItem>
+    <CodeArea FileContents="fileContents" />
+</UsaAccordion>

--- a/components/src/Piipan.Components.Demo/Program.cs
+++ b/components/src/Piipan.Components.Demo/Program.cs
@@ -1,8 +1,10 @@
-using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Piipan.Components.Modals;
+using Piipan.Components.Routing;
 
 namespace Piipan.Components.Demo
 {
@@ -14,7 +16,8 @@ namespace Piipan.Components.Demo
             builder.RootComponents.Add<App>("app");
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-
+            builder.Services.AddModalManager();
+            builder.Services.AddLockableNavigationManager();
             await builder.Build().RunAsync();
         }
     }

--- a/components/src/Piipan.Components.Demo/Shared/MainLayout.razor
+++ b/components/src/Piipan.Components.Demo/Shared/MainLayout.razor
@@ -1,6 +1,6 @@
 ﻿@inherits LayoutComponentBase
 
-<div class="page">
+<div class="page" id="inert-area">
     <div class="sidebar">
         <NavMenu />
     </div>
@@ -9,3 +9,4 @@
         @Body
     </main>
 </div>
+<ModalContainer />

--- a/components/src/Piipan.Components.Demo/_Imports.razor
+++ b/components/src/Piipan.Components.Demo/_Imports.razor
@@ -11,3 +11,5 @@
 @using Piipan.Components.Layout
 @using Piipan.Components.Demo.Components
 @using Piipan.Components.Demo.Models
+@using Piipan.Components.Modals
+@inject IModalManager ModalManager

--- a/components/src/Piipan.Components.Demo/wwwroot/components/DemoModalComponent.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/components/DemoModalComponent.txt
@@ -1,0 +1,43 @@
+﻿@using Piipan.Components.Modals
+@inject IModalManager ModalManager
+
+@code {
+    [CascadingParameter] public ModalInfo ModalInfo { get; set; }
+    [Parameter] public Action ContinueCallback { get; set; }
+    private void Close()
+    {
+        ModalManager.Close(ModalInfo);
+    }
+    private void Continue()
+    {
+        ModalManager.Close(ModalInfo);
+        if (ContinueCallback != null)
+        {
+            ContinueCallback?.Invoke();    
+        }
+    }
+}
+
+
+<h2 class="usa-modal__heading" id="modal-1-heading">
+    Continue Without Saving?
+</h2>
+<div class="usa-prose">
+    <p id="modal-1-description">
+    Any unsaved changes will be lost.
+    </p>
+</div>
+<div class="usa-modal__footer">
+    <ul class="usa-button-group">
+    <li class="usa-button-group__item">
+        <button type="button" class="usa-button" @onclick="Continue">
+        Continue
+        </button>
+    </li>
+    <li class="usa-button-group__item">
+        <button type="button" class="usa-button usa-button--unstyled padding-105 text-center" @onclick="Close">
+        Cancel and return to form
+        </button>
+    </li>
+    </ul>
+</div>

--- a/components/src/Piipan.Components.Demo/wwwroot/components/InputRadioComponent.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/components/InputRadioComponent.txt
@@ -1,0 +1,14 @@
+﻿@using Piipan.Components.Demo.Models
+@using static Piipan.Components.Shared.CommonConstants
+@code {
+    [Parameter] public InputBooleanModel TextModel { get; set; } = new InputBooleanModel();
+}
+
+<UsaForm Model="TextModel">
+    <UsaRadioGroup @bind-Value="TextModel.NotRequiredField">
+        <UsaRadio Value="true">First Display Text</UsaRadio>
+        <UsaRadio Value="false">Second Display Text</UsaRadio>
+    </UsaRadioGroup>
+    <p>Current value is @TextModel.NotRequiredField</p>
+    <button class="@ButtonClass">Submit</button>
+</UsaForm>

--- a/components/src/Piipan.Components.Demo/wwwroot/components/ModalComponent.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/components/ModalComponent.txt
@@ -1,0 +1,22 @@
+﻿@using Piipan.Components.Layout
+@using Piipan.Components.Modals
+@using static Piipan.Components.Shared.CommonConstants
+@code {
+    string message = "";
+    private void OpenModal(bool forceAction)
+    {
+        ModalManager.Show(new DemoModalComponent
+        {
+            ContinueCallback = () =>
+            {
+                message = "Continue button pressed";
+                StateHasChanged();
+            }
+        }, new ModalInfo { ForceAction = forceAction });
+    }
+}
+
+<button type="button" @onclick="() => OpenModal(false)" class="@ButtonClass">Show Default Modal</button>
+<button type="button" @onclick="() => OpenModal(true)" class="@ButtonClass">Show Forced Action Modal</button>
+
+<p>@message</p>

--- a/components/src/Piipan.Components.Demo/wwwroot/models/InputTextModel.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/models/InputTextModel.txt
@@ -1,5 +1,5 @@
-﻿using Piipan.Components.Validation;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
+using Piipan.Components.Validation;
 
 namespace Piipan.Components.Demo.Models
 {
@@ -14,5 +14,11 @@ namespace Piipan.Components.Demo.Models
         [UsaRequired]
         [Display(Name = "Required Field")]
         public string RequiredField { get; set; }
+    }
+
+    public class InputBooleanModel
+    {
+        [Display(Name = "Optional Field")]
+        public bool? NotRequiredField { get; set; }
     }
 }

--- a/components/src/Piipan.Components/Modals/IModalManager.cs
+++ b/components/src/Piipan.Components/Modals/IModalManager.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace Piipan.Components.Modals
+{
+    public interface IModalManager
+    {
+        public Action ModalsUpdated { get; set; }
+        public List<ModalInfo> OpenModals { get; set; }
+        public void Show<T>(T modal, ModalInfo modalInfo = null) where T : IComponent;
+
+        public void Close(ModalInfo modalInfo);
+    }
+}

--- a/components/src/Piipan.Components/Modals/ModalContainer.razor
+++ b/components/src/Piipan.Components/Modals/ModalContainer.razor
@@ -1,0 +1,74 @@
+﻿@inject IJSRuntime JSRuntime
+
+@code {
+    IJSObjectReference modalJavascriptReference;
+    private DotNetObjectReference<ModalContainer> objRef;
+
+    /// <summary>
+    /// Subscribe to the ModalManager's ModalsUpdated method, so we know to re-render ourself when they get changed.
+    /// </summary>
+    protected override void OnInitialized()
+    {
+        ModalManager.ModalsUpdated += StateHasChanged;
+    }
+
+    /// <summary>
+    /// Whenever the modal container is re-rendered, reset Focus Traps to the top modal only if one exists
+    /// and subscribe to the escape keydown to close the last modal.
+    /// </summary>
+    /// <param name="firstRender"></param>
+    /// <returns></returns>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (modalJavascriptReference == null)
+        {
+            modalJavascriptReference = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Piipan.Components/Modals/ModalContainer.razor.js");    
+        }
+        if (objRef == null)
+        {
+            objRef = DotNetObjectReference.Create(this);
+        }
+        _ = modalJavascriptReference.InvokeVoidAsync("SetFocusTrapsAndEscapeListener", objRef);
+    }
+
+    /// <summary>
+    /// Called from ModalContainer.razor.js when a user hits the Escape key when modals are opened
+    /// Closes the last modal opened as long as it doesn't have an action required
+    /// </summary>
+    [JSInvokable]
+    public void CloseNearestModal()
+    {
+        if (ModalManager.OpenModals.Count > 0)
+        {
+            var modalToClose = ModalManager.OpenModals.Last();
+            if (!modalToClose.ForceAction)
+            {
+                ModalManager.Close(ModalManager.OpenModals.Last());                
+            }
+        }
+    }
+
+    /// <summary>
+    /// If the Modal Overlay is clicked, close the modal unless an action is required.
+    /// </summary>
+    /// <param name="modalInfo"></param>
+    private void ModalOverlayClicked(ModalInfo modalInfo)
+    {
+        if (!modalInfo.ForceAction)
+        {
+            ModalManager.Close(modalInfo);
+        }
+    }
+}
+
+@foreach (var modalInfo in ModalManager.OpenModals) 
+{
+    <div class="usa-modal-wrapper is-visible" role="dialog">
+        <div class="usa-modal-overlay" aria-controls="example-modal-1" @onclick="() => ModalOverlayClicked(modalInfo)">
+            <CascadingValue Value="modalInfo">
+                <UsaModal>@modalInfo.RenderFragment</UsaModal>
+            </CascadingValue>
+        </div>
+    </div>
+}

--- a/components/src/Piipan.Components/Modals/ModalContainer.razor.js
+++ b/components/src/Piipan.Components/Modals/ModalContainer.razor.js
@@ -1,0 +1,39 @@
+﻿let modalsOpened = false;
+let dotNetReference = undefined;
+function EscapeListener(ev) {
+    if (ev.key === "Escape") {
+        return dotNetReference.invokeMethodAsync('CloseNearestModal');
+    }
+}
+
+// Sets the main page to inert, meaning focus cannot go inside it. Only the last modal can have focus go inside it.
+// Also, we add an escape button listener to the ModalContainer, which closes the last opened modal.
+export function SetFocusTrapsAndEscapeListener(callingComponent) {
+    dotNetReference = callingComponent;
+    const modalWrappers = document.querySelectorAll('.usa-modal-wrapper');
+    const inertArea = document.getElementById('inert-area');
+    if (modalWrappers.length === 0) {
+        inertArea?.removeAttribute('inert');
+        if (modalsOpened) {
+            document.removeEventListener('keydown', EscapeListener);
+        }
+        modalsOpened = false;
+    }
+    else {
+        inertArea?.setAttribute('inert', '');
+
+        for (let i = 0; i < modalWrappers.length - 1; i++) {
+            if (i === modalWrappers.length - 1) {
+                modalWrappers.removeAttribute('inert');
+            }
+            else {
+                modalWrappers.setAttribute('inert', '');
+            }
+        }
+        if (!modalsOpened) {
+            document.addEventListener('keydown', EscapeListener);
+        }
+        modalsOpened = true;
+    }
+
+}

--- a/components/src/Piipan.Components/Modals/ModalInfo.cs
+++ b/components/src/Piipan.Components/Modals/ModalInfo.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace Piipan.Components.Modals
+{
+    /// <summary>
+    /// All necessary information to show the modal. Currently this only contains a RenderFragment,
+    /// but more properties could be used in the future.
+    /// </summary>
+    public class ModalInfo
+    {
+        public RenderFragment RenderFragment { get; set; }
+        public bool ForceAction { get; set; }
+    }
+}

--- a/components/src/Piipan.Components/Modals/ModalManager.cs
+++ b/components/src/Piipan.Components/Modals/ModalManager.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Components;
+
+namespace Piipan.Components.Modals
+{
+    /// <summary>
+    /// The manager service that takes care of showing/hiding modals for the application.
+    /// </summary>
+    public class ModalManager : IModalManager
+    {
+        public Action ModalsUpdated { get; set; }
+        public List<ModalInfo> OpenModals { get; set; } = new List<ModalInfo>();
+
+        // Creates the ModalInfo and adds it to our open modals, and then calls ModalsUpdated.
+        // This will get picked up by the ModalContainer to render all open modals.
+        public void Show<T>(T modal, ModalInfo modalInfo = null) where T : IComponent
+        {
+            Type modalType = typeof(T);
+            var properties = modalType.GetProperties()
+                .Where(prop => prop.IsDefined(typeof(ParameterAttribute), false));
+
+            modalInfo ??= new ModalInfo();
+            modalInfo.RenderFragment = new RenderFragment(n =>
+            {
+                n.OpenComponent<T>(1);
+
+                int sequenceNum = 2;
+                foreach (var prop in properties)
+                {
+                    object value = prop.GetValue(modal);
+                    n.AddAttribute(sequenceNum++, prop.Name, value);
+                }
+
+                n.CloseComponent();
+            });
+            OpenModals.Add(modalInfo);
+            ModalsUpdated?.Invoke();
+        }
+
+        // Removes the given modalInfo from our open modals, and then calls ModalsUpdated.
+        // This will get picked up by the ModalContainer to render all remaining open modals.
+        public void Close(ModalInfo modalInfo)
+        {
+            OpenModals.Remove(modalInfo);
+            ModalsUpdated?.Invoke();
+        }
+    }
+}

--- a/components/src/Piipan.Components/Modals/ModalServiceCollectionExtensions.cs
+++ b/components/src/Piipan.Components/Modals/ModalServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Piipan.Components.Modals
+{
+    public static class ModalServiceCollectionExtensions
+    {
+        /// <summary>Adds services for the Modal Manager.</summary>
+        /// <param name="services">The service collection to register with.</param>
+        public static void AddModalManager(this IServiceCollection services)
+        {
+            services.AddScoped<IModalManager, ModalManager>();
+        }
+    }
+}

--- a/components/src/Piipan.Components/Modals/UsaModal.razor
+++ b/components/src/Piipan.Components/Modals/UsaModal.razor
@@ -1,0 +1,28 @@
+﻿@code {
+    [Parameter] public RenderFragment ChildContent { get; set; }
+    [CascadingParameter] public ModalInfo ModalInfo { get; set; }
+}
+
+  <div
+    class="usa-modal"
+    aria-labelledby="modal-1-heading"
+    aria-describedby="modal-1-description"
+    @onclick:stopPropagation="true">
+    <div class="usa-modal__content">
+      <div class="usa-modal__main">
+        @ChildContent
+      </div>
+      @if (!ModalInfo.ForceAction)
+        {
+          <button
+            class="usa-button usa-modal__close"
+            aria-label="Close this window"
+            @onclick="() => ModalManager.Close(ModalInfo)"
+          >
+            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+              <use xlink:href="/images/sprite.svg#close"></use>
+            </svg>
+          </button>            
+        }
+    </div>
+  </div>

--- a/components/src/Piipan.Components/Modals/UsaModal.razor.css
+++ b/components/src/Piipan.Components/Modals/UsaModal.razor.css
@@ -1,0 +1,11 @@
+﻿.usa-modal {
+    max-width: 29rem;
+}
+
+.usa-modal .usa-modal__main {
+    margin: 0 1.25rem;
+}
+
+.usa-modal ::deep .usa-modal__heading {
+    margin-bottom: 1rem;
+}

--- a/components/src/Piipan.Components/Routing/HotReloadManager.cs
+++ b/components/src/Piipan.Components/Routing/HotReloadManager.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.Metadata;
+
+[assembly: MetadataUpdateHandler(typeof(Piipan.Components.Routing.HotReloadManager))]
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    internal static class HotReloadManager
+    {
+        public static event Action? OnDeltaApplied;
+
+        /// <summary>
+        /// Gets a value that determines if OnDeltaApplied is subscribed to.
+        /// </summary>
+        public static bool IsSubscribedTo => OnDeltaApplied is not null;
+
+        /// <summary>
+        /// MetadataUpdateHandler event. This is invoked by the hot reload host via reflection.
+        /// </summary>
+        public static void UpdateApplication(Type[]? _) => OnDeltaApplied?.Invoke();
+    }
+}

--- a/components/src/Piipan.Components/Routing/NavigationContext.cs
+++ b/components/src/Piipan.Components/Routing/NavigationContext.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Piipan.Components.Routing;
+
+[ExcludeFromCodeCoverage]
+/// <summary>
+/// Provides information about the current asynchronous navigation event
+/// including the target path and the cancellation token.
+/// </summary>
+public sealed class NavigationContext
+{
+    internal NavigationContext(string path, CancellationToken cancellationToken)
+    {
+        Path = path;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>
+    /// The target path for the navigation.
+    /// </summary>
+    public string Path { get; }
+
+    /// <summary>
+    /// The <see cref="CancellationToken"/> to use to cancel navigation.
+    /// </summary>
+    public CancellationToken CancellationToken { get; }
+}

--- a/components/src/Piipan.Components/Routing/NavigationManagerExtensions.cs
+++ b/components/src/Piipan.Components/Routing/NavigationManagerExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Piipan.Components.Routing
+{
+    public static class NavigationManagerExtensions
+    {
+        /// <summary>Adds services for the lockable navigation manager.</summary>
+        /// <param name="services">The service collection to register with.</param>
+        public static void AddLockableNavigationManager(this IServiceCollection services)
+        {
+            services.AddScoped<PiipanNavigationManager>();
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/PiipanNavigationManager.cs
+++ b/components/src/Piipan.Components/Routing/PiipanNavigationManager.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace Piipan.Components.Routing;
+
+public class PiipanNavigationManager : NavigationManager, IDisposable
+{
+    public PiipanNavigationManager(NavigationManager parent)
+    {
+        _Parent = parent;
+        _Parent.LocationChanged += Parent_LocationChanged;
+    }
+
+    public void Dispose()
+    {
+        _Parent.LocationChanged -= Parent_LocationChanged;
+    }
+
+    private readonly NavigationManager _Parent;
+    private bool _IsBlindNavigation;
+
+    public bool BlockNavigation { get; set; } = false;
+
+    public event EventHandler<LocationChangedEventArgs>? NavigationBlocked;
+
+    private void Parent_LocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        if (_IsBlindNavigation)
+        {
+            _IsBlindNavigation = false;
+            return;
+        }
+
+        if (e.IsNavigationIntercepted && BlockNavigation)
+        {
+            _IsBlindNavigation = true;
+            _Parent.NavigateTo(Uri, false, true);
+
+            NavigationBlocked?.Invoke(this, e);
+            return;
+        }
+        else if (e.IsNavigationIntercepted)
+        {
+            _Parent.NavigateTo(e.Location, true);
+        }
+        _IsBlindNavigation = false;
+        BlockNavigation = false;
+        Uri = e.Location;
+        NotifyLocationChanged(e.IsNavigationIntercepted);
+    }
+
+    protected override void EnsureInitialized()
+    {
+        Initialize(_Parent.BaseUri, _Parent.Uri);
+
+        base.EnsureInitialized();
+    }
+
+    protected override void NavigateToCore(string uri, NavigationOptions options)
+    {
+        if (BlockNavigation)
+        {
+            // navigation is locked; notify but otherwise do nothing
+            NavigationBlocked?.Invoke(this, new LocationChangedEventArgs(uri, false));
+            return;
+        }
+
+        // navigation is unlocked; pass on to parent manager
+        _Parent.NavigateTo(uri, options);
+    }
+}

--- a/components/src/Piipan.Components/Routing/PiipanRouter.cs
+++ b/components/src/Piipan.Components/Routing/PiipanRouter.cs
@@ -1,0 +1,277 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src with a few modifications
+// 
+
+#nullable disable warnings
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace Piipan.Components.Routing
+{
+    /// <summary>
+    /// A component that supplies route data corresponding to the current navigation state.
+    /// </summary>
+    public class PiipanRouter : IComponent, IHandleAfterRender, IDisposable
+    {
+        static readonly char[] _queryOrHashStartChar = new[] { '?', '#' };
+        // Dictionary is intentionally used instead of ReadOnlyDictionary to reduce Blazor size
+        static readonly IReadOnlyDictionary<string, object> _emptyParametersDictionary
+            = new Dictionary<string, object>();
+
+        RenderHandle _renderHandle;
+        string _baseUri;
+        string _locationAbsolute;
+        bool _navigationInterceptionEnabled;
+        ILogger<Router> _logger;
+
+        private CancellationTokenSource _onNavigateCts;
+
+        private Task _previousOnNavigateTask = Task.CompletedTask;
+
+        private RouteKey _routeTableLastBuiltForRouteKey;
+
+        private bool _onNavigateCalled;
+
+        // Piipan Update: Switch NavigationManager to BlockableNavigationManager
+        [Inject] private PiipanNavigationManager NavigationManager { get; set; }
+
+        [Inject] private INavigationInterception NavigationInterception { get; set; }
+
+        [Inject] private ILoggerFactory LoggerFactory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the assembly that should be searched for components matching the URI.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public Assembly AppAssembly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a collection of additional assemblies that should be searched for components
+        /// that can match URIs.
+        /// </summary>
+        [Parameter] public IEnumerable<Assembly> AdditionalAssemblies { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content to display when a match is found for the requested route.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        /// Get or sets the content to display when asynchronous navigation is in progress.
+        /// </summary>
+        [Parameter] public RenderFragment? Navigating { get; set; }
+
+        /// <summary>
+        /// Gets or sets a handler that should be called before navigating to a new page.
+        /// </summary>
+        [Parameter] public EventCallback<NavigationContext> OnNavigateAsync { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag to indicate whether route matching should prefer exact matches
+        /// over wildcards.
+        /// <para>This property is obsolete and configuring it does nothing.</para>
+        /// </summary>
+        [Parameter] public bool PreferExactMatches { get; set; }
+
+        private RouteTable Routes { get; set; }
+
+        /// <inheritdoc />
+        public void Attach(RenderHandle renderHandle)
+        {
+            _logger = LoggerFactory.CreateLogger<Router>();
+            _renderHandle = renderHandle;
+            _baseUri = NavigationManager.BaseUri;
+            _locationAbsolute = NavigationManager.Uri;
+            NavigationManager.LocationChanged += OnLocationChanged;
+
+            if (TestableMetadataUpdate.IsSupported)
+            {
+                HotReloadManager.OnDeltaApplied += ClearRouteCaches;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task SetParametersAsync(ParameterView parameters)
+        {
+            parameters.SetParameterProperties(this);
+
+            if (AppAssembly == null)
+            {
+                throw new InvalidOperationException($"The {nameof(Router)} component requires a value for the parameter {nameof(AppAssembly)}.");
+            }
+
+            if (!_onNavigateCalled)
+            {
+                _onNavigateCalled = true;
+                await RunOnNavigateAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), isNavigationIntercepted: false);
+            }
+
+            Refresh(isNavigationIntercepted: false);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            NavigationManager.LocationChanged -= OnLocationChanged;
+            if (TestableMetadataUpdate.IsSupported)
+            {
+                HotReloadManager.OnDeltaApplied -= ClearRouteCaches;
+            }
+        }
+
+        private static string StringUntilAny(string str, char[] chars)
+        {
+            var firstIndex = str.IndexOfAny(chars);
+            return firstIndex < 0
+                ? str
+                : str.Substring(0, firstIndex);
+        }
+
+        private void RefreshRouteTable()
+        {
+            var routeKey = new RouteKey(AppAssembly, AdditionalAssemblies);
+
+            if (!routeKey.Equals(_routeTableLastBuiltForRouteKey))
+            {
+                _routeTableLastBuiltForRouteKey = routeKey;
+                Routes = RouteTableFactory.Create(routeKey);
+            }
+        }
+
+        private void ClearRouteCaches()
+        {
+            RouteTableFactory.ClearCaches();
+            _routeTableLastBuiltForRouteKey = default;
+        }
+
+        internal virtual void Refresh(bool isNavigationIntercepted)
+        {
+            // If an `OnNavigateAsync` task is currently in progress, then wait
+            // for it to complete before rendering. Note: because _previousOnNavigateTask
+            // is initialized to a CompletedTask on initialization, this will still
+            // allow first-render to complete successfully.
+            if (_previousOnNavigateTask.Status != TaskStatus.RanToCompletion)
+            {
+                if (Navigating != null)
+                {
+                    _renderHandle.Render(Navigating);
+                }
+                return;
+            }
+
+            RefreshRouteTable();
+
+            var locationPath = NavigationManager.ToBaseRelativePath(_locationAbsolute);
+            locationPath = StringUntilAny(locationPath, _queryOrHashStartChar);
+            var context = new RouteContext(locationPath);
+            Routes.Route(context);
+
+            // Piipan Update: Since WebAssembly is not doing the rendering (we are server side rendering),
+            // we should just render here instead of checking NotFound.
+            // This is because if the PiipanRouter is executing the page is found!
+            _renderHandle.Render(ChildContent);
+        }
+
+        internal async ValueTask RunOnNavigateAsync(string path, bool isNavigationIntercepted)
+        {
+            // Cancel the CTS instead of disposing it, since disposing does not
+            // actually cancel and can cause unintended Object Disposed Exceptions.
+            // This effectivelly cancels the previously running task and completes it.
+            _onNavigateCts?.Cancel();
+            // Then make sure that the task has been completely cancelled or completed
+            // before starting the next one. This avoid race conditions where the cancellation
+            // for the previous task was set but not fully completed by the time we get to this
+            // invocation.
+            await _previousOnNavigateTask;
+
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _previousOnNavigateTask = tcs.Task;
+
+            if (!OnNavigateAsync.HasDelegate)
+            {
+                Refresh(isNavigationIntercepted);
+            }
+
+            _onNavigateCts = new CancellationTokenSource();
+            var navigateContext = new NavigationContext(path, _onNavigateCts.Token);
+
+            var cancellationTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            navigateContext.CancellationToken.Register(state =>
+                ((TaskCompletionSource)state).SetResult(), cancellationTcs);
+
+            try
+            {
+                // Task.WhenAny returns a Task<Task> so we need to await twice to unwrap the exception
+                var task = await Task.WhenAny(OnNavigateAsync.InvokeAsync(navigateContext), cancellationTcs.Task);
+                await task;
+                tcs.SetResult();
+                Refresh(isNavigationIntercepted);
+            }
+            catch (Exception e)
+            {
+                _renderHandle.Render(builder => ExceptionDispatchInfo.Throw(e));
+            }
+        }
+
+        private void OnLocationChanged(object sender, LocationChangedEventArgs args)
+        {
+            _locationAbsolute = args.Location;
+            if (_renderHandle.IsInitialized && Routes != null)
+            {
+                _ = RunOnNavigateAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), args.IsNavigationIntercepted).Preserve();
+            }
+        }
+
+        Task IHandleAfterRender.OnAfterRenderAsync()
+        {
+            if (!_navigationInterceptionEnabled)
+            {
+                _navigationInterceptionEnabled = true;
+                return NavigationInterception.EnableNavigationInterceptionAsync();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static class Log
+        {
+            private static readonly Action<ILogger, string, string, Exception> _displayingNotFound =
+                LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(1, "DisplayingNotFound"), $"Displaying because path '{{Path}}' with base URI '{{BaseUri}}' does not match any component route");
+
+            private static readonly Action<ILogger, Type, string, string, Exception> _navigatingToComponent =
+                LoggerMessage.Define<Type, string, string>(LogLevel.Debug, new EventId(2, "NavigatingToComponent"), "Navigating to component {ComponentType} in response to path '{Path}' with base URI '{BaseUri}'");
+
+            private static readonly Action<ILogger, string, string, string, Exception> _navigatingToExternalUri =
+                LoggerMessage.Define<string, string, string>(LogLevel.Debug, new EventId(3, "NavigatingToExternalUri"), "Navigating to non-component URI '{ExternalUri}' in response to path '{Path}' with base URI '{BaseUri}'");
+
+            internal static void DisplayingNotFound(ILogger logger, string path, string baseUri)
+            {
+                _displayingNotFound(logger, path, baseUri, null);
+            }
+
+            internal static void NavigatingToComponent(ILogger logger, Type componentType, string path, string baseUri)
+            {
+                _navigatingToComponent(logger, componentType, path, baseUri, null);
+            }
+
+            internal static void NavigatingToExternalUri(ILogger logger, string externalUri, string path, string baseUri)
+            {
+                _navigatingToExternalUri(logger, externalUri, path, baseUri, null);
+            }
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/RouteConstraint.cs
+++ b/components/src/Piipan.Components/Routing/RouteConstraint.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    internal static class RouteConstraint
+    {
+        public static UrlValueConstraint Parse(string template, string segment, string constraint)
+        {
+            if (string.IsNullOrEmpty(constraint))
+            {
+                throw new ArgumentException($"Malformed segment '{segment}' in route '{template}' contains an empty constraint.");
+            }
+
+            var targetType = GetTargetType(constraint);
+            if (targetType is null || !UrlValueConstraint.TryGetByTargetType(targetType, out var result))
+            {
+                throw new ArgumentException($"Unsupported constraint '{constraint}' in route '{template}'.");
+            }
+
+            return result;
+        }
+
+        private static Type? GetTargetType(string constraint) => constraint switch
+        {
+            "bool" => typeof(bool),
+            "datetime" => typeof(DateTime),
+            "decimal" => typeof(decimal),
+            "double" => typeof(double),
+            "float" => typeof(float),
+            "guid" => typeof(Guid),
+            "int" => typeof(int),
+            "long" => typeof(long),
+            _ => null,
+        };
+    }
+}

--- a/components/src/Piipan.Components/Routing/RouteContext.cs
+++ b/components/src/Piipan.Components/Routing/RouteContext.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    internal class RouteContext
+    {
+        private static readonly char[] Separator = new[] { '/' };
+
+        public RouteContext(string path)
+        {
+            // This is a simplification. We are assuming there are no paths like /a//b/. A proper routing
+            // implementation would be more sophisticated.
+            Segments = path.Trim('/').Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+            // Individual segments are URL-decoded in order to support arbitrary characters, assuming UTF-8 encoding.
+            for (int i = 0; i < Segments.Length; i++)
+            {
+                Segments[i] = Uri.UnescapeDataString(Segments[i]);
+            }
+        }
+
+        public string[] Segments { get; }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        public Type? Handler { get; set; }
+
+        public IReadOnlyDictionary<string, object>? Parameters { get; set; }
+    }
+}

--- a/components/src/Piipan.Components/Routing/RouteEntry.cs
+++ b/components/src/Piipan.Components/Routing/RouteEntry.cs
@@ -1,0 +1,154 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+#nullable disable warnings
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    [DebuggerDisplay("Handler = {Handler}, Template = {Template}")]
+    internal class RouteEntry
+    {
+        public RouteEntry(RouteTemplate template, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type handler, List<string>? unusedRouteParameterNames)
+        {
+            Template = template;
+            UnusedRouteParameterNames = unusedRouteParameterNames;
+            Handler = handler;
+        }
+
+        public RouteTemplate Template { get; }
+
+        public List<string>? UnusedRouteParameterNames { get; }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        public Type Handler { get; }
+
+        internal void Match(RouteContext context)
+        {
+            var pathIndex = 0;
+            var templateIndex = 0;
+            Dictionary<string, object> parameters = null;
+            // We will iterate over the path segments and the template segments until we have consumed
+            // one of them.
+            // There are three cases we need to account here for:
+            // * Path is shorter than template ->
+            //   * This can match only if we have t-p optional parameters at the end.
+            // * Path and template have the same number of segments
+            //   * This can happen when the catch-all segment matches 1 segment
+            //   * This can happen when an optional parameter has been specified.
+            //   * This can happen when the route only contains literals and parameters.
+            // * Path is longer than template -> This can only match if the parameter has a catch-all at the end.
+            //   * We still need to iterate over all the path segments if the catch-all is constrained.
+            //   * We still need to iterate over all the template/path segments before the catch-all
+            while (pathIndex < context.Segments.Length && templateIndex < Template.Segments.Length)
+            {
+                var pathSegment = context.Segments[pathIndex];
+                var templateSegment = Template.Segments[templateIndex];
+
+                var matches = templateSegment.Match(pathSegment, out var match);
+                if (!matches)
+                {
+                    // A constraint or literal didn't match
+                    return;
+                }
+
+                if (!templateSegment.IsCatchAll)
+                {
+                    // We were dealing with a literal or a parameter, so just advance both cursors.
+                    pathIndex++;
+                    templateIndex++;
+
+                    if (templateSegment.IsParameter)
+                    {
+                        parameters ??= new(StringComparer.OrdinalIgnoreCase);
+                        parameters[templateSegment.Value] = match;
+                    }
+                }
+                else
+                {
+                    if (templateSegment.Constraints.Length == 0)
+                    {
+
+                        // Unconstrained catch all, we can stop early
+                        parameters ??= new(StringComparer.OrdinalIgnoreCase);
+                        parameters[templateSegment.Value] = string.Join('/', context.Segments, pathIndex, context.Segments.Length - pathIndex);
+
+                        // Mark the remaining segments as consumed.
+                        pathIndex = context.Segments.Length;
+
+                        // Catch-alls are always last.
+                        templateIndex++;
+
+                        // We are done, so break out of the loop.
+                        break;
+                    }
+                    else
+                    {
+                        // For constrained catch-alls, we advance the path index but keep the template index on the catch-all.
+                        pathIndex++;
+                        if (pathIndex == context.Segments.Length)
+                        {
+                            parameters ??= new(StringComparer.OrdinalIgnoreCase);
+                            parameters[templateSegment.Value] = string.Join('/', context.Segments, templateIndex, context.Segments.Length - templateIndex);
+
+                            // This is important to signal that we consumed the entire template.
+                            templateIndex++;
+                        }
+                    }
+                }
+            }
+
+            var hasRemainingOptionalSegments = templateIndex < Template.Segments.Length &&
+                RemainingSegmentsAreOptional(pathIndex, Template.Segments);
+
+            if ((pathIndex == context.Segments.Length && templateIndex == Template.Segments.Length) || hasRemainingOptionalSegments)
+            {
+                if (hasRemainingOptionalSegments)
+                {
+                    parameters ??= new Dictionary<string, object>(StringComparer.Ordinal);
+                    AddDefaultValues(parameters, templateIndex, Template.Segments);
+                }
+                if (UnusedRouteParameterNames?.Count > 0)
+                {
+                    parameters ??= new Dictionary<string, object>(StringComparer.Ordinal);
+                    for (var i = 0; i < UnusedRouteParameterNames.Count; i++)
+                    {
+                        parameters[UnusedRouteParameterNames[i]] = null;
+                    }
+                }
+                context.Handler = Handler;
+                context.Parameters = parameters;
+            }
+        }
+
+        private void AddDefaultValues(Dictionary<string, object> parameters, int templateIndex, TemplateSegment[] segments)
+        {
+            for (var i = templateIndex; i < segments.Length; i++)
+            {
+                var currentSegment = segments[i];
+                parameters[currentSegment.Value] = null;
+            }
+        }
+
+        private bool RemainingSegmentsAreOptional(int index, TemplateSegment[] segments)
+        {
+            for (var i = index; index < segments.Length - 1; index++)
+            {
+                if (!segments[i].IsOptional)
+                {
+                    return false;
+                }
+            }
+
+            return segments[^1].IsOptional || segments[^1].IsCatchAll;
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/RouteKey.cs
+++ b/components/src/Piipan.Components/Routing/RouteKey.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    internal readonly struct RouteKey : IEquatable<RouteKey>
+    {
+        public readonly Assembly? AppAssembly;
+        public readonly HashSet<Assembly>? AdditionalAssemblies;
+
+        public RouteKey(Assembly appAssembly, IEnumerable<Assembly> additionalAssemblies)
+        {
+            AppAssembly = appAssembly;
+            AdditionalAssemblies = additionalAssemblies is null ? null : new HashSet<Assembly>(additionalAssemblies);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is RouteKey other && Equals(other);
+        }
+
+        public bool Equals(RouteKey other)
+        {
+            if (!Equals(AppAssembly, other.AppAssembly))
+            {
+                return false;
+            }
+
+            if (AdditionalAssemblies is null && other.AdditionalAssemblies is null)
+            {
+                return true;
+            }
+
+            if (AdditionalAssemblies is null || other.AdditionalAssemblies is null)
+            {
+                return false;
+            }
+
+            return AdditionalAssemblies.Count == other.AdditionalAssemblies.Count &&
+                AdditionalAssemblies.SetEquals(other.AdditionalAssemblies);
+        }
+
+        public override int GetHashCode()
+        {
+            if (AppAssembly is null)
+            {
+                return 0;
+            }
+
+            if (AdditionalAssemblies is null)
+            {
+                return AppAssembly.GetHashCode();
+            }
+
+            // Producing a hash code that includes individual assemblies requires it to have a stable order.
+            // We'll avoid the cost of sorting and simply include the number of assemblies instead.
+            return HashCode.Combine(AppAssembly, AdditionalAssemblies.Count);
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/RouteTable.cs
+++ b/components/src/Piipan.Components/Routing/RouteTable.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    internal class RouteTable
+    {
+        public RouteTable(RouteEntry[] routes)
+        {
+            Routes = routes;
+        }
+
+        public RouteEntry[] Routes { get; }
+
+        public void Route(RouteContext routeContext)
+        {
+            for (var i = 0; i < Routes.Length; i++)
+            {
+                Routes[i].Match(routeContext);
+                if (routeContext.Handler != null)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/RouteTableFactory.cs
+++ b/components/src/Piipan.Components/Routing/RouteTableFactory.cs
@@ -1,0 +1,249 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    /// <summary>
+    /// Resolves components for an application.
+    /// </summary>
+    internal static class RouteTableFactory
+    {
+        private static readonly ConcurrentDictionary<RouteKey, RouteTable> Cache = new();
+        public static readonly IComparer<RouteEntry> RoutePrecedence = Comparer<RouteEntry>.Create(RouteComparison);
+
+        public static RouteTable Create(RouteKey routeKey)
+        {
+            if (Cache.TryGetValue(routeKey, out var resolvedComponents))
+            {
+                return resolvedComponents;
+            }
+
+            var componentTypes = GetRouteableComponents(routeKey);
+            var routeTable = Create(componentTypes);
+            Cache.TryAdd(routeKey, routeTable);
+            return routeTable;
+        }
+
+        public static void ClearCaches() => Cache.Clear();
+
+        private static List<Type> GetRouteableComponents(RouteKey routeKey)
+        {
+            var routeableComponents = new List<Type>();
+            if (routeKey.AppAssembly is not null)
+            {
+                GetRouteableComponents(routeableComponents, routeKey.AppAssembly);
+            }
+
+            if (routeKey.AdditionalAssemblies is not null)
+            {
+                foreach (var assembly in routeKey.AdditionalAssemblies)
+                {
+                    GetRouteableComponents(routeableComponents, assembly);
+                }
+            }
+
+            return routeableComponents;
+
+            static void GetRouteableComponents(List<Type> routeableComponents, Assembly assembly)
+            {
+                foreach (var type in assembly.ExportedTypes)
+                {
+                    if (typeof(IComponent).IsAssignableFrom(type) && type.IsDefined(typeof(RouteAttribute)))
+                    {
+                        routeableComponents.Add(type);
+                    }
+                }
+            }
+        }
+
+        internal static RouteTable Create(List<Type> componentTypes)
+        {
+            var templatesByHandler = new Dictionary<Type, string[]>();
+            foreach (var componentType in componentTypes)
+            {
+                // We're deliberately using inherit = false here.
+                //
+                // RouteAttribute is defined as non-inherited, because inheriting a route attribute always causes an
+                // ambiguity. You end up with two components (base class and derived class) with the same route.
+                var routeAttributes = componentType.GetCustomAttributes(typeof(RouteAttribute), inherit: false);
+                var templates = new string[routeAttributes.Length];
+                for (var i = 0; i < routeAttributes.Length; i++)
+                {
+                    var attribute = (RouteAttribute)routeAttributes[i];
+                    templates[i] = attribute.Template;
+                }
+
+                templatesByHandler.Add(componentType, templates);
+            }
+            return Create(templatesByHandler);
+        }
+
+        internal static RouteTable Create(Dictionary<Type, string[]> templatesByHandler)
+        {
+            var routes = new List<RouteEntry>();
+            foreach (var (type, templates) in templatesByHandler)
+            {
+                var allRouteParameterNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var parsedTemplates = new (RouteTemplate, HashSet<string>)[templates.Length];
+                for (var i = 0; i < templates.Length; i++)
+                {
+                    var parsedTemplate = TemplateParser.ParseTemplate(templates[i]);
+                    var parameterNames = GetParameterNames(parsedTemplate);
+                    parsedTemplates[i] = (parsedTemplate, parameterNames);
+
+                    foreach (var parameterName in parameterNames)
+                    {
+                        allRouteParameterNames.Add(parameterName);
+                    }
+                }
+
+                foreach (var (parsedTemplate, routeParameterNames) in parsedTemplates)
+                {
+                    var unusedRouteParameterNames = GetUnusedParameterNames(allRouteParameterNames, routeParameterNames);
+                    var entry = new RouteEntry(parsedTemplate, type, unusedRouteParameterNames);
+                    routes.Add(entry);
+                }
+            }
+
+            routes.Sort(RoutePrecedence);
+            return new RouteTable(routes.ToArray());
+        }
+
+        private static HashSet<string> GetParameterNames(RouteTemplate routeTemplate)
+        {
+            var parameterNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var segment in routeTemplate.Segments)
+            {
+                if (segment.IsParameter)
+                {
+                    parameterNames.Add(segment.Value);
+                }
+            }
+
+            return parameterNames;
+        }
+
+        private static List<string>? GetUnusedParameterNames(HashSet<string> allRouteParameterNames, HashSet<string> routeParameterNames)
+        {
+            List<string>? unusedParameters = null;
+            foreach (var item in allRouteParameterNames)
+            {
+                if (!routeParameterNames.Contains(item))
+                {
+                    unusedParameters ??= new();
+                    unusedParameters.Add(item);
+                }
+            }
+
+            return unusedParameters;
+        }
+
+        /// <summary>
+        /// Route precedence algorithm.
+        /// We collect all the routes and sort them from most specific to
+        /// less specific. The specificity of a route is given by the specificity
+        /// of its segments and the position of those segments in the route.
+        /// * A literal segment is more specific than a parameter segment.
+        /// * A parameter segment with more constraints is more specific than one with fewer constraints
+        /// * Segment earlier in the route are evaluated before segments later in the route.
+        /// For example:
+        /// /Literal is more specific than /Parameter
+        /// /Route/With/{parameter} is more specific than /{multiple}/With/{parameters}
+        /// /Product/{id:int} is more specific than /Product/{id}
+        ///
+        /// Routes can be ambiguous if:
+        /// They are composed of literals and those literals have the same values (case insensitive)
+        /// They are composed of a mix of literals and parameters, in the same relative order and the
+        /// literals have the same values.
+        /// For example:
+        /// * /literal and /Literal
+        /// /{parameter}/literal and /{something}/literal
+        /// /{parameter:constraint}/literal and /{something:constraint}/literal
+        ///
+        /// To calculate the precedence we sort the list of routes as follows:
+        /// * Shorter routes go first.
+        /// * A literal wins over a parameter in precedence.
+        /// * For literals with different values (case insensitive) we choose the lexical order
+        /// * For parameters with different numbers of constraints, the one with more wins
+        /// If we get to the end of the comparison routing we've detected an ambiguous pair of routes.
+        /// </summary>
+        internal static int RouteComparison(RouteEntry x, RouteEntry y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            var xTemplate = x.Template;
+            var yTemplate = y.Template;
+            var minSegments = Math.Min(xTemplate.Segments.Length, yTemplate.Segments.Length);
+            var currentResult = 0;
+            for (var i = 0; i < minSegments; i++)
+            {
+                var xSegment = xTemplate.Segments[i];
+                var ySegment = yTemplate.Segments[i];
+
+                var xRank = GetRank(xSegment);
+                var yRank = GetRank(ySegment);
+
+                currentResult = xRank.CompareTo(yRank);
+
+                // If they are both literals we can disambiguate
+                if ((xRank, yRank) == (0, 0))
+                {
+                    currentResult = StringComparer.OrdinalIgnoreCase.Compare(xSegment.Value, ySegment.Value);
+                }
+
+                if (currentResult != 0)
+                {
+                    break;
+                }
+            }
+
+            if (currentResult == 0)
+            {
+                currentResult = xTemplate.Segments.Length.CompareTo(yTemplate.Segments.Length);
+            }
+
+            if (currentResult == 0)
+            {
+                throw new InvalidOperationException($@"The following routes are ambiguous:
+'{x.Template.TemplateText}' in '{x.Handler.FullName}'
+'{y.Template.TemplateText}' in '{y.Handler.FullName}'
+");
+            }
+
+            return currentResult;
+        }
+
+        private static int GetRank(TemplateSegment xSegment)
+        {
+            return xSegment switch
+            {
+                // Literal
+                { IsParameter: false } => 0,
+                // Parameter with constraints
+                { IsParameter: true, IsCatchAll: false, Constraints: { Length: > 0 } } => 1,
+                // Parameter without constraints
+                { IsParameter: true, IsCatchAll: false, Constraints: { Length: 0 } } => 2,
+                // Catch all parameter with constraints
+                { IsParameter: true, IsCatchAll: true, Constraints: { Length: > 0 } } => 3,
+                // Catch all parameter without constraints
+                { IsParameter: true, IsCatchAll: true, Constraints: { Length: 0 } } => 4,
+                // The segment is not correct
+                _ => throw new InvalidOperationException($"Unknown segment definition '{xSegment}.")
+            };
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/RouteTemplate.cs
+++ b/components/src/Piipan.Components/Routing/RouteTemplate.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    [DebuggerDisplay("{TemplateText}")]
+    internal class RouteTemplate
+    {
+        public RouteTemplate(string templateText, TemplateSegment[] segments)
+        {
+            TemplateText = templateText;
+            Segments = segments;
+
+            for (var i = 0; i < segments.Length; i++)
+            {
+                var segment = segments[i];
+                if (segment.IsOptional)
+                {
+                    OptionalSegmentsCount++;
+                }
+                if (segment.IsCatchAll)
+                {
+                    ContainsCatchAllSegment = true;
+                }
+            }
+        }
+
+        public string TemplateText { get; }
+
+        public TemplateSegment[] Segments { get; }
+
+        public int OptionalSegmentsCount { get; }
+
+        public bool ContainsCatchAllSegment { get; }
+    }
+}

--- a/components/src/Piipan.Components/Routing/StringSegmentAccumulator.cs
+++ b/components/src/Piipan.Components/Routing/StringSegmentAccumulator.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    // This is very similar to Microsoft.Extensions.Primitives.StringValues, except it works in terms
+    // of ReadOnlyMemory<char> rather than string, so the querystring handling logic doesn't need to
+    // allocate per-value when tracking things that will be parsed as value types.
+    internal struct StringSegmentAccumulator
+    {
+        private int count;
+        private ReadOnlyMemory<char> _single;
+        private List<ReadOnlyMemory<char>>? _multiple;
+
+        public ReadOnlyMemory<char> this[int index]
+        {
+            get
+            {
+                if (index >= count)
+                {
+                    throw new IndexOutOfRangeException();
+                }
+
+                return count == 1 ? _single : _multiple![index];
+            }
+        }
+
+        public int Count => count;
+
+        public void SetSingle(ReadOnlyMemory<char> value)
+        {
+            _single = value;
+
+            if (count != 1)
+            {
+                if (count > 1)
+                {
+                    _multiple = null;
+                }
+
+                count = 1;
+            }
+        }
+
+        public void Add(ReadOnlyMemory<char> value)
+        {
+            switch (count++)
+            {
+                case 0:
+                    _single = value;
+                    break;
+                case 1:
+                    _multiple = new();
+                    _multiple.Add(_single);
+                    _multiple.Add(value);
+                    _single = default;
+                    break;
+                default:
+                    _multiple!.Add(value);
+                    break;
+            }
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/TemplateParser.cs
+++ b/components/src/Piipan.Components/Routing/TemplateParser.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    // This implementation is temporary, in the future we'll want to have
+    // a more performant/properly designed routing set of abstractions.
+    // To be more precise these are some things we are scoping out:
+    // * We are not doing link generation.
+    // * We are not supporting all the route constraint formats supported by ASP.NET server-side routing.
+    // The class in here just takes care of parsing a route and extracting
+    // simple parameters from it.
+    // Some differences with ASP.NET Core routes are:
+    // * We don't support complex segments.
+    // The things that we support are:
+    // * Literal path segments. (Like /Path/To/Some/Page)
+    // * Parameter path segments (Like /Customer/{Id}/Orders/{OrderId})
+    // * Catch-all parameters (Like /blog/{*slug})
+    internal class TemplateParser
+    {
+        public static readonly char[] InvalidParameterNameCharacters =
+            new char[] { '{', '}', '=', '.' };
+
+        internal static RouteTemplate ParseTemplate(string template)
+        {
+            var originalTemplate = template;
+            template = template.Trim('/');
+            if (template == string.Empty)
+            {
+                // Special case "/";
+                return new RouteTemplate("/", Array.Empty<TemplateSegment>());
+            }
+
+            var segments = template.Split('/');
+            var templateSegments = new TemplateSegment[segments.Length];
+            for (int i = 0; i < segments.Length; i++)
+            {
+                var segment = segments[i];
+                if (string.IsNullOrEmpty(segment))
+                {
+                    throw new InvalidOperationException(
+                        $"Invalid template '{template}'. Empty segments are not allowed.");
+                }
+
+                if (segment[0] != '{')
+                {
+                    if (segment[segment.Length - 1] == '}')
+                    {
+                        throw new InvalidOperationException(
+                            $"Invalid template '{template}'. Missing '{{' in parameter segment '{segment}'.");
+                    }
+                    if (segment[^1] == '?')
+                    {
+                        throw new InvalidOperationException(
+                            $"Invalid template '{template}'. '?' is not allowed in literal segment '{segment}'.");
+                    }
+                    templateSegments[i] = new TemplateSegment(originalTemplate, segment, isParameter: false);
+                }
+                else
+                {
+                    if (segment[segment.Length - 1] != '}')
+                    {
+                        throw new InvalidOperationException(
+                            $"Invalid template '{template}'. Missing '}}' in parameter segment '{segment}'.");
+                    }
+
+                    if (segment.Length < 3)
+                    {
+                        throw new InvalidOperationException(
+                            $"Invalid template '{template}'. Empty parameter name in segment '{segment}' is not allowed.");
+                    }
+
+                    var invalidCharacter = segment.IndexOfAny(InvalidParameterNameCharacters, 1, segment.Length - 2);
+                    if (invalidCharacter != -1)
+                    {
+                        throw new InvalidOperationException(
+                            $"Invalid template '{template}'. The character '{segment[invalidCharacter]}' in parameter segment '{segment}' is not allowed.");
+                    }
+
+                    templateSegments[i] = new TemplateSegment(originalTemplate, segment.Substring(1, segment.Length - 2), isParameter: true);
+                }
+            }
+
+            for (int i = 0; i < templateSegments.Length; i++)
+            {
+                var currentSegment = templateSegments[i];
+
+                if (currentSegment.IsCatchAll && i != templateSegments.Length - 1)
+                {
+                    throw new InvalidOperationException($"Invalid template '{template}'. A catch-all parameter can only appear as the last segment of the route template.");
+                }
+
+                if (!currentSegment.IsParameter)
+                {
+                    continue;
+                }
+
+                for (int j = i + 1; j < templateSegments.Length; j++)
+                {
+                    var nextSegment = templateSegments[j];
+
+                    if (currentSegment.IsOptional && !nextSegment.IsOptional && !nextSegment.IsCatchAll)
+                    {
+                        throw new InvalidOperationException($"Invalid template '{template}'. Non-optional parameters or literal routes cannot appear after optional parameters.");
+                    }
+
+                    if (string.Equals(currentSegment.Value, nextSegment.Value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            $"Invalid template '{template}'. The parameter '{currentSegment}' appears multiple times.");
+                    }
+                }
+            }
+
+            return new RouteTemplate(template, templateSegments);
+        }
+    }
+}

--- a/components/src/Piipan.Components/Routing/TemplateSegment.cs
+++ b/components/src/Piipan.Components/Routing/TemplateSegment.cs
@@ -1,0 +1,151 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    internal class TemplateSegment
+    {
+        public TemplateSegment(string template, string segment, bool isParameter)
+        {
+            IsParameter = isParameter;
+
+            IsCatchAll = isParameter && segment.StartsWith('*');
+
+            if (IsCatchAll)
+            {
+                // Only one '*' currently allowed
+                Value = segment[1..];
+
+                var invalidCharacterIndex = Value.IndexOf('*');
+                if (invalidCharacterIndex != -1)
+                {
+                    throw new InvalidOperationException($"Invalid template '{template}'. A catch-all parameter may only have one '*' at the beginning of the segment.");
+                }
+            }
+            else
+            {
+                Value = segment;
+            }
+
+            // Process segments that parameters  that do not contain a token separating a type constraint.
+            if (IsParameter)
+            {
+                if (Value.IndexOf(':') < 0)
+                {
+
+                    // Set the IsOptional flag to true for segments that contain
+                    // a parameter with no type constraints but optionality set
+                    // via the '?' token.
+                    var questionMarkIndex = Value.IndexOf('?');
+                    if (questionMarkIndex == Value.Length - 1)
+                    {
+                        IsOptional = true;
+                        Value = Value[0..^1];
+                    }
+                    // If the `?` optional marker shows up in the segment but not at the very end,
+                    // then throw an error.
+                    else if (questionMarkIndex >= 0)
+                    {
+                        throw new ArgumentException($"Malformed parameter '{segment}' in route '{template}'. '?' character can only appear at the end of parameter name.");
+                    }
+
+                    Constraints = Array.Empty<UrlValueConstraint>();
+                }
+                else
+                {
+                    var tokens = Value.Split(':');
+                    if (tokens[0].Length == 0)
+                    {
+                        throw new ArgumentException($"Malformed parameter '{segment}' in route '{template}' has no name before the constraints list.");
+                    }
+
+                    Value = tokens[0];
+                    IsOptional = tokens[^1].EndsWith('?');
+                    if (IsOptional)
+                    {
+                        tokens[^1] = tokens[^1][0..^1];
+                    }
+
+                    Constraints = new UrlValueConstraint[tokens.Length - 1];
+                    for (var i = 1; i < tokens.Length; i++)
+                    {
+                        Constraints[i - 1] = RouteConstraint.Parse(template, segment, tokens[i]);
+                    }
+                }
+            }
+            else
+            {
+                Constraints = Array.Empty<UrlValueConstraint>();
+            }
+
+            if (IsParameter)
+            {
+                if (IsOptional && IsCatchAll)
+                {
+                    throw new InvalidOperationException($"Invalid segment '{segment}' in route '{template}'. A catch-all parameter cannot be marked optional.");
+                }
+
+                // Moving the check for this here instead of TemplateParser so we can allow catch-all.
+                // We checked for '*' up above specifically for catch-all segments, this one checks for all others
+                if (Value.IndexOf('*') != -1)
+                {
+                    throw new InvalidOperationException($"Invalid template '{template}'. The character '*' in parameter segment '{{{segment}}}' is not allowed.");
+                }
+            }
+        }
+
+        // The value of the segment. The exact text to match when is a literal.
+        // The parameter name when its a segment
+        public string Value { get; }
+
+        public bool IsParameter { get; }
+
+        public bool IsOptional { get; }
+
+        public bool IsCatchAll { get; }
+
+        public UrlValueConstraint[] Constraints { get; }
+
+        public bool Match(string pathSegment, out object? matchedParameterValue)
+        {
+            if (IsParameter)
+            {
+                matchedParameterValue = pathSegment;
+
+                foreach (var constraint in Constraints)
+                {
+                    if (!constraint.TryParse(pathSegment, out matchedParameterValue))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                matchedParameterValue = null;
+                return string.Equals(Value, pathSegment, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        public override string ToString() => this switch
+        {
+            { IsParameter: true, IsOptional: false, IsCatchAll: false, Constraints: { Length: 0 } } => $"{{{Value}}}",
+            { IsParameter: true, IsOptional: false, IsCatchAll: false, Constraints: { Length: > 0 } } => $"{{{Value}:{string.Join(':', (object[])Constraints)}}}",
+            { IsParameter: true, IsOptional: true, Constraints: { Length: 0 } } => $"{{{Value}?}}",
+            { IsParameter: true, IsOptional: true, Constraints: { Length: > 0 } } => $"{{{Value}:{string.Join(':', (object[])Constraints)}?}}",
+            { IsParameter: true, IsCatchAll: true, Constraints: { Length: 0 } } => $"{{*{Value}}}",
+            { IsParameter: true, IsCatchAll: true, Constraints: { Length: > 0 } } => $"{{*{Value}:{string.Join(':', (object[])Constraints)}?}}",
+            { IsParameter: false } => Value,
+            _ => throw new InvalidOperationException("Invalid template segment.")
+        };
+    }
+}

--- a/components/src/Piipan.Components/Routing/TestableMetadataUpdate.cs
+++ b/components/src/Piipan.Components/Routing/TestableMetadataUpdate.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.Metadata;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    internal sealed class TestableMetadataUpdate
+    {
+        public static bool TestIsSupported { private get; set; }
+
+        /// <summary>
+        /// A proxy for <see cref="MetadataUpdater.IsSupported" /> that is testable.
+        /// </summary>
+        public static bool IsSupported => MetadataUpdater.IsSupported || TestIsSupported;
+    }
+}

--- a/components/src/Piipan.Components/Routing/UrlValueConstraint.cs
+++ b/components/src/Piipan.Components/Routing/UrlValueConstraint.cs
@@ -1,0 +1,189 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Taken from https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src
+// Unfortunately these classes are marked internal, so we had to pull them down to create the PiipanRouter
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Piipan.Components.Routing
+{
+    [ExcludeFromCodeCoverage]
+    /// <summary>
+    /// Shared logic for parsing tokens from route values and querystring values.
+    /// </summary>
+    internal abstract class UrlValueConstraint
+    {
+        public delegate bool TryParseDelegate<T>(ReadOnlySpan<char> str, [MaybeNullWhen(false)] out T result);
+
+        private static readonly ConcurrentDictionary<Type, UrlValueConstraint> _cachedInstances = new();
+
+        public static bool TryGetByTargetType(Type targetType, [MaybeNullWhen(false)] out UrlValueConstraint result)
+        {
+            if (!_cachedInstances.TryGetValue(targetType, out result))
+            {
+                result = Create(targetType);
+                if (result is null)
+                {
+                    return false;
+                }
+
+                _cachedInstances.TryAdd(targetType, result);
+            }
+
+            return true;
+        }
+
+        private static bool TryParse(ReadOnlySpan<char> str, out string result)
+        {
+            result = str.ToString();
+            return true;
+        }
+
+        private static bool TryParse(ReadOnlySpan<char> str, out DateTime result)
+            => DateTime.TryParse(str, CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+
+        private static bool TryParse(ReadOnlySpan<char> str, out DateOnly result)
+            => DateOnly.TryParse(str, CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+
+        private static bool TryParse(ReadOnlySpan<char> str, out TimeOnly result)
+            => TimeOnly.TryParse(str, CultureInfo.InvariantCulture, DateTimeStyles.None, out result);
+
+        private static bool TryParse(ReadOnlySpan<char> str, out decimal result)
+            => decimal.TryParse(str, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
+
+        private static bool TryParse(ReadOnlySpan<char> str, out double result)
+            => double.TryParse(str, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
+
+        private static bool TryParse(ReadOnlySpan<char> str, out float result)
+            => float.TryParse(str, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
+
+        private static bool TryParse(ReadOnlySpan<char> str, out int result)
+            => int.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+
+        private static bool TryParse(ReadOnlySpan<char> str, out long result)
+            => long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+
+        private static UrlValueConstraint? Create(Type targetType) => targetType switch
+        {
+            var x when x == typeof(string) => new TypedUrlValueConstraint<string>(TryParse),
+            var x when x == typeof(bool) => new TypedUrlValueConstraint<bool>(bool.TryParse),
+            var x when x == typeof(bool?) => new NullableTypedUrlValueConstraint<bool>(bool.TryParse),
+            var x when x == typeof(DateTime) => new TypedUrlValueConstraint<DateTime>(TryParse),
+            var x when x == typeof(DateTime?) => new NullableTypedUrlValueConstraint<DateTime>(TryParse),
+            var x when x == typeof(DateOnly) => new TypedUrlValueConstraint<DateOnly>(TryParse),
+            var x when x == typeof(DateOnly?) => new NullableTypedUrlValueConstraint<DateOnly>(TryParse),
+            var x when x == typeof(TimeOnly) => new TypedUrlValueConstraint<TimeOnly>(TryParse),
+            var x when x == typeof(TimeOnly?) => new NullableTypedUrlValueConstraint<TimeOnly>(TryParse),
+            var x when x == typeof(decimal) => new TypedUrlValueConstraint<decimal>(TryParse),
+            var x when x == typeof(decimal?) => new NullableTypedUrlValueConstraint<decimal>(TryParse),
+            var x when x == typeof(double) => new TypedUrlValueConstraint<double>(TryParse),
+            var x when x == typeof(double?) => new NullableTypedUrlValueConstraint<double>(TryParse),
+            var x when x == typeof(float) => new TypedUrlValueConstraint<float>(TryParse),
+            var x when x == typeof(float?) => new NullableTypedUrlValueConstraint<float>(TryParse),
+            var x when x == typeof(Guid) => new TypedUrlValueConstraint<Guid>(Guid.TryParse),
+            var x when x == typeof(Guid?) => new NullableTypedUrlValueConstraint<Guid>(Guid.TryParse),
+            var x when x == typeof(int) => new TypedUrlValueConstraint<int>(TryParse),
+            var x when x == typeof(int?) => new NullableTypedUrlValueConstraint<int>(TryParse),
+            var x when x == typeof(long) => new TypedUrlValueConstraint<long>(TryParse),
+            var x when x == typeof(long?) => new NullableTypedUrlValueConstraint<long>(TryParse),
+            var x => null
+        };
+
+        public abstract bool TryParse(ReadOnlySpan<char> value, [MaybeNullWhen(false)] out object result);
+
+        public abstract object? Parse(ReadOnlySpan<char> value, string destinationNameForMessage);
+
+        public abstract Array ParseMultiple(StringSegmentAccumulator values, string destinationNameForMessage);
+
+        private class TypedUrlValueConstraint<T> : UrlValueConstraint
+        {
+            private readonly TryParseDelegate<T> _parser;
+
+            public TypedUrlValueConstraint(TryParseDelegate<T> parser)
+            {
+                _parser = parser;
+            }
+
+            public override bool TryParse(ReadOnlySpan<char> value, [MaybeNullWhen(false)] out object result)
+            {
+                if (_parser(value, out var typedResult))
+                {
+                    result = typedResult!;
+                    return true;
+                }
+                else
+                {
+                    result = null;
+                    return false;
+                }
+            }
+
+            public override object? Parse(ReadOnlySpan<char> value, string destinationNameForMessage)
+            {
+                if (!_parser(value, out var parsedValue))
+                {
+                    throw new InvalidOperationException($"Cannot parse the value '{value.ToString()}' as type '{typeof(T)}' for '{destinationNameForMessage}'.");
+                }
+
+                return parsedValue;
+            }
+
+            public override Array ParseMultiple(StringSegmentAccumulator values, string destinationNameForMessage)
+            {
+                var count = values.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
+                var result = new T?[count];
+
+                for (var i = 0; i < count; i++)
+                {
+                    if (!_parser(values[i].Span, out result[i]))
+                    {
+                        throw new InvalidOperationException($"Cannot parse the value '{values[i]}' as type '{typeof(T)}' for '{destinationNameForMessage}'.");
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        private sealed class NullableTypedUrlValueConstraint<T> : TypedUrlValueConstraint<T?> where T : struct
+        {
+            public NullableTypedUrlValueConstraint(TryParseDelegate<T> parser)
+                : base(SupportNullable(parser))
+            {
+            }
+
+            private static TryParseDelegate<T?> SupportNullable(TryParseDelegate<T> parser)
+            {
+                return TryParseNullable;
+
+                bool TryParseNullable(ReadOnlySpan<char> value, [MaybeNullWhen(false)] out T? result)
+                {
+                    if (value.IsEmpty)
+                    {
+                        result = default;
+                        return true;
+                    }
+                    else if (parser(value, out var parsedValue))
+                    {
+                        result = parsedValue;
+                        return true;
+                    }
+                    else
+                    {
+                        result = default;
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/src/Piipan.Components/_Imports.razor
+++ b/components/src/Piipan.Components/_Imports.razor
@@ -2,5 +2,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
 @using Piipan.Components.Enums
+@using Piipan.Components.Modals
 @using Piipan.Components.Validation
 @using Piipan.Components.Shared
+@inject IModalManager ModalManager

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchForm.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchForm.razor
@@ -1,9 +1,6 @@
 ﻿@using Piipan.Match.Api.Models
 @using Piipan.Match.Api.Models.Resolution
 
-@inject NavigationManager NavigationManager
-
-
 @code {
     [Parameter] public MatchSearchRequest Query { get; set; }
     [Parameter] public ParameterBase<List<MatchResApiResponse>> QueryResult { get; set; }

--- a/query-tool/src/Piipan.QueryTool.Client/Modals/ConfirmModal.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Modals/ConfirmModal.razor
@@ -1,0 +1,43 @@
+﻿@using Piipan.Components.Modals
+@inject IModalManager ModalManager
+
+@code {
+    [CascadingParameter] public ModalInfo ModalInfo { get; set; }
+    [Parameter] public Action ContinueCallback { get; set; }
+    private void Close()
+    {
+        ModalManager.Close(ModalInfo);
+    }
+    private void Continue()
+    {
+        ModalManager.Close(ModalInfo);
+        if (ContinueCallback != null)
+        {
+            ContinueCallback?.Invoke();    
+        }
+    }
+}
+
+
+<h2 class="usa-modal__heading" id="modal-1-heading">
+    Continue Without Saving?
+</h2>
+<div class="usa-prose">
+    <p id="modal-1-description">
+    Any unsaved changes will be lost.
+    </p>
+</div>
+<div class="usa-modal__footer">
+    <ul class="usa-button-group">
+    <li class="usa-button-group__item">
+        <button type="button" class="usa-button" @onclick="Continue">
+        Continue
+        </button>
+    </li>
+    <li class="usa-button-group__item">
+        <button type="button" class="usa-button usa-button--unstyled padding-105 text-center" @onclick="Close">
+        Cancel and return to form
+        </button>
+    </li>
+    </ul>
+</div>

--- a/query-tool/src/Piipan.QueryTool.Client/Modals/ConfirmModalWrapper.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Modals/ConfirmModalWrapper.razor
@@ -1,0 +1,84 @@
+﻿@using Piipan.Components.Modals
+@using Piipan.Components.Routing
+@inject PiipanNavigationManager NavigationManager
+@inject IModalManager ModalManager
+@inject IJSRuntime JSRuntime
+
+@implements IDisposable
+
+@code {
+    [Parameter] public RenderFragment ChildContent { get; set; }
+    [Parameter] public UsaForm RelatedForm { get; set; }
+    private IJSObjectReference modalJavascriptReference;
+
+    /// <summary>
+    /// Subscribe to the NavigationBlocked event to show the modal.
+    /// </summary>
+    protected override void OnInitialized()
+    {
+        NavigationManager.NavigationBlocked += ShowModal;
+    }
+
+    /// <summary>
+    /// After this is rendered (and thus the Web Assembly & Javascript runtime is available), import the ConfirmModalWrapper javascript.
+    /// This javascript includes a call to checking beforeunload, which is called when a user tries to navigation away from our app
+    /// or close the window entirely.
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (modalJavascriptReference == null)
+        {
+            modalJavascriptReference = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./Modals/ConfirmModalWrapper.razor.js");    
+        }
+    }
+
+    /// <summary>
+    /// When the page first loads, the form is null until the page renders. So this will get called twice. 
+    /// The second time, when the form exists, subscribe to its IsDirtyChanged method to update whether or not the Navigation should
+    /// be blocked.
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        if (RelatedForm != null && !(RelatedForm.IsDirtyChanged?.GetInvocationList().Contains(UpdateBlockNavigation) ?? false))
+        {
+            RelatedForm.IsDirtyChanged += UpdateBlockNavigation;
+        }
+    }
+
+    /// <summary>
+    /// When the form changes whether it's dirty or not, update the navigation blocker and the window's beforeunload listener.
+    /// </summary>
+    private async Task UpdateBlockNavigation(bool isDirty)
+    {
+        NavigationManager.BlockNavigation = isDirty;
+        await modalJavascriptReference.InvokeVoidAsync("SetUnloadListener", isDirty);
+    }
+
+    /// <summary>
+    /// When this wrapper is disposed, stop checking for an event to free up resources
+    /// </summary>
+    public void Dispose()
+    {
+        RelatedForm.IsDirtyChanged -= UpdateBlockNavigation;
+    }
+
+    /// <summary>
+    /// This is called when navigation is blocked by the Blazor router if the form is dirty. Show the confirmation modal.
+    /// </summary>
+    private void ShowModal(object sender, LocationChangedEventArgs e)
+    {
+        ModalManager.Show<ConfirmModal>(new ConfirmModal()
+        {
+            // If continue is clicked, unblock the navigation intercepter and then navigate to the page you were attempting to go to.
+            ContinueCallback = async () => {
+                await UpdateBlockNavigation(false);
+                NavigationManager.NavigateTo(e.Location, true);
+            }
+        });
+    }
+}
+
+<Piipan.Components.Routing.PiipanRouter AppAssembly="@typeof(ConfirmModalWrapper).Assembly">
+    @ChildContent
+</Piipan.Components.Routing.PiipanRouter>

--- a/query-tool/src/Piipan.QueryTool.Client/Modals/ConfirmModalWrapper.razor.js
+++ b/query-tool/src/Piipan.QueryTool.Client/Modals/ConfirmModalWrapper.razor.js
@@ -1,0 +1,15 @@
+﻿const beforeUnloadListener = (event) => {
+    event.preventDefault();
+    return event.returnValue = "Continue Without Saving?";
+};
+
+// This is called from ConfirmModalWrapper when NavigationBlocked changes. If it's true, we should block navigation
+// using the default browser functionality anytime Blazor cannot intercept it.
+export function SetUnloadListener(shouldConfirm) {
+    if (shouldConfirm) {
+        window.addEventListener("beforeunload", beforeUnloadListener, { capture: true });
+    }
+    else {
+        window.removeEventListener("beforeunload", beforeUnloadListener, { capture: true });
+    }
+}

--- a/query-tool/src/Piipan.QueryTool.Client/Program.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Program.cs
@@ -2,9 +2,12 @@ using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Piipan.Components.Modals;
+using Piipan.Components.Routing;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-
+builder.Services.AddModalManager();
+builder.Services.AddLockableNavigationManager();
 await builder.Build().RunAsync();

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml
@@ -3,7 +3,6 @@
 @using Piipan.Match.Api.Models.Resolution
 @using Piipan.States.Api.Models
 @using Piipan.QueryTool.Client.Models
-<link rel="stylesheet" href="app.css" type="text/css" />
 @inject IAntiforgery antiforgery
 @model Piipan.QueryTool.Pages.MatchModel
 @{

--- a/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Shared/_Layout.cshtml
@@ -15,6 +15,7 @@
     var pageName = Context.Request.Path.ToString().Split('/').Last().ToLower();
 }
 <body>
+    <div id="inert-area">
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
     <div class="usa-overlay"></div>
         <div class="sticky-footer">
@@ -99,6 +100,7 @@
             <partial name="_CUI" />
         </div>
     </div>
+    <component type="typeof(Piipan.Components.Modals.ModalContainer)" render-mode="WebAssembly" />
     @Html.AntiForgeryToken()
     <script src="~/js/uswds.min.js" asp-append-version="true"></script>
     <script src="/_framework/blazor.webassembly.js" asp-append-version="true"></script>

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NEasyAuthMiddleware;
+using Piipan.Components.Modals;
+using Piipan.Components.Routing;
 using Piipan.Match.Client.Extensions;
 using Piipan.QueryTool.Binders;
 using Piipan.Shared.Authorization;
@@ -70,6 +72,9 @@ namespace Piipan.QueryTool
             services.AddSingleton<ISsnNormalizer, SsnNormalizer>();
             services.AddSingleton<ILdsHasher, LdsHasher>();
             services.AddSingleton<ILdsDeidentifier, LdsDeidentifier>();
+
+            services.AddModalManager();
+            services.AddLockableNavigationManager();
 
             services.AddHttpContextAccessor();
             services.AddEasyAuth();


### PR DESCRIPTION
## What’s changing?

We are adding the Modal component, as well as Navigation blocking behavior for when forms have been updated but not saved. These "dirty" forms should ask the user if they want to continue filling out the form or if they want to leave the page. This behavior is found in the ConfirmModalWrapper. Simply put an existing UsaForm inside a ConfirmModalWrapper component and the navigation blocking will happen.

The navigation blocking itself is done using a combination of an overridden NavigationManager called PiipanNavigationManager and an overriden Router called PiipanRouter. These two classes are among those [here](https://github.com/dotnet/aspnetcore/tree/v6.0.6/src/Components/Components/src).

Since the [Router](https://github.com/dotnet/aspnetcore/blob/v6.0.6/src/Components/Components/src/Routing/Router.cs) uses classes internal to AspNetCore, we had to recreate those classes. They are simple copy/pastes and a namespace change from the repository. The reason we need the router is to hijack when the location is about to change and perform a logic check on it. The Location Changing event is something [being worked on](https://github.com/dotnet/aspnetcore/issues/14962) by the AspNet team, with it currently slated to go out in .Net7, so at that time we may not need to have a custom NavigationManager/Router. At that time most of the logic in the Piipan.Components.Routing namespace can likely be replaced, and the ConfirmModalWrapper could listen to LocationChanging instead of NavigationBlocked.

## Why?

Closes NAC 446

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
