### PR TITLE
Update CHANGELOG using consistent versioning for 1.1.1.x releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project **does not** adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0.44] - 2022-07-12
+## [1.1.1.44] - 2022-07-12
 
 ### Changed
 - Made Participant Id a required field for Duplicate Participation API search requests
@@ -23,10 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Pulled State Metadata SQL data insertion out of Match specific SQL file
 - Replaced placeholder email addresses with safe-to-use top level testing domain 
 
-## [1.1.0.43] - 2022-06-28
+## [1.1.1.43] - 2022-06-28
 
 ### Changed
-- Added support for capturing participant upload status and start/completion timestamps in the Metrics database
+- Added support for capturing participant upload status and start/completion timestamps in the Metrics database (retroactively included in v1.1.1)
 
 ### Added
 - State API internal documentation
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Moved Match Resolution documenation out of Duplicate Participation API documentation to internal Match Resolution API documentation.
 - Cypress tests failures caused by States API
 
-## [1.1.0.42] - 2022-06-15
+## [1.1.1.42] - 2022-06-15
 
 ### Changed
 - Improved documentation for Duplicate Participation API
@@ -48,10 +48,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated IAC scripts to support Azure US Gov & Azure CLI 2.37
 
 ### Added
-- Added column encryption support for sensitive PII values in Postgres
+- Added column encryption support for sensitive PII values in Postgres (retroactively included in v1.1.1)
 - Added internal support and API for State Metadata
 - Added basic email notification support/infrastructure
 - Added match status, disposition information, state contact information, and participant information to the Match Details page
+
+## [1.1.1] - 2022-06-30
+
+### Changed
+- Added support for capturing participant upload status and start/completion timestamps in the Metrics database.
+
+### Added
+- Added AES encryption for columns containing sensitive PII values in Postgres
 
 ## [1.1.0] - 2022-05-31
 
@@ -421,6 +429,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Initial APIs for use by group 1A state integrators.
 
+[1.1.1.44]: https://github.com/18F/piipan/releases/tag/v1.1.1.44
+[1.1.1.43]: https://github.com/18F/piipan/releases/tag/v1.1.1.43
+[1.1.1.42]: https://github.com/18F/piipan/releases/tag/v1.1.0.42
+[1.1.1]: https://github.com/18F/piipan/releases/tag/v1.1.1
+[1.1.0]: https://github.com/18F/piipan/releases/tag/v1.1.0
+[1.0.1.40]: https://github.com/18F/piipan/releases/tag/v1.0.1.40
+[1.0.1.39]: https://github.com/18F/piipan/releases/tag/v1.0.1.39
+[1.0.1.38]: https://github.com/18F/piipan/releases/tag/v1.0.1.38
+[1.0.1.37]: https://github.com/18F/piipan/releases/tag/v1.0.1.37
+[1.0.1.36]: https://github.com/18F/piipan/releases/tag/v1.0.1.36
+[1.0.1]: https://github.com/18F/piipan/releases/tag/v1.0.1
+[1.0.0.34]: https://github.com/18F/piipan/releases/tag/v1.0.0.34
 [1.0.0.33]: https://github.com/18F/piipan/releases/tag/v1.0.0.33
 [1.0]: https://github.com/18F/piipan/releases/tag/v1.0
 [0.97]: https://github.com/18F/piipan/releases/tag/v0.97


### PR DESCRIPTION
## What’s changing?

- Add 1.1.1 note back in (was clobbered by retroactive reverts and merges)
- Update subsequent releases to use 1.1.1.x versioning
- Add links for past several releases that did not have them

## Why?

CHANGELOG got out of whack during all the work for merging v1.1.1 and subsequent releases. Closes NAC-1049.

## This PR has:

- [ ] ~**Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~
- [x] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)
- [ ] ~**Automated unit tests** (_to maintain or increase level of code coverage_)~
- [ ] ~**Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~

## Anything else?
