### PR TITLE
Initial commit for final disposition updates

### DIFF
--- a/components/src/Piipan.Components.Demo/Components/InputTextComponent.razor
+++ b/components/src/Piipan.Components.Demo/Components/InputTextComponent.razor
@@ -11,5 +11,8 @@
     <UsaFormGroup>
         <UsaInputText @bind-Value="TextModel.RequiredField" />
     </UsaFormGroup>
+    <UsaFormGroup>
+        <UsaInputText @bind-Value="TextModel.RequiredIfField" />
+    </UsaFormGroup>
     <button class="@ButtonClass">Submit</button>
 </UsaForm>

--- a/components/src/Piipan.Components.Demo/Models/InputTextModel.cs
+++ b/components/src/Piipan.Components.Demo/Models/InputTextModel.cs
@@ -1,5 +1,5 @@
-﻿using Piipan.Components.Validation;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
+using Piipan.Components.Validation;
 
 namespace Piipan.Components.Demo.Models
 {
@@ -14,5 +14,12 @@ namespace Piipan.Components.Demo.Models
         [UsaRequired]
         [Display(Name = "Required Field")]
         public string RequiredField { get; set; }
+
+        [UsaRequiredIf(
+            nameof(RequiredField), null, "@@@ is required when RequiredField has a value",
+            nameof(NotRequiredField), null, "@@@ is required when NotRequiredField has a value"
+        )]
+        [Display(Name = "Required If Field")]
+        public string RequiredIfField { get; set; }
     }
 }

--- a/components/src/Piipan.Components.Demo/wwwroot/components/InputTextComponent.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/components/InputTextComponent.txt
@@ -11,5 +11,8 @@
     <UsaFormGroup>
         <UsaInputText @bind-Value="TextModel.RequiredField" />
     </UsaFormGroup>
+    <UsaFormGroup>
+        <UsaInputText @bind-Value="TextModel.RequiredIfField" />
+    </UsaFormGroup>
     <button class="@ButtonClass">Submit</button>
 </UsaForm>

--- a/components/src/Piipan.Components.Demo/wwwroot/models/InputTextModel.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/models/InputTextModel.txt
@@ -1,5 +1,5 @@
-﻿using Piipan.Components.Validation;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
+using Piipan.Components.Validation;
 
 namespace Piipan.Components.Demo.Models
 {
@@ -14,5 +14,12 @@ namespace Piipan.Components.Demo.Models
         [UsaRequired]
         [Display(Name = "Required Field")]
         public string RequiredField { get; set; }
+
+        [UsaRequiredIf(
+            nameof(RequiredField), null, "@@@ is required when RequiredField has a value",
+            nameof(NotRequiredField), null, "@@@ is required when NotRequiredField has a value"
+        )]
+        [Display(Name = "Required If Field")]
+        public string RequiredIfField { get; set; }
     }
 }

--- a/components/src/Piipan.Components/Forms/UsaForm.razor
+++ b/components/src/Piipan.Components/Forms/UsaForm.razor
@@ -40,7 +40,7 @@
                                     }
                                     <button class="@ButtonClass @ButtonUnstyledClass"
                                         @onclick="async () => { await FocusElement(errorPair.FormGroup.InputElementId); }">
-                                        @errorPair.FormGroup.Label
+                                        @(errorPair.FormGroup.ErrorPlaceholderOverride ?? errorPair.FormGroup.Label)
                                     </button>
                                     @splitError.Substring(linkPart + 3)
                                 </li>

--- a/components/src/Piipan.Components/Forms/UsaFormGroup.razor
+++ b/components/src/Piipan.Components/Forms/UsaFormGroup.razor
@@ -4,6 +4,7 @@
 @code {
     [CascadingParameter] public UsaForm Form { get; set; }
     [Parameter] public RenderFragment LabelOverride { get; set; }
+    [Parameter] public string ErrorPlaceholderOverride { get; set; }
     [Parameter] public RenderFragment ChildContent { get; set; }
     [Parameter] public RenderFragment HintContent { get; set; }
 
@@ -34,7 +35,7 @@
                     var splitMessages = message.Split('\n');
                     @foreach (var splitMessage in splitMessages)
                     {
-                        @splitMessage.Replace(ValidationFieldPlaceholder, Label)
+                        @splitMessage.Replace(ValidationFieldPlaceholder, (ErrorPlaceholderOverride ?? Label))
                         <br />
                     }
                 }

--- a/components/src/Piipan.Components/Forms/UsaInputBase.cs
+++ b/components/src/Piipan.Components/Forms/UsaInputBase.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -33,8 +35,8 @@ namespace Piipan.Components.Forms
             base.OnInitialized();
             FormGroup.PreverificationChecks = PreverificationChecks;
             FormGroup.FieldIdentifier = this.FieldIdentifier;
-            string sourceProperty = ValueExpression.GetAttribute<T, UsaRequiredIfAttribute>()?.SourceProperty;
-            if (!string.IsNullOrEmpty(sourceProperty))
+            var sourceProperties = ValueExpression.GetAttribute<T, UsaRequiredIfAttribute>()?.Dependencies.Select(n => n.sourceProperty)?.ToArray() ?? Array.Empty<string>();
+            foreach (var sourceProperty in sourceProperties)
             {
                 FormGroup.FieldDependencies.Add(sourceProperty);
             }

