### PR TITLE
Showing/Hiding Match Detail edit section based off user's role

### DIFF
--- a/query-tool/docs/query-tool.md
+++ b/query-tool/docs/query-tool.md
@@ -62,6 +62,8 @@ For the "Search for Snap Participants" screen, you need to have a user that has 
 
 Any users that are authenticated but not authorized to view the page will be redirected to a "Not Authenticated" page to let them know their role or location is not valid for the page.
 
+Additionally, certain areas of the app will require certain roles. For example, that edit section of the Match Details page is only available to users that have a role that can edit a match. The valid roles are set up in the appsettings "Roles" section. Each area takes in an array of roles that can perform the action, and as long as you contain any of these roles you have permission to use the functionality.
+
 ## Testing
 
 Tests will be run on the continuous integration server, but

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/MatchDetail.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/MatchDetail.razor
@@ -14,10 +14,13 @@
     [Parameter] public string Token { get; set; }
     [Parameter] public MatchDetailSaveResponseData SaveResponse { get; set; }
     [Parameter] public List<ServerError> ServerErrors { get; set; }
+    [Parameter] public string Role { get; set; }
+    [Parameter] public string[] RequiredRolesToEdit { get; set; }
 
     private DispositionModel model;
 
     private bool saving = false;
+    private bool CanEditFields => RequiredRolesToEdit.Contains(Role);
     List<(string Property, string Error)> serverErrorList;
 
 
@@ -123,11 +126,14 @@
         </dl>
     </div>
     <!-- \match header -->
-    <div class="match-detail-grid">
-        <div>
-            <ResolutionFields State="@LoggedInUsersState" InitiatingState="IsUserInInitiatingState()" Token="@Token" DispositionData="@model"/>
-            <button class="usa-button ResolutionFieldsSave" disabled="@saving">@(saving ? "Saving Changes..." : "Save Changes")</button>
-        </div>
+    <div class="match-detail-grid @(CanEditFields ? "" : "one-col")">
+        @if (CanEditFields)
+        {
+            <div>
+                <ResolutionFields State="@LoggedInUsersState" InitiatingState="IsUserInInitiatingState()" Token="@Token" DispositionData="@model"/>
+                <button class="usa-button ResolutionFieldsSave" disabled="@saving">@(saving ? "Saving Changes..." : "Save Changes")</button>
+            </div>
+        }
         <div>
             <UsaAccordion>
                 <UsaAccordionItem StartsExpanded="true">

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml
@@ -20,6 +20,8 @@
         param-LoggedInUsersState="Model.UserState"
         param-SaveResponse="Model.MatchDetailSaveResponse"
         param-ServerErrors="Model.RequestErrors"
