### PR TITLE
Adding tooltip component and adding it to Match Details

### DIFF
--- a/components/src/Piipan.Components.Demo/Components/TooltipComponent.razor
+++ b/components/src/Piipan.Components.Demo/Components/TooltipComponent.razor
@@ -1,0 +1,6 @@
+﻿@using Piipan.Components.Tooltips
+@code {
+    [Parameter] public string TooltipText { get; set; }
+}
+
+<UsaTooltip TooltipText="@TooltipText">Hover or Focus On Me</UsaTooltip>

--- a/components/src/Piipan.Components.Demo/Pages/Index.razor
+++ b/components/src/Piipan.Components.Demo/Pages/Index.razor
@@ -1,6 +1,7 @@
 ﻿@page "/"
 @using System.ComponentModel.DataAnnotations
 @using Piipan.Components.Alerts
+@using Piipan.Components.Tooltips
 @using Piipan.Components.Validation
 @using Piipan.Components.Tag
 @using static Piipan.Components.Layout.LayoutConstants
@@ -113,6 +114,13 @@
                 <UsaTag>Some Tag</UsaTag>
             </BodyContent>
             <FooterContent><button type="button" @onclick="@(() => navManager.NavigateTo("/tag"))" class="@ButtonClass">View Tag</button></FooterContent>
+        </UsaCard>
+        <UsaCard Header="Tooltip">
+            <BodyContent>
+                <p>A tooltip is a short descriptive message that appears when a user hovers or focuses on an element.</p>
+                <UsaTooltip TooltipText="Some Tooltip Text">Some Tooltip</UsaTooltip>
+            </BodyContent>
+            <FooterContent><button type="button" @onclick="@(() => navManager.NavigateTo("/tooltip"))" class="@ButtonClass">View Tooltip</button></FooterContent>
         </UsaCard>
     </UsaCardGroup>
 </UsaForm>

--- a/components/src/Piipan.Components.Demo/Pages/Tooltip.razor
+++ b/components/src/Piipan.Components.Demo/Pages/Tooltip.razor
@@ -1,0 +1,25 @@
+﻿@page "/tooltip"
+@inherits BaseComponent
+@code {
+    protected override string[] Files { get; set; } = { "components/TooltipComponent.razor" };
+
+    private string TooltipText { get; set; } = "Some Text";
+}
+
+<h1>Tooltip</h1>
+
+<UsaAccordion Multiselectable="true">
+    <UsaAccordionItem StartsExpanded="true">
+        <HeadingContent>Component Demo</HeadingContent>
+        <BodyContent>
+            <UsaForm Model="TooltipText">
+                <UsaFormGroup>
+                    <UsaInputText @bind-Value="TooltipText" />
+                </UsaFormGroup>
+            </UsaForm>
+            <div style="margin-top: 20px"></div>
+            <TooltipComponent TooltipText="@TooltipText" />
+        </BodyContent>
+    </UsaAccordionItem>
+    <CodeArea FileContents="fileContents" />
+</UsaAccordion>

--- a/components/src/Piipan.Components.Demo/Shared/NavMenu.razor
+++ b/components/src/Piipan.Components.Demo/Shared/NavMenu.razor
@@ -12,6 +12,7 @@
             <li><NavLink href="/input-text-area/">Input Text Area</NavLink></li>
             <li><NavLink href="/modal/">Modal</NavLink></li>
             <li><NavLink href="/tag/">Tag</NavLink></li>
+            <li><NavLink href="/tooltip/">Tooltip</NavLink></li>
         </ul>
     </nav>
 </div>

--- a/components/src/Piipan.Components.Demo/wwwroot/components/TooltipComponent.txt
+++ b/components/src/Piipan.Components.Demo/wwwroot/components/TooltipComponent.txt
@@ -1,0 +1,6 @@
+﻿@using Piipan.Components.Tooltips
+@code {
+    [Parameter] public string TooltipText { get; set; }
+}
+
+<UsaTooltip TooltipText="@TooltipText">Hover or Focus On Me</UsaTooltip>