--- a/components/src/Piipan.Components/Validation/UsaMinimumDateAttribute.cs
+++ b/components/src/Piipan.Components/Validation/UsaMinimumDateAttribute.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Piipan.Components.Validation
+{
+    /// <summary>
+    /// UsaMinimumDate can be used to make one property dependent on another one's date. For example:
+    /// 
+    /// public class Foo
+    /// {
+    ///    public DateTime? Prop1 { get; set; }
+    ///    
+    ///    [UsaMinimumDate(nameof(Prop1))]
+    ///    public DateTime? Prop2 { get; set; } // This property must be greater than or equal to Prop1 if both Properties have a value
+    /// }
+    /// </summary>
+    public class UsaMinimumDateAttribute : ValidationAttribute
+    {
+        public string SourceProperty { get; set; }
+
+        public UsaMinimumDateAttribute(string sourceProperty) : base()
+        {
+            SourceProperty = sourceProperty;
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var instance = validationContext.ObjectInstance;
+            var type = instance.GetType();
+
+
+            var sourcePropertyValue = type.GetProperty(SourceProperty).GetValue(instance, null) as DateTime?;
+            var testValueAsDate = value as DateTime?;
+
+            // If the source property test value doesn't have a value, we should make our property required if the source property has ANY value
+            if (sourcePropertyValue != null && testValueAsDate != null && testValueAsDate.Value.Date < sourcePropertyValue.Value.Date)
+            {
+                ErrorMessage = ErrorMessage.Replace("{0}", sourcePropertyValue.Value.ToString("MM/dd/yyyy"));
+                return new ValidationResult(ErrorMessage, new string[] { validationContext.MemberName });
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/components/src/Piipan.Components/Validation/UsaRequiredIfAttribute.cs
+++ b/components/src/Piipan.Components/Validation/UsaRequiredIfAttribute.cs
@@ -1,31 +1,48 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Piipan.Components.Validation
 {
     /// <summary>
-    /// UsaRequiredIf can be used to make one property dependent on another. For example:
+    /// UsaRequiredIf can be used to make one property dependent on others. 
+    /// Unfortunately, the CLR can only take in an array of strings, and cannot accept classes or tuples
+    /// See https://github.com/dotnet/roslyn/issues/22459 for more info.
+    /// Therefore, we accept an array of string parameters that should be defined in groups of 3.
+    /// First is the source property name, second is the source property test value, and third is the error message.
+    /// If you have another property to test, you can add it as a 4th, 5th, and 6th string parameter.
+    /// For example:
     /// 
     /// public class Foo
     /// {
     ///    public string Prop1 { get; set; }
     ///    
-    ///    [UsaRequiredIf(nameof(Prop1))]
-    ///    public string Prop2 { get; set; } // This property is required ONLY if Prop1 has a value
+    ///    [UsaRequiredIf(nameof(Prop1), "", "Error Message")]
+    ///    public string Prop2 { get; set; } // This property is required ONLY if Prop1 has a value and will show the error message "Error Message"
     ///    
-    ///    [UsaRequiredIf(nameof(Prop1), "Test")]
-    ///    public string Prop3 { get; set; } // This property is required ONLY if Prop1 has the value of "Test"
+    ///    [UsaRequiredIf(
+    ///       nameof(Prop1), "Test", "Prop3 is required",
+    ///       nameof(Prop2), "", "Prop3 is required"
+    ///    )]
+    ///    public string Prop3 { get; set; } // This property is required ONLY if Prop1 has the value of "Test" or if Prop2 has any value
     /// }
     /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
     public class UsaRequiredIfAttribute : ValidationAttribute
     {
-        public string SourceProperty { get; set; }
-        private readonly string _sourcePropertyTestValue;
+        public (string sourceProperty, string sourcePropertyTestValue, string errorMessage)[] Dependencies { get; set; } = Array.Empty<(string sourceProperty, string sourcePropertyTestValue, string errorMessage)>();
 
-        public UsaRequiredIfAttribute(string sourceProperty, string sourcePropertyTestValue = null) : base()
+        public UsaRequiredIfAttribute(params string[] dependencyInfo) : base()
         {
             ErrorMessage = ValidationConstants.RequiredMessage;
-            SourceProperty = sourceProperty;
-            _sourcePropertyTestValue = sourcePropertyTestValue;
+            List<(string sourceProperty, string sourcePropertyTestValue, string errorMessage)> list = new();
+
+            // Populate the dependencies array.
+            for (int i = 0; i + 2 < dependencyInfo.Length; i += 3)
+            {
+                list.Add((dependencyInfo[i], dependencyInfo[i + 1], dependencyInfo[i + 2]));
+            }
+            Dependencies = list.ToArray();
         }
 
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
@@ -35,24 +52,28 @@ namespace Piipan.Components.Validation
             var instance = validationContext.ObjectInstance;
             var type = instance.GetType();
 
-            var sourcePropertyValue = type.GetProperty(SourceProperty).GetValue(instance, null);
+            foreach (var dependency in Dependencies)
+            {
+                var sourcePropertyValue = type.GetProperty(dependency.sourceProperty).GetValue(instance, null);
 
-            // If the source property test value doesn't have a value, we should make our property required if the source property has ANY value
-            if (string.IsNullOrEmpty(_sourcePropertyTestValue))
-            {
-                if (!string.IsNullOrEmpty(sourcePropertyValue?.ToString()) && string.IsNullOrEmpty(currentValueAsString))
+                // If the source property test value doesn't have a value, we should make our property required if the source property has ANY value
+                if (string.IsNullOrEmpty(dependency.sourcePropertyTestValue))
                 {
-                    return new ValidationResult(ErrorMessage, new string[] { validationContext.MemberName });
+                    if (!string.IsNullOrEmpty(sourcePropertyValue?.ToString()) && string.IsNullOrEmpty(currentValueAsString))
+                    {
+                        return new ValidationResult(dependency.errorMessage, new string[] { validationContext.MemberName });
+                    }
+                }
+                // If the source property test value DOES have a value, we should make our property required ONLY if the source property value is equal to the test value
+                else
+                {
+                    if (sourcePropertyValue?.ToString() == dependency.sourcePropertyTestValue && string.IsNullOrEmpty(currentValueAsString))
+                    {
+                        return new ValidationResult(dependency.errorMessage, new string[] { validationContext.MemberName });
+                    }
                 }
             }
-            // If the source property test value DOES have a value, we should make our property required ONLY if the source property value is equal to the test value
-            else
-            {
-                if (sourcePropertyValue?.ToString() == _sourcePropertyTestValue && string.IsNullOrEmpty(currentValueAsString))
-                {
-                    return new ValidationResult(ErrorMessage, new string[] { validationContext.MemberName });
-                }
-            }
+
 
             return ValidationResult.Success;
         }

--- a/components/tests/Piipan.Components.Tests/Validation/UsaMinimumDateAttributeTests.cs
+++ b/components/tests/Piipan.Components.Tests/Validation/UsaMinimumDateAttributeTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Piipan.Components.Validation;
+using Xunit;
+
+namespace Piipan.Components.Tests.Validation
+{
+    public class UsaMinimumDateAttributeTests
+    {
+        public class DummyModel
+        {
+            public DateTime? SourceDate { get; set; }
+
+            [UsaMinimumDate(nameof(SourceDate))]
+            public DateTime? TargetDate { get; set; }
+        }
+
+        /// <summary>
+        /// Validate a UsaMinimumDate attribute attached to a dummy model using various parameters. Must use strings as parameters due to XUnit not allowing
+        /// us to put DateTimes into InlineData
+        /// </summary>
+        [Theory]
+        [InlineData(null, null, false)] // No error thrown when both source and target property is null
+        [InlineData(null, "07/21/2022", false)] // No error thrown when source property is null
+        [InlineData("07/21/2022", null, false)] // No error thrown when target property is null (this attribute does not make this field required!)
+        [InlineData("07/21/2022", "07/21/2022", false)] // No error thrown when target property is equal to source property
+        [InlineData("07/21/2022", "07/22/2022", false)] // No error thrown when target property is greater than source property
+        [InlineData("07/21/2022", "07/20/2022", true)] // Error thrown when target property is smaller than source property
+        public void UsaMinimumDate_ValidateTests(string prop1Value, string prop2Value, bool hasError)
+        {
+            // Arrange
+            var attribute = new UsaMinimumDateAttribute(nameof(DummyModel.SourceDate)) { ErrorMessage = "Date is not greater than {0}" };
+
+            var dummyModel = new DummyModel()
+            {
+                SourceDate = prop1Value == null ? null : DateTime.Parse(prop1Value),
+                TargetDate = prop2Value == null ? null : DateTime.Parse(prop2Value)
+            };
+
+            // Act
+            var validationResult = attribute.GetValidationResult(dummyModel.TargetDate, new System.ComponentModel.DataAnnotations.ValidationContext(dummyModel));
+
+            // Assert
+            Assert.Equal(hasError, !string.IsNullOrEmpty(validationResult?.ErrorMessage));
+            if (hasError)
+            {
+                Assert.Equal($"Date is not greater than 07/21/2022", validationResult.ErrorMessage);
+            }
+        }
+    }
+}

--- a/components/tests/Piipan.Components.Tests/Validation/UsaRequiredIfAttributeTests.cs
+++ b/components/tests/Piipan.Components.Tests/Validation/UsaRequiredIfAttributeTests.cs
@@ -4,54 +4,172 @@ using Xunit;
 namespace Piipan.Components.Tests.Validation
 {
     /// <summary>
-    /// Tests associated with the UsaRequired attribute
+    /// Tests associated with the UsaRequiredIf attribute
     /// </summary>
     public class UsaRequiredIfAttributeTests
     {
         public class DummyModel
         {
-            public string SourceString { get; set; }
+            public string Prop1 { get; set; }
 
-            [UsaRequiredIf(nameof(SourceString))]
-            public string TargetString { get; set; }
+            [UsaRequiredIf(nameof(Prop1), "", "some error")]
+            public string Prop2 { get; set; }
+
+            [UsaRequiredIf(
+                nameof(Prop1), "", "some error",
+                nameof(Prop2), "", "some other error")]
+            public string Prop3 { get; set; }
         }
 
         /// <summary>
         /// Validate a UsaRequiredIf attribute attached to a dummy model using various parameters
         /// </summary>
-        /// <param name="value">The value of the associated field</param>
-        /// <param name="isValidExpected">Whether or not we expect this field to have an error after the value is entered</param>
         [Theory]
-        [InlineData("", "test", null, null)]
-        [InlineData(null, "test", null, null)]
-        [InlineData("", "", null, null)]
-        [InlineData(null, null, null, null)]
-        [InlineData("test", "", null, "Target Value cannot be empty because source value is not null")]
-        [InlineData("test", "test", null, null)]
-        [InlineData("expected", "", "expected", "Target Value cannot be empty because source value is set to the expected value")]
-        [InlineData("expected", "test", "expected", null)]
-        [InlineData("notexpected", "", "expected", null)]
-        [InlineData("notexpected", "test", "expected", null)]
-        public void UsaRequiredIf_ValidateTests(string sourceValue, string targetValue, string requiredIfEqualText, string errorText)
+        [InlineData("", "test", false)]
+        [InlineData("", "", false)]
+        [InlineData("test", "", true)] // Error thrown when property 1 has a value and property 2 does not
+        [InlineData("test", "test", false)]
+        public void UsaRequiredIf_ValidateTests_OneProperty_RequiredIfNotEmpty(string prop1Value, string prop2Value, bool hasError)
         {
             // Arrange
-            var attribute = new UsaRequiredIfAttribute(nameof(DummyModel.SourceString), requiredIfEqualText)
-            {
-                ErrorMessage = errorText
-            };
+            var attribute = new UsaRequiredIfAttribute(
+                nameof(DummyModel.Prop1), "", "Property is required since Prop1 is not empty");
 
             var dummyModel = new DummyModel()
             {
-                SourceString = sourceValue,
-                TargetString = targetValue
+                Prop1 = prop1Value,
+                Prop2 = prop2Value
             };
 
             // Act
-            var validationResult = attribute.GetValidationResult(targetValue, new System.ComponentModel.DataAnnotations.ValidationContext(dummyModel));
+            var validationResult = attribute.GetValidationResult(prop2Value, new System.ComponentModel.DataAnnotations.ValidationContext(dummyModel));
 
             // Assert
-            Assert.Equal(errorText, validationResult?.ErrorMessage);
+            Assert.Equal(hasError, !string.IsNullOrEmpty(validationResult?.ErrorMessage));
         }
 
+        /// <summary>
+        /// Validate a UsaRequiredIf attribute attached to a dummy model using various parameters against an expected value
+        /// </summary>
+        [Theory]
+        [InlineData("expectedvalue", "test", false)]
+        [InlineData("expectedvalue", "", true)] // Error thrown when property 1 has expectedvalue and property 2 is empty
+        [InlineData("notexpectedvalue", "", false)] // Error NOT thrown when property 1 has an unexpected value and property 2 is empty
+        [InlineData("notexpectedvalue", "test", false)]
+        public void UsaRequiredIf_ValidateTests_OneProperty_RequiredIfEqual(string prop1Value, string prop2Value, bool hasError)
+        {
+            // Arrange
+            var attribute = new UsaRequiredIfAttribute(
+                nameof(DummyModel.Prop1), "expectedvalue", "Property is required since Prop1 is expectedvalue");
+
+            var dummyModel = new DummyModel()
+            {
+                Prop1 = prop1Value,
+                Prop2 = prop2Value
+            };
+
+            // Act
+            var validationResult = attribute.GetValidationResult(prop2Value, new System.ComponentModel.DataAnnotations.ValidationContext(dummyModel));
+
+            // Assert
+            Assert.Equal(hasError, !string.IsNullOrEmpty(validationResult?.ErrorMessage));
+        }
+
+        /// <summary>
+        /// Validate a UsaRequiredIf attribute attached to a dummy model using various parameters using multiple properties
+        /// </summary>
+        [Theory]
+        [InlineData("", "", "", false)]
+        [InlineData("", "", "test", false)]
+        [InlineData("test", "", "", true)] // Error thrown when property 1 has a value and property 3 does not
+        [InlineData("", "test", "", true)] // Error thrown when property 2 has a value and property 3 does not
+        public void UsaRequiredIf_ValidateTests_MultipleProperties_RequiredIfNotEmpty(string prop1Value, string prop2Value, string prop3Value, bool hasError)
+        {
+            // Arrange
+            var attribute = new UsaRequiredIfAttribute(
+                nameof(DummyModel.Prop1), "", "Property is required since Prop1 is not empty",
+                nameof(DummyModel.Prop2), "", "Property is required since Prop2 is not empty");
+
+            var dummyModel = new DummyModel()
+            {
+                Prop1 = prop1Value,
+                Prop2 = prop2Value,
+                Prop3 = prop3Value
+            };
+
+            // Act
+            var validationResult = attribute.GetValidationResult(prop3Value, new System.ComponentModel.DataAnnotations.ValidationContext(dummyModel));
+
+            // Assert
+            Assert.Equal(hasError, !string.IsNullOrEmpty(validationResult?.ErrorMessage));
+        }
+
+        /// <summary>
+        /// Validate a UsaRequiredIf attribute attached to a dummy model using various parameters using multiple properties against an expected value
+        /// </summary>
+        [Theory]
+        [InlineData("expectedvalue", "", "test", false)]
+        [InlineData("", "expectedvalue", "test", false)]
+        [InlineData("expectedvalue", "", "", true)] // Error thrown when property 1 has expectedvalue and property 3 is empty
+        [InlineData("", "expectedvalue", "", true)] // Error thrown when property 2 has expectedvalue and property 3 is empty
+        [InlineData("notexpectedvalue", "", "", false)] // Error NOT thrown when property 1 has an unexpected value and property 3 is empty
+        [InlineData("", "notexpectedvalue", "", false)] // Error NOT thrown when property 2 has an unexpected value and property 3 is empty
+        [InlineData("expectedvalue", "expectedvalue", "", true)] // Error thrown when both properties have expectedvalue and property 3 is empty
+        [InlineData("notexpectedvalue", "notexpectedvalue", "test", false)]
+        public void UsaRequiredIf_ValidateTests_MultipleProperty_RequiredIfEqual(string prop1Value, string prop2Value, string prop3Value, bool hasError)
+        {
+            // Arrange
+            var attribute = new UsaRequiredIfAttribute(
+                nameof(DummyModel.Prop1), "expectedvalue", "Property is required since Prop1 is expectedvalue",
+                nameof(DummyModel.Prop2), "expectedvalue", "Property is required since Prop2 is expectedvalue");
+
+            var dummyModel = new DummyModel()
+            {
+                Prop1 = prop1Value,
+                Prop2 = prop2Value,
+                Prop3 = prop3Value
+            };
+
+            // Act
+            var validationResult = attribute.GetValidationResult(prop3Value, new System.ComponentModel.DataAnnotations.ValidationContext(dummyModel));
+
+            // Assert
+            Assert.Equal(hasError, !string.IsNullOrEmpty(validationResult?.ErrorMessage));
+        }
+
+        /// <summary>
+        /// Validate a UsaRequiredIf attribute attached to a dummy model using various parameters using multiple properties. One property is checking an expected value,
+        /// and the other is checking to see if it has any value.
+        /// For this test, Property 3 is required if: Property 1 has the value of "expectedvalue", OR Property 2 has any value.
+        /// </summary>
+        [Theory]
+        [InlineData("expectedvalue", "", "", true)] // Error thrown when property 1 has expectedvalue and property 3 is empty
+        [InlineData("", "anyvalue", "", true)] // Error thrown when property 2 has any value and property 3 is empty
+        [InlineData("expectedvalue", "anyvalue", "", true)] // Error thrown when Property 1 has the expected value, property 2 has any value, and property 3 is empty
+        [InlineData("notexpectedvalue", "", "", false)] // No error necessary, because Property 1 is not the expected value, and Property 2 doesn't have a value.
+        [InlineData("expectedvalue", "", "test", false)] // No error because Property 3 has a value
+        [InlineData("", "anyvalue", "test", false)] // No error because Property 3 has a value
+        [InlineData("expectedvalue", "anyvalue", "test", false)] // No error because Property 3 has a value
+        [InlineData("notexpectedvalue", "", "test", false)] // No error because Property 3 has a value, but beyond that it isn't even required to have one
+        public void UsaRequiredIf_ValidateTests_MultipleProperty_RequiredIfEqualOrNotEmpty(string prop1Value, string prop2Value, string prop3Value, bool hasError)
+        {
+            // Arrange
+            var attribute = new UsaRequiredIfAttribute(
+                nameof(DummyModel.Prop1), "expectedvalue", "Property is required since Prop1 is expectedvalue",
+                nameof(DummyModel.Prop2), "", "Property is required since Prop2 is not empty");
+
+            var dummyModel = new DummyModel()
+            {
+                Prop1 = prop1Value,
+                Prop2 = prop2Value,
+                Prop3 = prop3Value
+            };
+
+            // Act
+            var validationResult = attribute.GetValidationResult(prop3Value, new System.ComponentModel.DataAnnotations.ValidationContext(dummyModel));
+
+            // Assert
+            Assert.Equal(hasError, !string.IsNullOrEmpty(validationResult?.ErrorMessage));
+        }
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Api/IMatchResolutionApi.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Api/IMatchResolutionApi.cs
@@ -8,6 +8,6 @@ namespace Piipan.Match.Api
     {
         Task<MatchResApiResponse> GetMatch(string matchId, string requestLocation);
         Task<MatchResListApiResponse> GetMatches();
-        Task<MatchResApiResponse> AddMatchResEvent(string matchId, AddEventRequest request, string initiatingState);
+        Task<(MatchResApiResponse SuccessResponse, string FailResponse)> AddMatchResEvent(string matchId, AddEventRequest request, string initiatingState);
     }
 }

--- a/match/src/Piipan.Match/Piipan.Match.Client/MatchResolutionClient.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Client/MatchResolutionClient.cs
@@ -52,7 +52,7 @@ namespace Piipan.Match.Client
         /// <summary>
         /// sendsS a patch request to update match res events
         /// </summary>
-        public async Task<MatchResApiResponse> AddMatchResEvent(string matchId, AddEventRequest request, string initiatingState)
+        public async Task<(MatchResApiResponse SuccessResponse, string FailResponse)> AddMatchResEvent(string matchId, AddEventRequest request, string initiatingState)
         {
             return await _apiClient.PatchAsync<AddEventRequest, MatchResApiResponse>($"matches/{matchId}/disposition", request, () =>
             {

--- a/match/src/Piipan.Match/Piipan.Match.Core/Parsers/AddEventRequestParser.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Parsers/AddEventRequestParser.cs
@@ -1,10 +1,10 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Piipan.Match.Api.Models;
-using Newtonsoft.Json;
 using FluentValidation;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Piipan.Match.Api.Models;
 
 namespace Piipan.Match.Core.Parsers
 {
@@ -59,6 +59,10 @@ namespace Piipan.Match.Core.Parsers
                 }
 
                 return request;
+            }
+            catch (ValidationException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/match/src/Piipan.Match/Piipan.Match.Core/Validators/AddEventRequestValidator.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Validators/AddEventRequestValidator.cs
@@ -1,5 +1,5 @@
-using Piipan.Match.Api.Models;
 using FluentValidation;
+using Piipan.Match.Api.Models;
 
 namespace Piipan.Match.Core.Validators
 {
@@ -13,6 +13,50 @@ namespace Piipan.Match.Core.Validators
             RuleFor(r => r.Data)
                 .NotNull()
                 .NotEmpty();
+
+            When(x => x.Data != null, () =>
+            {
+
+                RuleFor(r => r.Data.InitialActionAt).Custom((val, context) =>
+                {
+                    if (val == null && !string.IsNullOrEmpty(context.InstanceToValidate.Data.InitialActionTaken))
+                    {
+                        context.AddFailure("Initial Action Date is required");
+                    }
+                    else if (val == null && !string.IsNullOrEmpty(context.InstanceToValidate.Data.FinalDisposition))
+                    {
+                        context.AddFailure("Initial Action Date is required because a Final Disposition has been selected");
+                    }
+                });
+
+                RuleFor(r => r.Data.InitialActionTaken).Custom((val, context) =>
+                {
+                    if (string.IsNullOrEmpty(val) && context.InstanceToValidate.Data.InitialActionAt != null)
+                    {
+                        context.AddFailure("Initial Action Taken is required because a date has been selected");
+                    }
+                    else if (string.IsNullOrEmpty(val) && !string.IsNullOrEmpty(context.InstanceToValidate.Data.FinalDisposition))
+                    {
+                        context.AddFailure("Initial Action Taken is required because a Final Disposition has been selected");
+                    }
+                });
+
+                RuleFor(r => r.Data.FinalDispositionDate).Custom((val, context) =>
+                {
+                    if (val == null && !string.IsNullOrEmpty(context.InstanceToValidate.Data.FinalDisposition))
+                    {
+                        context.AddFailure("Final Disposition Date is required");
+                    }
+                });
+
+                RuleFor(r => r.Data.FinalDisposition).Custom((val, context) =>
+                {
+                    if (string.IsNullOrEmpty(val) && context.InstanceToValidate.Data.FinalDispositionDate != null)
+                    {
+                        context.AddFailure("Final Disposition Taken is required because a date has been selected");
+                    }
+                });
+            });
         }
     }
 }

--- a/match/tests/Piipan.Match.Core.Tests/Validators/AddEventRequestValidatorTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Validators/AddEventRequestValidatorTests.cs
@@ -1,0 +1,139 @@
+﻿using FluentValidation.TestHelper;
+using Piipan.Match.Api.Models;
+using Piipan.Match.Core.Validators;
+using Xunit;
+
+
+namespace Piipan.Match.Core.Tests.Validators
+{
+    public class AddEventRequestValidatorTests
+    {
+        public AddEventRequestValidator Validator()
+        {
+            return new AddEventRequestValidator();
+        }
+
+        [Fact]
+        public void ReturnsErrorWhenDataEmpty()
+        {
+            // Setup
+            var model = new AddEventRequest()
+            {
+                Data = null
+            };
+            // Act
+            var result = Validator().TestValidate(model);
+            // Assert
+            result.ShouldHaveValidationErrorFor(result => result.Data);
+        }
+
+        #region InitialActionAt
+
+        [Fact]
+        public void ReturnsErrorWhen_InitialActionAtIsEmpty_And_InitialActionTakenIsNot()
+        {
+            // Setup
+            var model = new AddEventRequest()
+            {
+                Data = new AddEventRequestData
+                {
+                    InitialActionTaken = "Notice Sent"
+                }
+            };
+            // Act
+            var result = Validator().TestValidate(model);
+            // Assert
+            result.ShouldHaveValidationErrorFor(result => result.Data.InitialActionAt);
+        }
+
+        [Fact]
+        public void ReturnsErrorWhen_InitialActionAtIsEmpty_And_FinalDispositionIsNot()
+        {
+            // Setup
+            var model = new AddEventRequest()
+            {
+                Data = new AddEventRequestData
+                {
+                    FinalDisposition = "Benefits Denied"
+                }
+            };
+            // Act
+            var result = Validator().TestValidate(model);
+            // Assert
+            result.ShouldHaveValidationErrorFor(result => result.Data.InitialActionAt);
+        }
+
+        #endregion InitialActionAt
+        #region InitialActionTaken
+        [Fact]
+        public void ReturnsErrorWhen_InitialActionTakenIsEmpty_And_InitialActionAtIsNot()
+        {
+            // Setup
+            var model = new AddEventRequest()
+            {
+                Data = new AddEventRequestData
+                {
+                    InitialActionAt = System.DateTime.Now
+                }
+            };
+            // Act
+            var result = Validator().TestValidate(model);
+            // Assert
+            result.ShouldHaveValidationErrorFor(result => result.Data.InitialActionTaken);
+        }
+
+        [Fact]
+        public void ReturnsErrorWhen_InitialActionTakenIsEmpty_And_FinalDispositionIsNot()
+        {
+            // Setup
+            var model = new AddEventRequest()
+            {
+                Data = new AddEventRequestData
+                {
+                    FinalDisposition = "Benefits Denied"
+                }
+            };
+            // Act
+            var result = Validator().TestValidate(model);
+            // Assert
+            result.ShouldHaveValidationErrorFor(result => result.Data.InitialActionTaken);
+        }
+        #endregion InitialActionTaken
+        #region FinalDispositionDate
+        [Fact]
+        public void ReturnsErrorWhen_FinalDispositionDateIsEmpty_And_FinalDispositionIsNot()
+        {
+            // Setup
+            var model = new AddEventRequest()
+            {
+                Data = new AddEventRequestData
+                {
+                    FinalDisposition = "Benefits Denied"
+                }
+            };
+            // Act
+            var result = Validator().TestValidate(model);
+            // Assert
+            result.ShouldHaveValidationErrorFor(result => result.Data.FinalDispositionDate);
+        }
+        #endregion FinalDispositionDate
+        #region FinalDisposition
+        [Fact]
+        public void ReturnsErrorWhen_FinalDispositionIsEmpty_And_FinalDispositionDateIsNot()
+        {
+            // Setup
+            var model = new AddEventRequest()
+            {
+                Data = new AddEventRequestData
+                {
+                    FinalDispositionDate = System.DateTime.Now
+                }
+            };
+            // Act
+            var result = Validator().TestValidate(model);
+            // Assert
+            result.ShouldHaveValidationErrorFor(result => result.Data.FinalDisposition);
+        }
+        #endregion FinalDisposition
+    }
+}

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
@@ -204,7 +204,7 @@ namespace Piipan.Match.Func.ResolutionApi.IntegrationTests
             {
                 MatchId = matchId,
                 Initiator = "ea",
-                CreatedAt = DateTime.UtcNow,
+                CreatedAt = DateTime.Parse("2022-07-01"),
                 States = new string[] { "ea", "eb" },
                 Hash = "foo",
                 HashType = "ldshash",

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
@@ -204,7 +204,6 @@ namespace Piipan.Match.Func.ResolutionApi.IntegrationTests
             {
                 MatchId = matchId,
                 Initiator = "ea",
-                CreatedAt = DateTime.Parse("2022-07-01"),
                 States = new string[] { "ea", "eb" },
                 Hash = "foo",
                 HashType = "ldshash",
@@ -222,7 +221,7 @@ namespace Piipan.Match.Func.ResolutionApi.IntegrationTests
             };
             InsertMatchResEvent(matchResEvent);
 
-            var mockRequest = MockRequest("{ \"data\": { \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\", \"final_disposition\": \"bar\", \"final_disposition_date\": \"2022-07-20T00:00:02\" } }");
+            var mockRequest = MockRequest("{ \"data\": { \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\", \"final_disposition\": \"bar\", \"final_disposition_date\": \"" + System.DateTime.UtcNow.AddDays(2).ToString("s") + "\" } }");
             var mockLogger = new Mock<ILogger>();
             var api = Construct();
 

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,10 +17,6 @@ using Piipan.Match.Core.Models;
 using Piipan.Match.Core.Parsers;
 using Piipan.Match.Core.Validators;
 using Piipan.Shared.Database;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Xunit;
 
 namespace Piipan.Match.Func.ResolutionApi.IntegrationTests
@@ -218,11 +218,11 @@ namespace Piipan.Match.Func.ResolutionApi.IntegrationTests
                 MatchId = matchId,
                 Actor = "user",
                 ActorState = "eb",
-                Delta = "{ \"final_disposition\": \"foo\", \"final_disposition_date\": \"2022-07-20T00:00:02\" }"
+                Delta = "{ \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\", \"final_disposition\": \"foo\", \"final_disposition_date\": \"2022-07-20T00:00:02\" }"
             };
             InsertMatchResEvent(matchResEvent);
 
-            var mockRequest = MockRequest("{ \"data\": { \"final_disposition\": \"bar\", \"final_disposition_date\": \"2022-07-20T00:00:02\" } }");
+            var mockRequest = MockRequest("{ \"data\": { \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\", \"final_disposition\": \"bar\", \"final_disposition_date\": \"2022-07-20T00:00:02\" } }");
             var mockLogger = new Mock<ILogger>();
             var api = Construct();
 

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
@@ -333,8 +333,8 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
                 .Setup(r => r.GetRecordByMatchId(It.IsAny<string>()))
                 .ReturnsAsync(new MatchRecordDbo()
                 {
-                    States = new string[] { "ea", "eb"
-                }
+                    States = new string[] { "ea", "eb" },
+                    CreatedAt = DateTime.Parse("2022-07-01")
                 });
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var events = new List<IMatchResEvent>() {
@@ -382,6 +382,65 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
                 It.Is<MatchResEventDbo>(m => m.Actor == "system" && m.Delta == api.ClosedDelta)
             ), Times.Once());
             Assert.Equal(200, response.StatusCode);
+        }
+
+        [Fact]
+        public async void AddEvent_CheckIfFinalDispositionDateError()
+        {
+            var matchRecordDao = new Mock<IMatchRecordDao>();
+            matchRecordDao
+                .Setup(r => r.GetRecordByMatchId(It.IsAny<string>()))
+                .ReturnsAsync(new MatchRecordDbo()
+                {
+                    States = new string[] { "ea", "eb" },
+                    CreatedAt = DateTime.Parse("2022-08-01") // Created At date > Final Disposition Date
+                });
+            var matchResEventDao = new Mock<IMatchResEventDao>();
+            var events = new List<IMatchResEvent>() {
+                new MatchResEventDbo() {
+                    Delta = "{ \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\",  \"final_disposition\": \"foo\", \"final_disposition_date\": \"2022-07-20T00:00:02\" }",
+                    ActorState = "eb"
+                }
+            };
+            matchResEventDao
+                .Setup(r => r.GetEvents(
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()
+                ))
+                .ReturnsAsync(events);
+            matchResEventDao
+             .Setup(r => r.AddEvent(
+                 It.IsAny<MatchResEventDbo>()
+             ))
+             .ReturnsAsync(1);
+            var matchResAggregator = new Mock<IMatchResAggregator>();
+            matchResAggregator
+                .Setup(r => r.Build(It.IsAny<IMatchRecord>(), It.IsAny<IEnumerable<IMatchResEvent>>()))
+                .Returns(new MatchResRecord()
+                {
+                    Status = "open"
+                });
+            var requestParser = new AddEventRequestParser(
+                new AddEventRequestValidator(),
+                Mock.Of<ILogger<AddEventRequestParser>>()
+            );
+            var api = new AddEventApi(
+                matchRecordDao.Object,
+                matchResEventDao.Object,
+                matchResAggregator.Object,
+                requestParser
+            );
+            var mockRequest = MockRequest("{ \"data\": { \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\", \"final_disposition\": \"bar\", \"final_disposition_date\": \"2022-07-20T00:00:01\" } }"); // coming form state ea
+            var logger = new Mock<ILogger>();
+
+            // Act
+            BadRequestObjectResult response = (BadRequestObjectResult)(await api.AddEvent(mockRequest.Object, "foo", logger.Object));
+
+            // Assert
+            matchResEventDao.Verify(mock => mock.AddEvent(
+                It.Is<MatchResEventDbo>(m => m.Actor == "system" && m.Delta == api.ClosedDelta)
+            ), Times.Never());
+            Assert.Equal(400, response.StatusCode);
         }
     }
 }

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -115,13 +112,14 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchRecordDao = new Mock<IMatchRecordDao>();
             matchRecordDao
                 .Setup(r => r.GetRecordByMatchId(It.IsAny<string>()))
-                .ReturnsAsync(new MatchRecordDbo() { States = new string[] { "ea", "bc"}});
+                .ReturnsAsync(new MatchRecordDbo() { States = new string[] { "ea", "bc" } });
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var matchResAggregator = new Mock<IMatchResAggregator>();
             var requestParser = new Mock<IStreamParser<AddEventRequest>>();
             matchResAggregator
                 .Setup(r => r.Build(It.IsAny<IMatchRecord>(), It.IsAny<IEnumerable<IMatchResEvent>>()))
-                .Returns(new MatchResRecord(){
+                .Returns(new MatchResRecord()
+                {
                     Status = "closed"
                 });
             var api = new AddEventApi(
@@ -147,7 +145,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchRecordDao = new Mock<IMatchRecordDao>();
             matchRecordDao
                 .Setup(r => r.GetRecordByMatchId(It.IsAny<string>()))
-                .ReturnsAsync(new MatchRecordDbo() { States = new string[] { "bc", "de"}});
+                .ReturnsAsync(new MatchRecordDbo() { States = new string[] { "bc", "de" } });
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var matchResAggregator = new Mock<IMatchResAggregator>();
             var requestParser = new Mock<IStreamParser<AddEventRequest>>();
@@ -191,7 +189,8 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchResAggregator = new Mock<IMatchResAggregator>();
             matchResAggregator
                 .Setup(r => r.Build(It.IsAny<IMatchRecord>(), It.IsAny<IEnumerable<IMatchResEvent>>()))
-                .Returns(new MatchResRecord(){
+                .Returns(new MatchResRecord()
+                {
                     Status = "open"
                 });
             var requestParser = new AddEventRequestParser(
@@ -275,9 +274,11 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchRecordDao = new Mock<IMatchRecordDao>();
             matchRecordDao
                 .Setup(r => r.GetRecordByMatchId(It.IsAny<string>()))
-                .ReturnsAsync(new MatchRecordDbo() {
+                .ReturnsAsync(new MatchRecordDbo()
+                {
                     States = new string[] { "ea", "eb"
-                } });
+                }
+                });
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var events = new List<IMatchResEvent>() {
                 new MatchResEventDbo() {
@@ -291,10 +292,12 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
                     It.IsAny<bool>()
                 ))
                 .ReturnsAsync(events);
+
             var matchResAggregator = new Mock<IMatchResAggregator>();
             matchResAggregator
                 .Setup(r => r.Build(It.IsAny<IMatchRecord>(), It.IsAny<IEnumerable<IMatchResEvent>>()))
-                .Returns(new MatchResRecord(){
+                .Returns(new MatchResRecord()
+                {
                     Status = "open"
                 });
             var requestParser = new AddEventRequestParser(
@@ -325,9 +328,11 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchRecordDao = new Mock<IMatchRecordDao>();
             matchRecordDao
                 .Setup(r => r.GetRecordByMatchId(It.IsAny<string>()))
-                .ReturnsAsync(new MatchRecordDbo() {
+                .ReturnsAsync(new MatchRecordDbo()
+                {
                     States = new string[] { "ea", "eb"
-                } });
+                }
+                });
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var events = new List<IMatchResEvent>() {
                 new MatchResEventDbo() {
@@ -344,7 +349,8 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchResAggregator = new Mock<IMatchResAggregator>();
             matchResAggregator
                 .Setup(r => r.Build(It.IsAny<IMatchRecord>(), It.IsAny<IEnumerable<IMatchResEvent>>()))
-                .Returns(new MatchResRecord(){
+                .Returns(new MatchResRecord()
+                {
                     Status = "open"
                 });
             var requestParser = new AddEventRequestParser(

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
@@ -339,7 +339,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var events = new List<IMatchResEvent>() {
                 new MatchResEventDbo() {
-                    Delta = "{ \"final_disposition\": \"foo\", \"final_disposition_date\": \"2022-07-20T00:00:02\" }",
+                    Delta = "{ \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\",  \"final_disposition\": \"foo\", \"final_disposition_date\": \"2022-07-20T00:00:02\" }",
                     ActorState = "eb"
                 }
             };
@@ -371,7 +371,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
                 matchResAggregator.Object,
                 requestParser
             );
-            var mockRequest = MockRequest("{ \"data\": { \"final_disposition\": \"bar\", \"final_disposition_date\": \"2022-07-20T00:00:01\" } }"); // coming form state ea
+            var mockRequest = MockRequest("{ \"data\": { \"initial_action_taken\": \"Notice Sent\", \"initial_action_at\": \"2022-07-20T00:00:02\", \"final_disposition\": \"bar\", \"final_disposition_date\": \"2022-07-20T00:00:01\" } }"); // coming form state ea
             var logger = new Mock<ILogger>();
 
             // Act

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/FinalDisposition.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/FinalDisposition.razor
@@ -6,33 +6,51 @@
     private (string,string)[] DropdownOptionsOne = new (string,string)[] {("Benefits Approved", "Benefits Approved"), ("Benefits Denied", "Benefits Denied")};
     private (string,string)[] DropdownOptionsTwo = new (string, string)[] { ("Benefits Terminated", "Benefits Terminated"), ("Benefits Unchanged", "Benefits Unchanged") };
 
-    private RenderFragment GetDispositonLabel()
+    private string DispositonLabelString => DispositionData.FinalDisposition switch
     {
-        return @<text> @(DispositionData.FinalDisposition switch
+
+        "Benefits Approved" => "Benefits Start Date",
+        "Benefits Terminated" => "Benefits End Date",
+        _ => "Final Disposition Date"
+    };
+    private RenderFragment DispositionLabel => @<text>@DispositonLabelString</text>;
+
+    private void FinalDispositionChanged(string value)
+    {
+        DispositionData.FinalDisposition = value;
+        if (!string.IsNullOrEmpty(value) && DispositionData.FinalDispositionDate == null && 
+            (DispositionData.FinalDisposition == "Benefits Unchanged" || DispositionData.FinalDisposition == "Benefits Denied"))
         {
-
-            "Benefits Approved" => "Benefits Start Date",
-            "Benefits Terminated" => "Benefits End Date",
-            _ => "Final Disposition Date"
-
-        })</text>;
-
+            DispositionData.FinalDispositionDate = DateTime.Now.Date;
+        }
     }
+    protected override void OnInitialized()
+    {
+        DispositionData.InitialActionChanged += InitialActionChangedHandler;
+    }
+    public void Dispose()
+    {
+        DispositionData.InitialActionChanged -= InitialActionChangedHandler;
+    }
+    private void InitialActionChangedHandler() => InvokeAsync(StateHasChanged);
+    private bool disableInputs => string.IsNullOrEmpty(DispositionData.InitialActionTaken) && string.IsNullOrEmpty(DispositionData.FinalDisposition) && DispositionData.FinalDispositionDate == null;
 }
-<div class="FinalDispositionDiv">
+<div id="final-disposition-section"  class="FinalDispositionDiv @(disableInputs ? "disabled-area" : "")">
     <h5 class="FinalDispositionHeader">Final Disposition</h5>
     <p class="FinalDispositionText">Final Disposition information can be added once the initial Action has been selected.</p>
     <div class="ResolutionFieldsDropdownWidth">
         <UsaFormGroup>
-            <UsaSelect DropdownOptions="@(InitiatingState ? DropdownOptionsOne : DropdownOptionsTwo)" @bind-Value="DispositionData.FinalDisposition" />
+            <UsaSelect DropdownOptions="@(InitiatingState ? DropdownOptionsOne : DropdownOptionsTwo)" 
+            Value="@DispositionData.FinalDisposition" ValueChanged="(value => FinalDispositionChanged(value))"
+            ValueExpression="() => DispositionData.FinalDisposition" disabled="@disableInputs" />
         </UsaFormGroup>
     </div>
         
 
-        @if (!String.IsNullOrEmpty(DispositionData.FinalDisposition) || DispositionData.FinalDispositionDate != null)
+    @if (!String.IsNullOrEmpty(DispositionData.FinalDisposition) || DispositionData.FinalDispositionDate != null)
     {
-        <UsaFormGroup LabelOverride="@GetDispositonLabel()">
-            <UsaInputDate @bind-Value="DispositionData.FinalDispositionDate" />
+        <UsaFormGroup LabelOverride="DispositionLabel" ErrorPlaceholderOverride="@DispositonLabelString">
+            <UsaInputDate @bind-Value="DispositionData.FinalDispositionDate" disabled="@disableInputs" />
         </UsaFormGroup>
     }
 </div>

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/MatchDetail.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/MatchDetail.razor
@@ -23,7 +23,8 @@
 
     protected override void OnInitialized()
     {
-        model = new DispositionModel(IsUserInInitiatingState() ? InitiatingStateDisposition :   MatchingStateDisposition);
+        model = SaveResponse?.FailedDispositionModel ?? (new DispositionModel(IsUserInInitiatingState() ? InitiatingStateDisposition :   MatchingStateDisposition));
+        model.MatchDate = Match.Data.Data.CreatedAt;
         if (ServerErrors?.Count > 0)
         {
             serverErrorList = new(ServerErrors.Select(n => (n.Property, n.Error)));

--- a/query-tool/src/Piipan.QueryTool.Client/Models/DispositionModel.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Models/DispositionModel.cs
@@ -10,14 +10,28 @@ namespace Piipan.QueryTool.Client.Models
     {
         [Display(Name = "Initial Action Date")]
         [JsonProperty("initial_action_at")]
-        [UsaRequiredIf(nameof(InitialActionTaken), ErrorMessage = "@@@ is required")]
+        [UsaRequiredIf(
+            nameof(FinalDisposition), "", "@@@ is required because a Final Disposition has been selected",
+            nameof(InitialActionTaken), "", "@@@ is required"
+        )]
         public DateTime? InitialActionAt { get; set; }
 
-
+        private string _initialActionTaken;
         [Display(Name = "Initial Action Taken")]
         [JsonProperty("initial_action_taken")]
-        [UsaRequiredIf(nameof(InitialActionAt), ErrorMessage = "@@@ is required because a date has been selected")]
-        public string InitialActionTaken { get; set; }
+        [UsaRequiredIf(
+            nameof(FinalDisposition), "", "@@@ is required because a Final Disposition has been selected",
+            nameof(InitialActionAt), "", "@@@ is required because a date has been selected"
+        )]
+        public string InitialActionTaken
+        {
+            get => _initialActionTaken;
+            set
+            {
+                _initialActionTaken = value;
+                InitialActionChanged?.Invoke();
+            }
+        }
 
         private bool? _invalidMatch = null;
         [JsonProperty("invalid_match")]
@@ -32,6 +46,7 @@ namespace Piipan.QueryTool.Client.Models
         }
 
         public Action InvalidMatchChanged { get; set; }
+        public Action InitialActionChanged { get; set; }
 
         [Display(Name = "Invalid Match Reason")]
         [JsonProperty("invalid_match_reason")]
@@ -39,16 +54,27 @@ namespace Piipan.QueryTool.Client.Models
         [Display(Name = "Reason for Other")]
         [JsonProperty("other_reasoning_for_invalid_match")]
         public string? OtherReasoningForInvalidMatch { get; set; }
+
         [JsonProperty("final_disposition")]
         [Display(Name = "Final Disposition Taken")]
+        [UsaRequiredIf(nameof(FinalDispositionDate), "", "@@@ is required because a date has been selected")]
         public string FinalDisposition { get; set; }
+
         [Display(Name = "Final Disposition Date")]
         [JsonProperty("final_disposition_date")]
+        [UsaRequiredIf(nameof(FinalDisposition), "", "@@@ is required")]
+        // If the Match Date is not set this won't validate. We set it in MatchDetail.razor.
+        // So this is client-side validation ONLY. Server-side validation will also occur in
+        // AddEventApi's AddEvent method.
+        [UsaMinimumDate(nameof(MatchDate), ErrorMessage = "@@@ cannot be before the match date of {0}")]
         public DateTime? FinalDispositionDate { get; set; }
+
         [JsonProperty("vulnerable_individual")]
         public bool? VulnerableIndividual { get; set; }
         [JsonProperty("state")]
         public string State { get; set; }
+
+        public DateTime? MatchDate { get; set; }
 
         public DispositionModel() { }
         public DispositionModel(Disposition disposition)

--- a/query-tool/src/Piipan.QueryTool.Client/Models/MatchDetailSaveResponseData.cs
+++ b/query-tool/src/Piipan.QueryTool.Client/Models/MatchDetailSaveResponseData.cs
@@ -3,5 +3,8 @@
     public class MatchDetailSaveResponseData
     {
         public bool? SaveSuccess { get; set; }
+
+        // The values you were attempting to save when a save fails
+        public DispositionModel FailedDispositionModel { get; set; }
     }
 }

--- a/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
+++ b/query-tool/src/Piipan.QueryTool/Pages/Match.cshtml.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Piipan.Match.Api;
 using Piipan.Match.Api.Models;
 using Piipan.Match.Api.Models.Resolution;
 using Piipan.QueryTool.Client.Models;
+using Piipan.Shared.Helpers;
 using Piipan.Shared.Http;
 using Piipan.Shared.Roles;
 
@@ -175,8 +175,8 @@ namespace Piipan.QueryTool.Pages
                             }
                             else
                             {
-                                ApiErrorResponse apiErrorResponse = JsonConvert.DeserializeObject<ApiErrorResponse>(failResponse);
-                                if (apiErrorResponse.Errors?.Count > 0)
+                                ApiErrorResponse apiErrorResponse = JsonHelper.TryParse<ApiErrorResponse>(failResponse);
+                                if (apiErrorResponse?.Errors?.Count > 0)
                                 {
                                     foreach (var error in apiErrorResponse.Errors)
                                     {

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/FinalDispositionTests.razor
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/FinalDispositionTests.razor
@@ -73,7 +73,7 @@
             </div>
             <div diff:ignore> //Ignoring Initial Action Component
             </div>
-            <div class="FinalDispositionDiv" >
+            <div id="final-disposition-section" class="FinalDispositionDiv" >
               <h5 class="FinalDispositionHeader" >Final Disposition</h5>
               <p class="FinalDispositionText" >Final Disposition information can be added once the initial Action has been selected.</p>
               <div class="ResolutionFieldsDropdownWidth" >
@@ -112,7 +112,7 @@
         </div>
         <div diff:ignore> //Ignoring Initial Action Component
         </div>
-        <div class="FinalDispositionDiv" >
+        <div id="final-disposition-section" class="FinalDispositionDiv" >
             <h5 class="FinalDispositionHeader" >Final Disposition</h5>
             <p class="FinalDispositionText" >Final Disposition information can be added once the initial Action has been selected.</p>
             <div class="ResolutionFieldsDropdownWidth" >

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/FinalDispositionTests.razor
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/FinalDispositionTests.razor
@@ -1,4 +1,5 @@
-﻿@using Piipan.Match.Api.Models.Resolution
+﻿@using Piipan.Components.Forms
+@using Piipan.Match.Api.Models.Resolution
 @using Piipan.QueryTool.Client.Components.MatchDetail
 @using Piipan.QueryTool.Client.Models
 @inherits BaseComponentTest<ResolutionFields>
@@ -14,7 +15,7 @@
             DispositionData = new DispositionModel
             {
                 InitialActionAt = null,
-                InitialActionTaken = "",
+                InitialActionTaken = "Notice Sent",
                 InvalidMatch = false,
                 InvalidMatchReason = "",
                 OtherReasoningForInvalidMatch = "",
@@ -27,7 +28,8 @@
             InitiatingState = true
         };
     }
-
+    private IRenderedComponent<FinalDisposition> finalDispositionComponent;
+    private IRenderedComponent<UsaForm> usaForm;
 
     /// <summary>
     /// Create a StateParticipantInformation component
@@ -39,12 +41,14 @@
             JSInterop.SetupVoid("piipan.utilities.setCursorPosition", _ => true).SetVoidResult();
             JSInterop.SetupVoid("piipan.utilities.scrollToElement", _ => true).SetVoidResult();
         
-        Component = Render<ResolutionFields>(
+        usaForm = Render<UsaForm>(
             @<Piipan.Components.Forms.UsaForm Model="InitialValues.DispositionData">
                 <ResolutionFields State="@InitialValues.State" InitiatingState="InitialValues.InitiatingState" DispositionData="@InitialValues.DispositionData">
                 </ResolutionFields>
             </Piipan.Components.Forms.UsaForm>
         );
+        Component = usaForm.FindComponent<ResolutionFields>();
+        finalDispositionComponent = Component.FindComponent<FinalDisposition>();
     }
 
     #region Tests
@@ -122,8 +126,144 @@
                 </div>
             </div>
         </div>
-    </text>
-        );
+        </text>
+    );
+    }
+
+    /// <summary>
+    /// Verify the action date gets correctly defaulted when it's supposed to be
+    /// </summary>
+    [Theory]
+    [InlineData("Benefits Unchanged", true)]
+    [InlineData("Benefits Denied", true)]
+    [InlineData("Benefits Approved", false)]
+    [InlineData("Benefits Terminated", false)]
+    public void FinalDispositionDate_DefaultedWhen_FinalDispositionSet_AndDateIsNull(string finalDispositionValue, bool shouldDefault)
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Assert
+        Assert.Null(finalDispositionComponent.Instance.DispositionData.FinalDispositionDate);
+
+        // Act
+        Component.Find("[name=\"DispositionData.FinalDisposition\"]").Change(finalDispositionValue);
+
+        // Assert
+        if (shouldDefault)
+        {
+            Assert.Equal(DateTime.Now.Date, finalDispositionComponent.Instance.DispositionData.FinalDispositionDate);
+        }
+        else
+        {
+            Assert.Null(finalDispositionComponent.Instance.DispositionData.FinalDispositionDate);
+        }
+    }
+
+    /// <summary>
+    /// Verify the action date gets correctly defaulted when it's supposed to be
+    /// </summary>
+    [Theory]
+    [InlineData("Benefits Unchanged")]
+    [InlineData("Benefits Denied")]
+    [InlineData("Benefits Approved")]
+    [InlineData("Benefits Terminated")]
+    public void FinalDispositionDate_NotDefaultedWhen_FinalDispositionSet_AndDateIsNotNull(string finalDispositionValue)
+    {
+        // Arrange
+        InitialValues.DispositionData.FinalDispositionDate = DateTime.Now.AddDays(-1).Date;
+        CreateTestComponent();
+
+        // Assert
+        Assert.Equal(DateTime.Now.AddDays(-1).Date, finalDispositionComponent.Instance.DispositionData.FinalDispositionDate);
+
+        // Act
+        Component.Find("[name=\"DispositionData.FinalDisposition\"]").Change(finalDispositionValue);
+
+        // Assert
+        Assert.Equal(DateTime.Now.AddDays(-1).Date, finalDispositionComponent.Instance.DispositionData.FinalDispositionDate);
+    }
+
+    /// <summary>
+    /// Verify an error is shown when the date is set and the action is not
+    /// </summary>
+    [Fact]
+    public void FinalDispositionDate_HiddenWhen_FinalDispositionIsNull()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Assert
+        Assert.Empty(Component.FindAll("[name=\"DispositionData.FinalDispositionDate\"]"));
+
+        // Act
+        Component.Find("[name=\"DispositionData.FinalDisposition\"]").Change("Benefits Terminated");
+
+        // Assert
+        Assert.NotEmpty(Component.FindAll("[name=\"DispositionData.FinalDispositionDate\"]"));
+
+        // Act - Change Final Disposition Back to empty
+        Component.Find("[name=\"DispositionData.FinalDisposition\"]").Change("");
+
+        // Assert
+        Assert.Empty(Component.FindAll("[name=\"DispositionData.FinalDispositionDate\"]"));
+    }
+
+    /// <summary>
+    /// Verify the initial action section is disabed when invalid match is true
+    /// but initial action date was previously set, and then it is cleared
+    /// </summary>
+    [Fact]
+    public void FinalDispositionDisabled_WhenInitialActionNotSet()
+    {
+        // Arrange
+        InitialValues.DispositionData.InitialActionTaken = "";
+        CreateTestComponent();
+
+        // Assert
+        VerifyDisabledFinalDispositionSection();
+    }
+
+    /// <summary>
+    /// Verify the initial action section is disabed when invalid match is true
+    /// but initial action date was previously set, and then it is cleared
+    /// </summary>
+    [Fact]
+    public void FinalDispositionEnabled_WhenInitialActionSet()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Assert
+        VerifyEnabledFinalDispositionSection();
+    }
+
+    private void VerifyDisabledFinalDispositionSection()
+    {
+        var initialActionSection = Component.Find("#final-disposition-section");
+
+        // Assert
+        Assert.True(initialActionSection.ClassList.Contains("disabled-area"));
+        var inputs = initialActionSection.QuerySelectorAll("select");
+        Assert.Equal(1, inputs.Count());
+        foreach (var input in inputs)
+        {
+            Assert.True(input.HasAttribute("disabled"));
+        }
+    }
+
+    private void VerifyEnabledFinalDispositionSection()
+    {
+        var initialActionSection = Component.Find("#final-disposition-section");
+
+        // Assert
+        Assert.False(initialActionSection.ClassList.Contains("disabled-area"));
+        var inputs = initialActionSection.QuerySelectorAll("select");
+        Assert.Equal(1, inputs.Count());
+        foreach (var input in inputs)
+        {
+            Assert.False(input.HasAttribute("disabled"));
+        }
     }
     #endregion
 }

--- a/shared/src/Piipan.Shared/Helpers/JsonHelper.cs
+++ b/shared/src/Piipan.Shared/Helpers/JsonHelper.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using Newtonsoft.Json.Schema.Generation;
+
+namespace Piipan.Shared.Helpers
+{
+    public static class JsonHelper
+    {
+        public static T TryParse<T>(string jsonData) where T : new()
+        {
+            JSchemaGenerator generator = new JSchemaGenerator();
+            JSchema parsedSchema = generator.Generate(typeof(T));
+            JObject jObject = JObject.Parse(jsonData);
+
+            return jObject.IsValid(parsedSchema) ?
+                JsonConvert.DeserializeObject<T>(jsonData) : default(T);
+        }
+    }
+}

--- a/shared/src/Piipan.Shared/Http/IAuthorizedApiClient.cs
+++ b/shared/src/Piipan.Shared/Http/IAuthorizedApiClient.cs
@@ -27,7 +27,7 @@ namespace Piipan.Shared.Http
         /// <param name="path">path portion of the API endpoint</param>
         /// <param name="body">object to be sent as request body</param>
         /// <param name="headerFactory">callback which supplies additional headers to be included in the outbound request</param>
-        Task<TResponse> PatchAsync<TRequest, TResponse>(string path, TRequest body, Func<IEnumerable<(string, string)>> headerFactory);
+        Task<(TResponse SuccessResponse, string FailResponse)> PatchAsync<TRequest, TResponse>(string path, TRequest body, Func<IEnumerable<(string, string)>> headerFactory);
 
         /// <summary>
         /// Send an asynchronous GET request to an API endpoint

--- a/shared/tests/Piipan.Shared.Tests/Helpers/JsonHelperTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Helpers/JsonHelperTests.cs
@@ -1,0 +1,39 @@
+﻿using Piipan.Shared.Helpers;
+using Xunit;
+
+namespace Piipan.Shared.Tests.Helpers
+{
+    public class JsonHelperTests
+    {
+        class DummyClass
+        {
+            public string Prop1 { get; set; }
+        }
+
+        [Fact]
+        public void TryParse_ReturnsObject_WhenValidJson()
+        {
+            // Arrange
+            string jsonToVerify = "{ \"Prop1\": \"test\" }";
+
+            // Act
+            var dummyValue = JsonHelper.TryParse<DummyClass>(jsonToVerify);
+
+            // Assert
+            Assert.Equal("test", dummyValue.Prop1);
+        }
+
+        [Fact]
+        public void TryParse_ReturnsDefaultObject_WhenInvalidJson()
+        {
+            // Arrange
+            string jsonToVerify = "{ \"InvalidProp\": \"test\" }";
+
+            // Act
+            var dummyValue = JsonHelper.TryParse<DummyClass>(jsonToVerify);
+
+            // Assert
+            Assert.Null(dummyValue);
+        }
+    }
+}

--- a/shared/tests/Piipan.Shared.Tests/Http/AuthorizedJsonApiClientTests.cs
+++ b/shared/tests/Piipan.Shared.Tests/Http/AuthorizedJsonApiClientTests.cs
@@ -2,14 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Piipan.Shared.Authentication;
-using Piipan.Shared.Http;
 using Moq;
 using Moq.Protected;
+using Piipan.Shared.Authentication;
+using Piipan.Shared.Http;
 using Xunit;
-using System.Text.Json;
 
 namespace Piipan.Shared.Tests.Http
 {
@@ -36,8 +36,8 @@ namespace Piipan.Shared.Tests.Http
             var httpMessageHandler = new Mock<HttpMessageHandler>();
             httpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
-                    "SendAsync", 
-                    ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri.ToString() == "https://tts.test/path"), 
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri.ToString() == "https://tts.test/path"),
                     ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(httpResponse);
 
@@ -50,7 +50,7 @@ namespace Piipan.Shared.Tests.Http
             clientFactory
                 .Setup(m => m.CreateClient(typeof(AuthorizedJsonApiClientTests).Name))
                 .Returns(client);
-            
+
             var tokenProvider = new Mock<ITokenProvider<AuthorizedJsonApiClientTests>>();
             var apiClient = new AuthorizedJsonApiClient<AuthorizedJsonApiClientTests>(
                 clientFactory.Object,
@@ -61,7 +61,7 @@ namespace Piipan.Shared.Tests.Http
             {
                 RequestMessage = "this is a request message"
             };
-            
+
             // Act
             var response = await apiClient.PostAsync<FakeRequestType, FakeResponseType>("/path", body);
 
@@ -81,9 +81,9 @@ namespace Piipan.Shared.Tests.Http
             var httpMessageHandler = new Mock<HttpMessageHandler>();
             httpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
-                    "SendAsync", 
-                    ItExpr.Is<HttpRequestMessage>(m => 
-                        m.Method == HttpMethod.Post && 
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m =>
+                        m.Method == HttpMethod.Post &&
                         m.RequestUri.ToString() == "https://tts.test/path" &&
                         m.Headers.Contains("added-header")),
                     ItExpr.IsAny<CancellationToken>())
@@ -98,7 +98,7 @@ namespace Piipan.Shared.Tests.Http
             clientFactory
                 .Setup(m => m.CreateClient(typeof(AuthorizedJsonApiClientTests).Name))
                 .Returns(client);
-            
+
             var tokenProvider = new Mock<ITokenProvider<AuthorizedJsonApiClientTests>>();
             var apiClient = new AuthorizedJsonApiClient<AuthorizedJsonApiClientTests>(
                 clientFactory.Object,
@@ -109,7 +109,7 @@ namespace Piipan.Shared.Tests.Http
             {
                 RequestMessage = "this is a request message"
             };
-            
+
             // Act
             var response = await apiClient.PostAsync<FakeRequestType, FakeResponseType>("/path", body, () =>
             {
@@ -174,8 +174,8 @@ namespace Piipan.Shared.Tests.Http
             });
 
             // Assert
-            Assert.IsType<FakeResponseType>(response);
-            Assert.Equal("this is a response message", response.ResponseMessage);
+            Assert.IsType<(FakeResponseType, string)>(response);
+            Assert.Equal("this is a response message", response.SuccessResponse.ResponseMessage);
         }
 
         [Fact]
@@ -190,8 +190,8 @@ namespace Piipan.Shared.Tests.Http
             var httpMessageHandler = new Mock<HttpMessageHandler>();
             httpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
-                    "SendAsync", 
-                    ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Get && m.RequestUri.ToString() == "https://tts.test/path"), 
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Get && m.RequestUri.ToString() == "https://tts.test/path"),
                     ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(httpResponse);
 
@@ -204,13 +204,13 @@ namespace Piipan.Shared.Tests.Http
             clientFactory
                 .Setup(m => m.CreateClient(typeof(AuthorizedJsonApiClientTests).Name))
                 .Returns(client);
-            
+
             var tokenProvider = new Mock<ITokenProvider<AuthorizedJsonApiClientTests>>();
             var apiClient = new AuthorizedJsonApiClient<AuthorizedJsonApiClientTests>(
                 clientFactory.Object,
                 tokenProvider.Object
             );
-            
+
             // Act
             var response = await apiClient.GetAsync<FakeResponseType>("/path");
 


### PR DESCRIPTION
## What’s changing?

Added the following checks client side and in the API
- Initial Action Taken cannot be null when Final Disposition is filled out
- Initial Action Date cannot be null when Final Disposition is filled out
- Final Disposition Date is required when Final Disposition is filled out
- Final Disposition is required when Final Disposition Date is filled out
- Final Disposition Date cannot be less than the match date

In addition, the following functionality was added:

- When Initial Action Taken isn't filled out, the Final Disposition area is disabled
- If Initial Action Taken is filled out, and Final Disposition is filled out, and then Initial Action Taken is cleared, Final Disposition will not be disabled. Instead an error will be thrown (see first two bullets above)
- Updated the PatchAsync response to not simply return a generic error. It will display the error returned from the API in a JSON failed response object. Then it's up to the client application to decide what to do with it. In our case, we add it to the server errors on top of the Match Detail page.
- If server-side errors do happen, we no longer throw away the values we tried submitting. We put them back in the form (but not on the right side)
- Default the Final Disposition Date when "Benefits Unchanged" or "Benefits Denied" was selected.

TL;DR
Final Disposition dropdown and date error validation, and disabling the section when Initial Action isn't yet filled in.

## Why?

Closes NAC-74 & NAC-592

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