+        param-Role="Model.Role"
+        param-RequiredRolesToEdit="Model.RequiredRolesToEdit"
         param-Token="antiforgery.GetAndStoreTokens(HttpContext).RequestToken"/>
     </div>
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
+using Piipan.Shared.Roles;
 
 namespace Piipan.QueryTool.Pages
 {
@@ -16,6 +19,7 @@ namespace Piipan.QueryTool.Pages
 
         private readonly ILogger<MatchModel> _logger;
         private readonly IMatchResolutionApi _matchResolutionApi;
+        private readonly IRolesProvider _rolesProvider;
 
         [BindProperty]
         public MatchSearchRequest Query { get; set; } = new MatchSearchRequest();
@@ -25,6 +29,7 @@ namespace Piipan.QueryTool.Pages
         public List<ServerError> RequestErrors { get; private set; } = new();
         public MatchDetailSaveResponseData MatchDetailSaveResponse { get; set; }
         public string UserState { get; set; } = "";
+        public string[] RequiredRolesToEdit => _rolesProvider.GetMatchEditRoles();
 
         public MatchModel(ILogger<MatchModel> logger
                            , IMatchResolutionApi matchResolutionApi
@@ -34,6 +39,7 @@ namespace Piipan.QueryTool.Pages
         {
             _logger = logger;
             _matchResolutionApi = matchResolutionApi;
+            _rolesProvider = serviceProvider.GetRequiredService<IRolesProvider>();
         }
 
         public void InitializeUserState()
@@ -125,54 +131,63 @@ namespace Piipan.QueryTool.Pages
             else
             {
                 MatchDetailSaveResponse = new MatchDetailSaveResponseData() { SaveSuccess = false };
-                // Remove binding errors from anything binding other than DispositionData (namely the Query property)
-                foreach (var modelStateKey in ModelState.Keys)
+                if (!_rolesProvider.GetMatchEditRoles().Contains(Role))
                 {
-                    if (!modelStateKey.Contains(nameof(DispositionData)))
-                    {
-                        ModelState[modelStateKey].Errors.Clear();
-                        ModelState[modelStateKey].ValidationState = Microsoft.AspNetCore.Mvc.ModelBinding.ModelValidationState.Valid;
-                    }
-                }
-                if (ModelState.IsValid)
-                {
-                    try
-                    {
-                        AddEventRequest addEventRequest = new AddEventRequest
-                        {
-                            Data = new AddEventRequestData
-                            {
-                                FinalDisposition = DispositionData.FinalDisposition,
-                                FinalDispositionDate = DispositionData.FinalDispositionDate,
-                                InitialActionAt = DispositionData.InitialActionAt,
-                                InitialActionTaken = DispositionData.InitialActionTaken,
-                                InvalidMatch = DispositionData.InvalidMatch,
-                                InvalidMatchReason = DispositionData.InvalidMatchReason,
-                                OtherReasoningForInvalidMatch = DispositionData.OtherReasoningForInvalidMatch,
-                                VulnerableIndividual = DispositionData.VulnerableIndividual
-                            }
-                        };
-                        await _matchResolutionApi.AddMatchResEvent(id, addEventRequest, Location);
-                        MatchDetailSaveResponse.SaveSuccess = true;
-                    }
-                    catch (Exception exception)
-                    {
-                        _logger.LogError(exception, exception.Message);
-                        RequestErrors.Add(new("", "There was an error saving your data. Please try again."));
-                    }
+                    _logger.LogError($"User {Email} does not have permissions to edit match details.");
+                    RequestErrors.Add(new("", "You lack the necessary role to save match details."));
                 }
                 else
                 {
-                    var keys = ModelState.Keys;
-                    foreach (var key in keys)
+                    // Remove binding errors from anything binding other than DispositionData (namely the Query property)
+                    foreach (var modelStateKey in ModelState.Keys)
                     {
-                        if (ModelState[key]?.Errors?.Count > 0)
+                        if (!modelStateKey.Contains(nameof(DispositionData)))
                         {
-                            var error = ModelState[key].Errors[0];
-                            RequestErrors.Add(new(key, error.ErrorMessage));
+                            ModelState[modelStateKey].Errors.Clear();
+                            ModelState[modelStateKey].ValidationState = Microsoft.AspNetCore.Mvc.ModelBinding.ModelValidationState.Valid;
+                        }
+                    }
+                    if (ModelState.IsValid)
+                    {
+                        try
+                        {
+                            AddEventRequest addEventRequest = new AddEventRequest
+                            {
+                                Data = new AddEventRequestData
+                                {
+                                    FinalDisposition = DispositionData.FinalDisposition,
+                                    FinalDispositionDate = DispositionData.FinalDispositionDate,
+                                    InitialActionAt = DispositionData.InitialActionAt,
+                                    InitialActionTaken = DispositionData.InitialActionTaken,
+                                    InvalidMatch = DispositionData.InvalidMatch,
+                                    InvalidMatchReason = DispositionData.InvalidMatchReason,
+                                    OtherReasoningForInvalidMatch = DispositionData.OtherReasoningForInvalidMatch,
+                                    VulnerableIndividual = DispositionData.VulnerableIndividual
+                                }
+                            };
+                            await _matchResolutionApi.AddMatchResEvent(id, addEventRequest, Location);
+                            MatchDetailSaveResponse.SaveSuccess = true;
+                        }
+                        catch (Exception exception)
+                        {
+                            _logger.LogError(exception, exception.Message);
+                            RequestErrors.Add(new("", "There was an error saving your data. Please try again."));
+                        }
+                    }
+                    else
+                    {
+                        var keys = ModelState.Keys;
+                        foreach (var key in keys)
+                        {
+                            if (ModelState[key]?.Errors?.Count > 0)
+                            {
+                                var error = ModelState[key].Errors[0];
+                                RequestErrors.Add(new(key, error.ErrorMessage));
+                            }
                         }
                     }
                 }
+
                 Match = await _matchResolutionApi.GetMatch(id, IsNationalOffice ? "*" : Location);
                 if (Match == null)
                 {

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
@@ -134,7 +134,7 @@ namespace Piipan.QueryTool.Pages
                 if (!_rolesProvider.GetMatchEditRoles().Contains(Role))
                 {
                     _logger.LogError($"User {Email} does not have permissions to edit match details.");
-                    RequestErrors.Add(new("", "You lack the necessary role to save match details."));
+                    RequestErrors.Add(new("", "You do not have the role and permissions to edit match details."));
                 }
                 else
                 {

--- a/query-tool/src/Piipan.QueryTool/Startup.cs
+++ b/query-tool/src/Piipan.QueryTool/Startup.cs
@@ -17,6 +17,7 @@ using Piipan.Shared.Claims;
 using Piipan.Shared.Deidentification;
 using Piipan.Shared.Locations;
 using Piipan.Shared.Logging;
+using Piipan.Shared.Roles;
 using Piipan.States.Client.Extensions;
 
 namespace Piipan.QueryTool
@@ -37,6 +38,7 @@ namespace Piipan.QueryTool
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<LocationOptions>(Configuration.GetSection(LocationOptions.SectionName));
+            services.Configure<RoleOptions>(Configuration.GetSection(RoleOptions.SectionName));
             services.Configure<ClaimsOptions>(Configuration.GetSection(ClaimsOptions.SectionName));
 
 
@@ -66,6 +68,7 @@ namespace Piipan.QueryTool
 
             services.AddTransient<IClaimsProvider, ClaimsProvider>();
             services.AddTransient<ILocationsProvider, LocationsProvider>();
+            services.AddTransient<IRolesProvider, RolesProvider>();
 
             services.AddSingleton<INameNormalizer, NameNormalizer>();
             services.AddSingleton<IDobNormalizer, DobNormalizer>();

--- a/query-tool/src/Piipan.QueryTool/appsettings.json
+++ b/query-tool/src/Piipan.QueryTool/appsettings.json
@@ -13,7 +13,10 @@
         "RolePrefix": "Role-"
     },
     "Locations": {
-        "NationalOfficeValue":  "National"
+        "NationalOfficeValue": "National"
+    },
+    "Roles": {
+        "EditMatch": [ "Worker" ]
     },
   "AuthorizationPolicy": {
     "RequiredClaims": []

--- a/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/BasePageTest.cs
@@ -14,6 +14,7 @@ using Moq.Language.Flow;
 using Piipan.QueryTool.Pages;
 using Piipan.Shared.Claims;
 using Piipan.Shared.Locations;
+using Piipan.Shared.Roles;
 using Piipan.States.Api;
 using Piipan.States.Api.Models;
 
@@ -40,6 +41,9 @@ namespace Piipan.QueryTool.Tests
 
             var locationProviderMock = new Mock<ILocationsProvider>();
             locationProviderMock.Setup(c => c.GetStates(It.IsAny<string>())).Returns(states ?? new string[] { location });
+
+            var roleProviderMock = new Mock<IRolesProvider>();
+            roleProviderMock.Setup(c => c.GetMatchEditRoles()).Returns(new string[] { "Worker" });
 
             var statesApiMock = new Mock<IStatesApi>();
 
@@ -70,6 +74,7 @@ namespace Piipan.QueryTool.Tests
 
             serviceProviderMock.Setup(c => c.GetService(typeof(IClaimsProvider))).Returns(claimsProviderMock.Object);
             serviceProviderMock.Setup(c => c.GetService(typeof(ILocationsProvider))).Returns(locationProviderMock.Object);
+            serviceProviderMock.Setup(c => c.GetService(typeof(IRolesProvider))).Returns(roleProviderMock.Object);
             serviceProviderMock.Setup(c => c.GetService(typeof(IStatesApi))).Returns(statesApiMock.Object);
             serviceProviderMock.Setup(c => c.GetService(typeof(IMemoryCache))).Returns(new MemoryCache(new MemoryCacheOptions()));
             return serviceProviderMock.Object;

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/MatchDetailTests.razor
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/MatchDetailTests.razor
@@ -119,7 +119,9 @@
                         }
                     }
                 }
-            }
+            },
+            Role = "Worker",
+            RequiredRolesToEdit = new string[] { "Worker" }
         };
     }
 