--- a/components/src/Piipan.Components/Piipan.Components.csproj
+++ b/components/src/Piipan.Components/Piipan.Components.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <None Include="Alerts\UsaAlertBox.razor" />
     <None Include="Tag\UsaTag.razor" />
+    <None Include="Tooltips\UsaTooltip.razor" />
   </ItemGroup>
 
 

--- a/components/src/Piipan.Components/Tooltips/UsaTooltip.razor
+++ b/components/src/Piipan.Components/Tooltips/UsaTooltip.razor
@@ -1,0 +1,61 @@
+﻿@inject IJSRuntime JSRuntime
+@code {
+    [Parameter] public string TooltipText { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; set; }
+
+    public record TooltipDisplayAttributes
+    {
+        public bool Flip { get; set; }
+        public decimal XPercent { get; set; }
+        public bool Processed { get; set; }
+    }
+
+    private bool didHover = false;
+    private bool didFocus = false;
+    private ElementReference TooltipElement;
+    TooltipDisplayAttributes latestDisplayAttributes = new();
+    public void ShowTooltip()
+    {
+        latestDisplayAttributes = new();
+    }
+
+    IJSObjectReference javascriptReference;
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (javascriptReference == null)
+        {
+            javascriptReference = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Piipan.Components/Tooltips/UsaTooltip.razor.js");    
+        }
+        if ((didHover || didFocus) && !latestDisplayAttributes.Processed)
+        {
+            latestDisplayAttributes = await javascriptReference.InvokeAsync<TooltipDisplayAttributes>("ShowTooltip", TooltipElement) ?? new();
+            latestDisplayAttributes.Processed = true;
+            Console.WriteLine(latestDisplayAttributes);
+            StateHasChanged();
+        }
+    }
+    private void KeyPressed(KeyboardEventArgs keyArgs)
+    {
+        if (keyArgs.Key == "Escape")
+        {
+            didHover = false;
+            didFocus = false;
+        }
+    }
+}
+
+<span class="usa-tooltip">
+    <button tabindex="0" @onkeydown=KeyPressed @onfocus="@(() => { didFocus = !didHover; ShowTooltip(); })"
+        @onmouseover=@(() => { didHover = !didFocus; ShowTooltip(); })
+        @onmouseout=@(() => didHover = false)
+        @onblur="@(() => didFocus = false)"
+        type="button" class="usa-tooltip__trigger usa-button usa-button--unstyled" style="margin-top: 0;" data-position="top" aria-describedby="tooltip-@TooltipElement.Id">@ChildContent</button>
+    <span id="tooltip-@TooltipElement.Id" 
+        @ref="TooltipElement" 
+        class="usa-tooltip__body usa-tooltip__body--@(latestDisplayAttributes.Flip ? "bottom" : "top") @(didHover || didFocus ? "is-set is-visible" : "")" 
+        role="tooltip" 
+        aria-hidden="@(didHover || didFocus ? "false" : "true")"
+        style="--translateXPercent: @(latestDisplayAttributes.XPercent * 100)%"
+    >@TooltipText</span>
+</span>

--- a/components/src/Piipan.Components/Tooltips/UsaTooltip.razor.css
+++ b/components/src/Piipan.Components/Tooltips/UsaTooltip.razor.css
@@ -1,0 +1,33 @@
+﻿.usa-tooltip__body {
+    max-width: 526px;
+    width: max-content;
+    font-weight: normal;
+    white-space: unset;
+    --translateXPercent: 0;
+    transform: translateX(calc(-1 * var(--translateXPercent)));
+}
+
+@media (max-width: 657px) {
+    .usa-tooltip__body {
+        max-width: 80vw;
+    }
+}
+
+.usa-tooltip__body.usa-tooltip__body--top {
+    bottom: calc(100% + 10px);
+}
+
+.usa-tooltip__body:after {
+    left: calc(var(--translateXPercent) + 9px);
+}
+.usa-tooltip__body--top:after {
+    bottom: -5px;
+}
+
+.usa-tooltip__body.usa-tooltip__body--bottom {
+    top: calc(100% + 10px);
+}
+
+.usa-tooltip__body--bottom:after {
+    top: -5px;
+}

