### PR TITLE
NAC-944: Added third parameter for table name with default value

### DIFF
--- a/iac/db-common.bash
+++ b/iac/db-common.bash
@@ -151,26 +151,40 @@ EOF
 }
 
 # Database access controls
+# Example grant access to all tables
+#   db_grant_read "DB_Name" "APP_Name"
+# Example grant access to some tables
+#   db_grant_read "DB_Name" "APP_Name" "table1, table2"
+# Example grant access a table
+#   db_grant_read "DB_Name" "APP_Name" "tableName"
+
 db_grant_read () {
   local db=$1
   local func=$2
-  local table=${3-'ALL TABLES'}
+  local table=${3-'ALL TABLES IN SCHEMA public'}
   local role=${func//-/_}
 
   psql "${PSQL_OPTS[@]}" -d "$db" -f - <<EOF
-    GRANT SELECT ON $table IN SCHEMA public TO $role;
+    GRANT SELECT ON $table TO $role;
 EOF
 }
 
+# Database readwrite access control
+# Example grant access to all tables
+#   db_grant_readwrite "DB_Name" "APP_Name"
+# Example grant access to some tables
+#   db_grant_readwrite "DB_Name" "APP_Name" "table1, table2"
+# Example grant access a table
+#   db_grant_readwrite "DB_Name" "APP_Name" "tableName"
 db_grant_readwrite () {
   local db=$1
   local func=$2
-  local table=${3-'ALL TABLES'}
+  local table=${3-'ALL TABLES IN SCHEMA public'}
   role=${func//-/_}
 
   psql "${PSQL_OPTS[@]}" -d "$db" -f - <<EOF
-    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON $table IN SCHEMA public TO $role;
-    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $role;
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON $table TO $role;
+    GRANT USAGE, SELECT ON ALL SEQUENCES TO $role;
 EOF
 }
 

--- a/iac/db-common.bash
+++ b/iac/db-common.bash
@@ -154,20 +154,22 @@ EOF
 db_grant_read () {
   local db=$1
   local func=$2
+  local table=${3-'ALL TABLES'}
   local role=${func//-/_}
 
   psql "${PSQL_OPTS[@]}" -d "$db" -f - <<EOF
-    GRANT SELECT ON ALL TABLES IN SCHEMA public TO $role;
+    GRANT SELECT ON $table IN SCHEMA public TO $role;
 EOF
 }
 
 db_grant_readwrite () {
-  db=$1
-  func=$2
+  local db=$1
+  local func=$2
+  local table=${3-'ALL TABLES'}
   role=${func//-/_}
 
   psql "${PSQL_OPTS[@]}" -d "$db" -f - <<EOF
-    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA public TO $role;
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON $table IN SCHEMA public TO $role;
     GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $role;
 EOF
 }


### PR DESCRIPTION
## What’s changing?

Added parameter with the table name to two functions on db_common to assign access level. This third parameter is optional, the default value is ALL TABLES. 

## Why?

NAC-944 Add additional functionality to support adding different levels of access at the table-level. For example, authorizing the state metadata API to only have access to the state_info table and no other tables in the collaboration database

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [x] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