@@ -134,7 +136,8 @@
             JSInterop.SetupVoid("piipan.utilities.scrollToElement", _ => true).SetVoidResult();
         Component = Render<MatchDetail>(
             @<MatchDetail Match="InitialValues.Match" ServerErrors="InitialValues.ServerErrors" 
-                StateInfo="InitialValues.StateInfo" LoggedInUsersState="Echo Bravo" SaveResponse="InitialValues.SaveResponse">
+                StateInfo="InitialValues.StateInfo" LoggedInUsersState="Echo Bravo" SaveResponse="InitialValues.SaveResponse"
+                Role="@InitialValues.Role" RequiredRolesToEdit="@InitialValues.RequiredRolesToEdit">
             </MatchDetail>
         );
         usaForm = Component.FindComponent<UsaForm>();
@@ -233,6 +236,20 @@
           </div>
         </div>
     );
+    }
+
+    /// <summary>
+    /// Verify that the resolution fields section should not exist when the user is not the correct role
+    /// </summary>
+    [Fact]
+    public void ResolutionFields_ShouldNotExist_WhenUserIsNotCorrectRole()
+    {
+        // Arrange
+        InitialValues.Role = "SomeOtherRole";
+        CreateTestComponent();
+
+        // Assert
+        Assert.Empty(Component.FindComponents<ResolutionFields>());
     }
 
     /// <summary>