--- a/components/src/Piipan.Components/Tooltips/UsaTooltip.razor.js
+++ b/components/src/Piipan.Components/Tooltips/UsaTooltip.razor.js
@@ -1,0 +1,13 @@
+﻿// Sets the main page to inert, meaning focus cannot go inside it. Only the last modal can have focus go inside it.
+// Also, we add an escape button listener to the ModalContainer, which closes the last opened modal.
+export function ShowTooltip(tooltipElement) {
+    const rect = tooltipElement.getBoundingClientRect();
+    let triggerXPercent = 0;
+    if (rect.x < 0 || (rect.x + rect.width > window.innerWidth)) {
+        const triggerElement = tooltipElement.closest('.usa-tooltip').querySelector('.usa-tooltip__trigger').getBoundingClientRect();
+        const triggerElementXPos = (triggerElement.x + (triggerElement.width / 2));
+        triggerXPercent = triggerElementXPos / window.innerWidth;
+    }
+    
+    return { Flip: rect.y < 0, XPercent: triggerXPercent };
+}

--- a/components/tests/Piipan.Components.Tests/Tooltips/UsaTooltipTests.razor
+++ b/components/tests/Piipan.Components.Tests/Tooltips/UsaTooltipTests.razor
@@ -1,0 +1,248 @@
+﻿@using Microsoft.JSInterop
+@using Piipan.Components.Tooltips
+@using static Piipan.Components.Tooltips.UsaTooltip
+@inherits BaseTest<UsaTooltip>
+@code {
+    #region Tests
+
+    BunitJSModuleInterop moduleInterop;
+    private const string JSFileRelativePath = "/Tooltips/UsaTooltip.razor.js";
+    IElement tooltipTrigger;
+    IElement tooltipBody;
+
+
+    /// <summary>
+    /// Set the default initial values for this test component
+    /// </summary>
+    public UsaTooltipTests() : base()
+    {
+        InitialValues = new UsaTooltip()
+        {
+            TooltipText = "This is a test tooltip",
+            ChildContent = @<p>Tooltip Hit Area</p>
+        };
+        moduleInterop = this.JSInterop.SetupModule($"./_content/Piipan.Components{JSFileRelativePath}");
+    }
+
+    /// <summary>
+    /// Verify the default markup of a tooltip
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Exist_And_Have_Correct_Markup()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Assert
+        Component!.MarkupMatches(
+            @<span class="usa-tooltip" >
+              <button tabindex="0"      type="button" class="usa-tooltip__trigger usa-button usa-button--unstyled" style="margin-top: 0;" data-position="top" aria-describedby="tooltip-" >
+                <p>Tooltip Hit Area</p>
+              </button>
+              <span id="tooltip-" class="usa-tooltip__body usa-tooltip__body--top " role="tooltip" aria-hidden="true" style="--translateXPercent: 0%"  >This is a test tooltip</span>
+        </span>
+    );
+    }
+
+    /// <summary>
+    /// Verify the tooltip should be visible when the trigger is hovered
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Be_Visible_When_Hovered()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Act
+        tooltipTrigger.MouseOver();
+
+        // Assert
+        Assert.True(tooltipBody.ClassList.Contains("is-set"));
+        Assert.True(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("false", tooltipBody.GetAttribute("aria-hidden"));
+
+        // Act
+        tooltipTrigger.MouseOut();
+
+        // Assert
+        Assert.False(tooltipBody.ClassList.Contains("is-set"));
+        Assert.False(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("true", tooltipBody.GetAttribute("aria-hidden"));
+    }
+
+    /// <summary>
+    /// Verify the tooltip should be visible when the trigger is focused
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Be_Visible_When_Focused()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Act
+        tooltipTrigger.Focus();
+
+        // Assert
+        Assert.True(tooltipBody.ClassList.Contains("is-set"));
+        Assert.True(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("false", tooltipBody.GetAttribute("aria-hidden"));
+
+        // Act
+        tooltipTrigger.Blur();
+
+        // Assert
+        Assert.False(tooltipBody.ClassList.Contains("is-set"));
+        Assert.False(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("true", tooltipBody.GetAttribute("aria-hidden"));
+    }
+
+    /// <summary>
+    /// Verify the tooltip should be visible when the trigger is focused. If the user then goes in and hovers, the tooltip won't close until the field loses focus
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Be_Only_Close_When_Blurred_When_Initially_Focused()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Act
+        tooltipTrigger.Focus();
+        tooltipTrigger.MouseOver();
+        tooltipTrigger.MouseOut();
+
+        // Assert still visible. When focused, hovering and de-hovering should not hide tooltip
+        Assert.True(tooltipBody.ClassList.Contains("is-set"));
+        Assert.True(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("false", tooltipBody.GetAttribute("aria-hidden"));
+
+        // Act
+        tooltipTrigger.Blur();
+
+        // Assert
+        Assert.False(tooltipBody.ClassList.Contains("is-set"));
+        Assert.False(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("true", tooltipBody.GetAttribute("aria-hidden"));
+    }
+
+    /// <summary>
+    /// Verify the tooltip should be visible when the trigger is hovered. If the user then goes in and focuses on the trigger, the tooltip won't close until the field loses hover
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Be_Only_Close_When_MouseOut_When_Initially_Hovered()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Act
+        tooltipTrigger.MouseOver();
+        tooltipTrigger.Focus();
+        tooltipTrigger.Blur();
+
+        // Assert still visible. When hovering, focusing/blurring should not change the tooltip
+        Assert.True(tooltipBody.ClassList.Contains("is-set"));
+        Assert.True(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("false", tooltipBody.GetAttribute("aria-hidden"));
+
+        // Act
+        tooltipTrigger.MouseOut();
+
+        // Assert
+        Assert.False(tooltipBody.ClassList.Contains("is-set"));
+        Assert.False(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("true", tooltipBody.GetAttribute("aria-hidden"));
+    }
+
+    /// <summary>
+    /// Verify the tooltip should close down when the escape key is pressed if it was initially focused
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Close_On_Focus_And_EscapeKey()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Act
+        tooltipTrigger.Focus();
+        tooltipTrigger.KeyDown("Escape");
+
+        // Assert
+        Assert.False(tooltipBody.ClassList.Contains("is-set"));
+        Assert.False(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("true", tooltipBody.GetAttribute("aria-hidden"));
+    }
+
+    /// <summary>
+    /// Verify the tooltip should close down when the escape key is pressed if it was initially hovered but subsequently focused
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Close_On_Hover_Then_Focus_And_EscapeKey()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Act
+        tooltipTrigger.MouseOver();
+        tooltipTrigger.Focus();
+        tooltipTrigger.KeyDown("Escape");
+
+        // Assert
+        Assert.False(tooltipBody.ClassList.Contains("is-set"));
+        Assert.False(tooltipBody.ClassList.Contains("is-visible"));
+        Assert.Equal("true", tooltipBody.GetAttribute("aria-hidden"));
+    }
+
+    /// <summary>
+    /// Verify the tooltip should appear under the element when the javascript returns that it's partially above the screen
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Display_Upside_Down_On_Vertical_Overflow()
+    {
+        // Arrange
+        CreateTestComponent();
+        moduleInterop.Setup<TooltipDisplayAttributes>("ShowTooltip", _ => true).SetResult(new TooltipDisplayAttributes() { Flip = true });
+
+        // Act
+        tooltipTrigger.MouseOver();
+
+        // Assert
+        Assert.False(tooltipBody.ClassList.Contains("usa-tooltip__body--top"));
+        Assert.True(tooltipBody.ClassList.Contains("usa-tooltip__body--bottom"));
+    }
+
+    /// <summary>
+    /// Verify the tooltip should appear translated left when the javascript returns that it's partially off the right side of the screen
+    /// </summary>
+    [Fact]
+    public void Tooltip_Should_Move_Left_On_Horizontal_Overflow()
+    {
+        // Arrange
+        CreateTestComponent();
+        moduleInterop.Setup<TooltipDisplayAttributes>("ShowTooltip", _ => true).SetResult(new TooltipDisplayAttributes() { XPercent = 0.5M });
+
+        // Act
+        tooltipTrigger.MouseOver();
+
+        // Assert
+        Assert.Equal("--translateXPercent: 50.0%", tooltipBody.GetAttribute("style"));
+    }
+
+    #endregion Tests
+
+    #region Helper Function
+    /// <summary>
+    /// Setup the component and register Javascript mocks
+    /// </summary>
+    protected override void CreateTestComponent()
+    {
+        JSInterop.SetupVoid("piipan.utilities.registerFormValidation", _ => true);
+        Component = Render<UsaTooltip>(
+            @<UsaTooltip TooltipText="@InitialValues.TooltipText" ChildContent="@InitialValues.ChildContent">
+            </UsaTooltip>
+        );
+        moduleInterop.Setup<TooltipDisplayAttributes>("ShowTooltip", _ => true).SetResult(new TooltipDisplayAttributes());
+        tooltipTrigger = Component.Find(".usa-tooltip__trigger");
+        tooltipBody = Component.Find(".usa-tooltip__body");
+    }
+
+    #endregion Helper Functions
+}

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/VulnerableInvalidStatus.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/VulnerableInvalidStatus.razor
@@ -15,13 +15,12 @@
             <UsaRadio Value=false>No</UsaRadio>
         </ChildContent>
         <LabelOverride>
-            <b><svg class="usa-icon usa-tooltip text-blue"
-            data-position="top"
-            title="A vulnerable individual is a participant that should have their location protected. Indicating that this participant is a vulnerable individual will inform any states involved with this match that this participant's location is not to be revealed in any communications."
-            aria-hidden="true" >
-        <use xlink:href="/images/sprite.svg#help"></use>
-        </svg>
-            Does this match involve a vulnerable individual?</b>
+            Does this match involve a vulnerable individual?
+            <Piipan.Components.Tooltips.UsaTooltip TooltipText="A vulnerable individual is a participant that should have their location protected. Indicating that this participant is a vulnerable individual will inform any states involved with this match that this participant's location is not to be revealed in any communications.">
+                <svg class="usa-icon text-blue">
+                    <use xlink:href="/images/sprite.svg#help"></use>
+                </svg>
+            </Piipan.Components.Tooltips.UsaTooltip>
         </LabelOverride>
     
 </UsaRadioGroup>
@@ -50,13 +49,12 @@
             <UsaRadio Value=false>No</UsaRadio>
         </ChildContent>
         <LabelOverride>
-            <b><svg class="usa-icon usa-tooltip text-blue"
-              data-position="top"
-                title="Invalid matches involve participants who are NOT receiving or applying for benefits in more than one state and may occur if there has been a typo in the information submitted to the NAC or in cases of identity theft. An explanation will be required if this match is indicated as invalid. "
-                aria-hidden="true" >
-            <use xlink:href="/images/sprite.svg#help"></use>
-          </svg>
-                Is this an invalid match?</b>
+            Is this an invalid match?
+            <Piipan.Components.Tooltips.UsaTooltip TooltipText="Invalid matches involve participants who are NOT receiving or applying for benefits in more than one state and may occur if there has been a typo in the information submitted to the NAC or in cases of identity theft. An explanation will be required if this match is indicated as invalid.">
+                <svg class="usa-icon text-blue">
+                    <use xlink:href="/images/sprite.svg#help"></use>
+                </svg>
+            </Piipan.Components.Tooltips.UsaTooltip>                
         </LabelOverride>
     
     </UsaRadioGroup>

--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/VulnerableInvalidStatus.razor.css
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/VulnerableInvalidStatus.razor.css
@@ -24,3 +24,12 @@ h5 {
 .ResolutionFieldsDropdownWidth {
     max-width: 296px;
 }
+
+.usa-icon {
+    height: 20px;
+    width: 20px;
+}
+
+::deep .usa-tooltip__trigger {
+    vertical-align: top;
+}

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/VulnerableInvalidStatusTests.razor
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/VulnerableInvalidStatusTests.razor
@@ -74,11 +74,13 @@
           <div class="usa-form-group ">
             <fieldset class="usa-fieldset" style=";">
               <legend class="usa-label usa-legend" for="DispositionData_VulnerableIndividual">
-                <b >
-                  <svg class="usa-icon usa-tooltip text-blue" data-position="top" title="A vulnerable individual is a participant that should have their location protected. Indicating that this participant is a vulnerable individual will inform any states involved with this match that this participant's location is not to be revealed in any communications." aria-hidden="true" >
-                    <use xlink:href="/images/sprite.svg#help" ></use>
-                  </svg>
-                  Does this match involve a vulnerable individual?</b>
+                Does this match involve a vulnerable individual?
+                <span class="usa-tooltip">
+                    <button tabindex="0" type="button" class="usa-tooltip__trigger usa-button usa-button--unstyled" style="margin-top: 0;" data-position="top" aria-describedby:ignore>
+                        <svg class="usa-icon text-blue"><use xlink:href="/images/sprite.svg#help"></use></svg>
+                    </button>
+                    <span id:ignore class="usa-tooltip__body usa-tooltip__body--top" role="tooltip" aria-hidden="true" style="--translateXPercent: 0%">A vulnerable individual is a participant that should have their location protected. Indicating that this participant is a vulnerable individual will inform any states involved with this match that this participant's location is not to be revealed in any communications.</span>
+                </span>
               </legend>
               <div class="usa-radio">
                 <input id:ignore  class="usa-radio__input valid" type="radio" name="DispositionData.VulnerableIndividual" value="True" >
@@ -93,11 +95,13 @@
           <div class="usa-form-group ">
             <fieldset class="usa-fieldset" style=";">
               <legend class="usa-label usa-legend" for="DispositionData_InvalidMatch">
-                <b >
-                  <svg class="usa-icon usa-tooltip text-blue" data-position="top" title="Invalid matches involve participants who are NOT receiving or applying for benefits in more than one state and may occur if there has been a typo in the information submitted to the NAC or in cases of identity theft. An explanation will be required if this match is indicated as invalid. " aria-hidden="true" >
-                    <use xlink:href="/images/sprite.svg#help" ></use>
-                  </svg>
-                  Is this an invalid match?</b>
+                Is this an invalid match?
+                <span class="usa-tooltip">
+                    <button tabindex="0" type="button" class="usa-tooltip__trigger usa-button usa-button--unstyled" style="margin-top: 0;" data-position="top" aria-describedby:ignore>
+                        <svg class="usa-icon text-blue"><use xlink:href="/images/sprite.svg#help"></use></svg>
+                    </button>
+                    <span id:ignore class="usa-tooltip__body usa-tooltip__body--top" role="tooltip" aria-hidden="true" style="--translateXPercent: 0%">Invalid matches involve participants who are NOT receiving or applying for benefits in more than one state and may occur if there has been a typo in the information submitted to the NAC or in cases of identity theft. An explanation will be required if this match is indicated as invalid.</span>
+                </span>
               </legend>
               <div class="usa-radio">
                 <input id:ignore  class="usa-radio__input valid" type="radio" name="DispositionData.InvalidMatch" value="True" checked="" >
@@ -160,11 +164,13 @@
               <div class="usa-form-group ">
                 <fieldset class="usa-fieldset" style=";">
                   <legend class="usa-label usa-legend" for="DispositionData_VulnerableIndividual">
-                    <b >
-                      <svg class="usa-icon usa-tooltip text-blue" data-position="top" title="A vulnerable individual is a participant that should have their location protected. Indicating that this participant is a vulnerable individual will inform any states involved with this match that this participant's location is not to be revealed in any communications." aria-hidden="true" >
-                        <use xlink:href="/images/sprite.svg#help" ></use>
-                      </svg>
-                      Does this match involve a vulnerable individual?</b>
+                    Does this match involve a vulnerable individual?
+                    <span class="usa-tooltip">
+                        <button tabindex="0" type="button" class="usa-tooltip__trigger usa-button usa-button--unstyled" style="margin-top: 0;" data-position="top" aria-describedby:ignore>
+                            <svg class="usa-icon text-blue"><use xlink:href="/images/sprite.svg#help"></use></svg>
+                        </button>
+                        <span id:ignore class="usa-tooltip__body usa-tooltip__body--top" role="tooltip" aria-hidden="true" style="--translateXPercent: 0%">A vulnerable individual is a participant that should have their location protected. Indicating that this participant is a vulnerable individual will inform any states involved with this match that this participant's location is not to be revealed in any communications.</span>
+                    </span>
                   </legend>
                   <div class="usa-radio">
                     <input id:ignore  class="usa-radio__input valid" type="radio" name="DispositionData.VulnerableIndividual" value="True" >
@@ -179,11 +185,13 @@
               <div class="usa-form-group ">
                 <fieldset class="usa-fieldset" style=";">
                   <legend class="usa-label usa-legend" for="DispositionData_InvalidMatch">
-                    <b >
-                      <svg class="usa-icon usa-tooltip text-blue" data-position="top" title="Invalid matches involve participants who are NOT receiving or applying for benefits in more than one state and may occur if there has been a typo in the information submitted to the NAC or in cases of identity theft. An explanation will be required if this match is indicated as invalid. " aria-hidden="true" >
-                        <use xlink:href="/images/sprite.svg#help" ></use>
-                      </svg>
-                      Is this an invalid match?</b>
+                    Is this an invalid match?
+                    <span class="usa-tooltip">
+                        <button tabindex="0" type="button" class="usa-tooltip__trigger usa-button usa-button--unstyled" style="margin-top: 0;" data-position="top" aria-describedby:ignore>
+                            <svg class="usa-icon text-blue"><use xlink:href="/images/sprite.svg#help"></use></svg>
+                        </button>
+                        <span id:ignore class="usa-tooltip__body usa-tooltip__body--top" role="tooltip" aria-hidden="true" style="--translateXPercent: 0%">Invalid matches involve participants who are NOT receiving or applying for benefits in more than one state and may occur if there has been a typo in the information submitted to the NAC or in cases of identity theft. An explanation will be required if this match is indicated as invalid.</span>
+                    </span>
                   </legend>
                   <div class="usa-radio">
                     <input id:ignore  class="usa-radio__input valid" type="radio" name="DispositionData.InvalidMatch" value="True" >


### PR DESCRIPTION
## What’s changing?

A Blazor tooltip component is added to the Component Library, allowing us to easily put a tooltip on any item. We then add it to the Match Detail page, on the Invalid Match and Vulnerable Individual parts of the screen.

## Why?

Closes NAC-445

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
