### PR TITLE
Upgrade CsvHelper to 28.0.1 (major dependency upgrade)

### DIFF
--- a/dashboard/src/Piipan.Dashboard/packages.lock.json
+++ b/dashboard/src/Piipan.Dashboard/packages.lock.json
@@ -646,8 +646,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1822,7 +1822,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
+++ b/dashboard/tests/Piipan.Dashboard.Tests/packages.lock.json
@@ -793,8 +793,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -2051,7 +2051,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Piipan.Etl.Func.BulkUpload.csproj
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Piipan.Etl.Func.BulkUpload.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.11.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="CsvHelper" Version="28.0.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Piipan.Etl.Func.BulkUpload.csproj
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/Piipan.Etl.Func.BulkUpload.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "CsvHelper": {
         "type": "Direct",
-        "requested": "[27.2.1, )",
-        "resolved": "27.2.1",
-        "contentHash": "uS5ix5hL9gL5taiAG//CScyJa8Fn1ZOh3FDhDvf4laboESFs84mCNropfp7PIt8xCkyQofljFpqu1B5UnSXjyA=="
+        "requested": "[28.0.1, )",
+        "resolved": "28.0.1",
+        "contentHash": "T/Eid0mP/GeWV1RcxmUPSsBCtOm6wHbFII6iFydPfpIa6cd+siec0KGrLq5uabI8sH6crFi84OA1vNLkp8Lzlw=="
       },
       "Microsoft.Azure.Functions.Extensions": {
         "type": "Direct",

--- a/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
+++ b/etl/src/Piipan.Etl/Piipan.Etl.Func.BulkUpload/packages.lock.json
@@ -108,9 +108,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -863,11 +863,11 @@
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "PostgreSQLCopyHelper": {
@@ -2070,7 +2070,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2092,7 +2092,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/Piipan.Etl.Func.BulkUpload.Tests.csproj
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/Piipan.Etl.Func.BulkUpload.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="csvhelper" Version="27.2.1" />
+    <PackageReference Include="csvhelper" Version="28.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Npgsql" Version="6.0.5" />

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/Piipan.Etl.Func.BulkUpload.Tests.csproj
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/Piipan.Etl.Func.BulkUpload.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="csvhelper" Version="28.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "CsvHelper": {
         "type": "Direct",
-        "requested": "[27.2.1, )",
-        "resolved": "27.2.1",
-        "contentHash": "uS5ix5hL9gL5taiAG//CScyJa8Fn1ZOh3FDhDvf4laboESFs84mCNropfp7PIt8xCkyQofljFpqu1B5UnSXjyA=="
+        "requested": "[28.0.1, )",
+        "resolved": "28.0.1",
+        "contentHash": "T/Eid0mP/GeWV1RcxmUPSsBCtOm6wHbFII6iFydPfpIa6cd+siec0KGrLq5uabI8sH6crFi84OA1vNLkp8Lzlw=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
@@ -2168,7 +2168,7 @@
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.11.0",
           "Azure.Storage.Blobs": "12.13.0",
-          "CsvHelper": "27.2.1",
+          "CsvHelper": "28.0.1",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
           "Microsoft.Azure.Services.AppAuthentication": "1.6.2",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.2.0",

--- a/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
+++ b/etl/tests/Piipan.Etl.Func.BulkUpload.Tests/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -927,11 +927,11 @@
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "NuGet.Frameworks": {
@@ -2176,7 +2176,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.NET.Sdk.Functions": "4.1.1",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Participants.Api": "1.0.0",
           "Piipan.Participants.Core": "1.0.0",
           "Piipan.Shared": "1.0.0"
@@ -2213,7 +2213,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2235,7 +2235,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/match/src/Piipan.Match/Piipan.Match.Core/Piipan.Match.Core.csproj
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Piipan.Match.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Nanoid" Version="2.1.0" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="FluentValidation" Version="11.1.0" />
   </ItemGroup>

--- a/match/src/Piipan.Match/Piipan.Match.Core/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Core/packages.lock.json
@@ -55,9 +55,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1557,7 +1557,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/match/src/Piipan.Match/Piipan.Match.Func.Api/Piipan.Match.Func.Api.csproj
+++ b/match/src/Piipan.Match/Piipan.Match.Func.Api/Piipan.Match.Func.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Nanoid" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Func.Api/packages.lock.json
@@ -87,9 +87,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -845,11 +845,11 @@
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "PostgreSQLCopyHelper": {
@@ -2242,7 +2242,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2281,7 +2281,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2303,7 +2303,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/packages.lock.json
+++ b/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/packages.lock.json
@@ -783,8 +783,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1961,7 +1961,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -1994,7 +1994,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/match/tests/Piipan.Match.Api.Tests/Piipan.Match.Api.Tests.csproj
+++ b/match/tests/Piipan.Match.Api.Tests/Piipan.Match.Api.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Api.Tests/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }

--- a/match/tests/Piipan.Match.Client.Tests/Piipan.Match.Client.Tests.csproj
+++ b/match/tests/Piipan.Match.Client.Tests/Piipan.Match.Client.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Client.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Client.Tests/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1849,7 +1849,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/match/tests/Piipan.Match.Core.IntegrationTests/Piipan.Match.Core.IntegrationTests.csproj
+++ b/match/tests/Piipan.Match.Core.IntegrationTests/Piipan.Match.Core.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Core.Tests/Piipan.Match.Core.Tests.csproj
+++ b/match/tests/Piipan.Match.Core.Tests/Piipan.Match.Core.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/match/tests/Piipan.Match.Core.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Core.Tests/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1674,7 +1674,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -1707,7 +1707,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/match/tests/Piipan.Match.Func.Api.IntegrationTests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.Api.IntegrationTests/packages.lock.json
@@ -914,19 +914,19 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "NuGet.Frameworks": {
@@ -2379,7 +2379,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2399,7 +2399,7 @@
           "Microsoft.NET.Sdk.Functions": "4.1.1",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Match.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2438,7 +2438,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2460,7 +2460,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {
@@ -2483,7 +2483,7 @@
         "type": "Project",
         "dependencies": {
           "dapper": "2.0.123",
-          "npgsql": "6.0.5"
+          "npgsql": "6.0.6"
         }
       }
     }

--- a/match/tests/Piipan.Match.Func.Api.Tests/Piipan.Match.Func.Api.Tests.csproj
+++ b/match/tests/Piipan.Match.Func.Api.Tests/Piipan.Match.Func.Api.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.Api.Tests/packages.lock.json
@@ -48,9 +48,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -923,11 +923,11 @@
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "NuGet.Frameworks": {
@@ -2380,7 +2380,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2400,7 +2400,7 @@
           "Microsoft.NET.Sdk.Functions": "4.1.1",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Match.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2439,7 +2439,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2461,7 +2461,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/Piipan.Match.Func.ResolutionApi.IntegrationTests.csproj
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/Piipan.Match.Func.ResolutionApi.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -2092,7 +2092,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2137,7 +2137,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {
@@ -2160,7 +2160,7 @@
         "type": "Project",
         "dependencies": {
           "dapper": "2.0.123",
-          "npgsql": "6.0.5"
+          "npgsql": "6.0.6"
         }
       },
       "piipan.states.api": {

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/packages.lock.json
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/packages.lock.json
@@ -852,8 +852,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -2090,7 +2090,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Nanoid": "2.1.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Match.Api": "1.0.0",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2135,7 +2135,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/Piipan.Metrics.Func.Api.csproj
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/Piipan.Metrics.Func.Api.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Api/packages.lock.json
@@ -65,9 +65,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1937,7 +1937,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/Piipan.Metrics.Func.Collect.csproj
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/Piipan.Metrics.Func.Collect.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/packages.lock.json
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/packages.lock.json
@@ -75,9 +75,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -793,11 +793,11 @@
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "PostgreSQLCopyHelper": {
@@ -1995,7 +1995,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2017,7 +2017,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/metrics/tests/Piipan.Metrics.Client.Tests/Piipan.Metrics.Client.Tests.csproj
+++ b/metrics/tests/Piipan.Metrics.Client.Tests/Piipan.Metrics.Client.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/metrics/tests/Piipan.Metrics.Client.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Client.Tests/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1842,7 +1842,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Core.IntegrationTests/Piipan.Metrics.Core.IntegrationTests.csproj
+++ b/metrics/tests/Piipan.Metrics.Core.IntegrationTests/Piipan.Metrics.Core.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/metrics/tests/Piipan.Metrics.Core.IntegrationTests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Core.IntegrationTests/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -861,11 +861,11 @@
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "NuGet.Frameworks": {
@@ -2117,7 +2117,7 @@
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.2.0",
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.NET.Sdk.Functions": "4.1.1",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Core": "1.0.0",
@@ -2139,7 +2139,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2161,7 +2161,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {
@@ -2184,7 +2184,7 @@
         "type": "Project",
         "dependencies": {
           "dapper": "2.0.123",
-          "npgsql": "6.0.5"
+          "npgsql": "6.0.6"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Core.Tests/Piipan.Metrics.Core.Tests.csproj
+++ b/metrics/tests/Piipan.Metrics.Core.Tests/Piipan.Metrics.Core.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/metrics/tests/Piipan.Metrics.Core.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Core.Tests/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1632,7 +1632,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Func.Api.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Func.Api.Tests/packages.lock.json
@@ -813,8 +813,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -2059,7 +2059,7 @@
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.NET.Sdk.Functions": "4.1.1",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Shared": "1.0.0"
@@ -2078,7 +2078,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/metrics/tests/Piipan.Metrics.Func.Collect.Tests/packages.lock.json
+++ b/metrics/tests/Piipan.Metrics.Func.Collect.Tests/packages.lock.json
@@ -851,19 +851,19 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "NuGet.Frameworks": {
@@ -2115,7 +2115,7 @@
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.2.0",
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.NET.Sdk.Functions": "4.1.1",
-          "Npgsql": "6.0.5",
+          "Npgsql": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Core": "1.0.0",
@@ -2137,7 +2137,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -2159,7 +2159,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/participants/src/Piipan.Participants/Piipan.Participants.Core/Piipan.Participants.Core.csproj
+++ b/participants/src/Piipan.Participants/Piipan.Participants.Core/Piipan.Participants.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql.NodaTime" Version="6.0.5" />
+    <PackageReference Include="Npgsql.NodaTime" Version="6.0.6" />
     <PackageReference Include="PostgreSQLCopyHelper" Version="2.8.0" />
   </ItemGroup>
 

--- a/participants/tests/Piipan.Participants.Core.IntegrationTests/Piipan.Participants.Core.IntegrationTests.csproj
+++ b/participants/tests/Piipan.Participants.Core.IntegrationTests/Piipan.Participants.Core.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />

--- a/participants/tests/Piipan.Participants.Core.Tests/Piipan.Participants.Core.Tests.csproj
+++ b/participants/tests/Piipan.Participants.Core.Tests/Piipan.Participants.Core.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
+++ b/participants/tests/Piipan.Participants.Core.Tests/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -487,11 +487,11 @@
       },
       "Npgsql.NodaTime": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "7rF+at3dd2tmVLqQq94Iv/OUT9m+MM0k8qNyNUquWpFWHZ9sCV9Ju4gZvY5V8M8sEJjk5ePZsr4qpk18A4fX+g==",
+        "resolved": "6.0.6",
+        "contentHash": "UoSvRBWBHvTxqMzR4ucsNyRcqOaL/oieVM9NkeoNaviyvVMDgMohDu82vQ3/rx3S0TzB3Oeglg+2Ygd/U+06aw==",
         "dependencies": {
           "NodaTime": "3.0.9",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "NuGet.Frameworks": {
@@ -1704,7 +1704,7 @@
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Newtonsoft.Json": "13.0.1",
-          "Npgsql.NodaTime": "6.0.5",
+          "Npgsql.NodaTime": "6.0.6",
           "Piipan.Metrics.Api": "1.0.0",
           "Piipan.Metrics.Core": "1.0.0",
           "Piipan.Participants.Api": "1.0.0",
@@ -1726,7 +1726,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/Etl.BulkUpload.Performance.TestRunner.csproj
+++ b/perf-tests/src/Etl.BulkUpload.Performance.TestRunner/Etl.BulkUpload.Performance.TestRunner.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.6.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="CsvHelper" Version="28.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
   </ItemGroup>

--- a/query-tool/src/Piipan.QueryTool/packages.lock.json
+++ b/query-tool/src/Piipan.QueryTool/packages.lock.json
@@ -649,8 +649,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1831,7 +1831,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
+++ b/query-tool/tests/Piipan.QueryTool.Tests/packages.lock.json
@@ -794,8 +794,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -2062,7 +2062,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.api": {

--- a/shared/src/Piipan.Shared.Cryptography/packages.lock.json
+++ b/shared/src/Piipan.Shared.Cryptography/packages.lock.json
@@ -380,8 +380,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1510,7 +1510,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/shared/src/Piipan.Shared.TestFixtures/Piipan.Shared.TestFixtures.csproj
+++ b/shared/src/Piipan.Shared.TestFixtures/Piipan.Shared.TestFixtures.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="dapper" Version="2.0.123" />
-    <PackageReference Include="npgsql" Version="6.0.5" />
+    <PackageReference Include="npgsql" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\match\ddl\match-record.sql" Link="match-record.sql" CopyToOutputDirectory="PreserveNewest" />

--- a/shared/src/Piipan.Shared.TestFixtures/packages.lock.json
+++ b/shared/src/Piipan.Shared.TestFixtures/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }

--- a/shared/src/Piipan.Shared/Piipan.Shared.csproj
+++ b/shared/src/Piipan.Shared/Piipan.Shared.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql" Version="6.0.6" />
   </ItemGroup>
 
 </Project>

--- a/shared/src/Piipan.Shared/packages.lock.json
+++ b/shared/src/Piipan.Shared/packages.lock.json
@@ -124,9 +124,9 @@
       },
       "Npgsql": {
         "type": "Direct",
-        "requested": "[6.0.5, )",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "requested": "[6.0.6, )",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }

--- a/shared/tests/Piipan.Shared.Cryptography.Tests/packages.lock.json
+++ b/shared/tests/Piipan.Shared.Cryptography.Tests/packages.lock.json
@@ -457,8 +457,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1647,7 +1647,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.shared.cryptography": {

--- a/shared/tests/Piipan.Shared.Tests/packages.lock.json
+++ b/shared/tests/Piipan.Shared.Tests/packages.lock.json
@@ -732,8 +732,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1948,7 +1948,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       }
     }

--- a/states/src/Piipan.States.Func.Api/packages.lock.json
+++ b/states/src/Piipan.States.Func.Api/packages.lock.json
@@ -731,8 +731,8 @@
       },
       "Npgsql": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "a11H5/b5yNTuFN0Ycjvb920oI6vQHadt6KhEMmcC7DfvsSHH8Z3wBam+CHmyWcfDxJJaxamcdBb8XA3BvqS4Kw==",
+        "resolved": "6.0.6",
+        "contentHash": "IIwnoJp0sFkhAydT/KKe/0NhlJKhYPIrXSE95AuU/2dqHNI9alxvjClJSGL+QE8NGqq1SFn+NenxVtm/JYsrJg==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -1906,7 +1906,7 @@
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Options": "6.0.0",
           "Newtonsoft.Json.Schema": "3.0.14",
-          "Npgsql": "6.0.5"
+          "Npgsql": "6.0.6"
         }
       },
       "piipan.states.api": {


### PR DESCRIPTION
## What’s changing?

CsvHelper upgraded to a new major version, 20.0.1. 
Also updating NpgSql

## Why?

This is necessary to close down dependabot PRs
https://github.com/18F/piipan/pull/3491
https://github.com/18F/piipan/pull/3493

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