--- a/shared/src/Piipan.Shared/Roles/IRolesProvider.cs
+++ b/shared/src/Piipan.Shared/Roles/IRolesProvider.cs
@@ -1,5 +1,9 @@
 ﻿namespace Piipan.Shared.Roles
 {
+    /// <summary>
+    /// The IRolesProvider will provide methods for the server to determine if a user has the roles to perform a function.
+    /// The server can then pass these roles onto the Client so that the client can show/hide certain areas of the screen.
+    /// </summary>
     public interface IRolesProvider
     {
         string[] GetMatchEditRoles();

--- a/shared/src/Piipan.Shared/Roles/IRolesProvider.cs
+++ b/shared/src/Piipan.Shared/Roles/IRolesProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Piipan.Shared.Roles
+{
+    public interface IRolesProvider
+    {
+        string[] GetMatchEditRoles();
+    }
+}

--- a/shared/src/Piipan.Shared/Roles/RoleOptions.cs
+++ b/shared/src/Piipan.Shared/Roles/RoleOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Piipan.Shared.Roles
+{
+    public class RoleOptions
+    {
+        public const string SectionName = "Roles";
+        public string[] EditMatch { get; set; }
+    }
+}

--- a/shared/src/Piipan.Shared/Roles/RolesProvider.cs
+++ b/shared/src/Piipan.Shared/Roles/RolesProvider.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+using Piipan.Shared.Locations;
+
+namespace Piipan.Shared.Roles
+{
+    public class RolesProvider : IRolesProvider
+    {
+        private readonly RoleOptions _options;
+
+        public RolesProvider(IOptions<RoleOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        public string[] GetMatchEditRoles()
+        {
+            return _options.EditMatch ?? Array.Empty<string>();
+        }
+    }
+}

--- a/shared/src/Piipan.Shared/Roles/RolesProvider.cs
+++ b/shared/src/Piipan.Shared/Roles/RolesProvider.cs
@@ -22,7 +22,7 @@ namespace Piipan.Shared.Roles
         /// <returns></returns>
         public string[] GetMatchEditRoles()
         {
-            return _options.EditMatch ?? Array.Empty<string>();
+            return _options?.EditMatch ?? Array.Empty<string>();
         }
     }
 }

--- a/shared/src/Piipan.Shared/Roles/RolesProvider.cs
+++ b/shared/src/Piipan.Shared/Roles/RolesProvider.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using Microsoft.Extensions.Options;
-using Piipan.Shared.Locations;
 
 namespace Piipan.Shared.Roles
 {
+    /// <summary>
+    /// The RolesProvider will provide methods for the server to determine if a user has the roles to perform a function.
+    /// The server can then pass these roles onto the Client so that the client can show/hide certain areas of the screen.
+    /// </summary>
     public class RolesProvider : IRolesProvider
     {
         private readonly RoleOptions _options;
@@ -13,6 +16,10 @@ namespace Piipan.Shared.Roles
             _options = options.Value;
         }
 
+        /// <summary>
+        /// Returns which roles are acceptable when editing a match.
+        /// </summary>
+        /// <returns></returns>
         public string[] GetMatchEditRoles()
         {
             return _options.EditMatch ?? Array.Empty<string>();

--- a/shared/tests/Piipan.Shared.Tests/Roles/RolesProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Roles/RolesProviderTests.cs
@@ -27,5 +27,39 @@ namespace Piipan.Shared.Tests.Roles
             // Assert
             Assert.Equal(new string[] { "Worker" }, roles);
         }
+
+        /// <summary>
+        /// Make sure the RolesProvider is returning back an empty list when roleOptions is null
+        /// </summary>
+        [Fact]
+        public void GetEditMatchRolesWhenOptionsAreNull()
+        {
+            // Arrange
+            var options = Options.Create<RoleOptions>(null);
+            var rolesProvider = new RolesProvider(options);
+
+            // Act
+            var roles = rolesProvider.GetMatchEditRoles();
+
+            // Assert
+            Assert.Empty(roles);
+        }
+
+        /// <summary>
+        /// Make sure the RolesProvider is returning back an empty list when roleOptions.EditMatch is null
+        /// </summary>
+        [Fact]
+        public void GetEditMatchRolesWhenEditMatchIsNull()
+        {
+            // Arrange
+            var options = Options.Create(new RoleOptions { EditMatch = null });
+            var rolesProvider = new RolesProvider(options);
+
+            // Act
+            var roles = rolesProvider.GetMatchEditRoles();
+
+            // Assert
+            Assert.Empty(roles);
+        }
     }
 }

--- a/shared/tests/Piipan.Shared.Tests/Roles/RolesProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Roles/RolesProviderTests.cs
@@ -12,7 +12,7 @@ namespace Piipan.Shared.Tests.Roles
         };
 
         /// <summary>
-        /// Get the
+        /// Make sure the RolesProvider is returning back the acceptable roles for editing a match
         /// </summary>
         [Fact]
         public void GetEditMatchRoles()

--- a/shared/tests/Piipan.Shared.Tests/Roles/RolesProviderTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Roles/RolesProviderTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Options;
+using Piipan.Shared.Roles;
+using Xunit;
+
+namespace Piipan.Shared.Tests.Roles
+{
+    public class RolesProviderTests
+    {
+        RoleOptions roleOptions = new RoleOptions
+        {
+            EditMatch = new string[] { "Worker" }
+        };
+
+        /// <summary>
+        /// Get the
+        /// </summary>
+        [Fact]
+        public void GetEditMatchRoles()
+        {
+            // Arrange
+            var options = Options.Create(roleOptions);
+            var rolesProvider = new RolesProvider(options);
+
+            // Act
+            var roles = rolesProvider.GetMatchEditRoles();
+
+            // Assert
+            Assert.Equal(new string[] { "Worker" }, roles);
+        }
+    }
+}


### PR DESCRIPTION
## What’s changing?

The edit section of the Match Detail page should only be shown to users with certain roles (see NAC-501).
The roles that are able to edit the Match Detail page will be configurable via the appsettings.json. For development purposes, we are allowing users with the role of "Worker".

## Why?

Closes NAC-501

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
