### PR TITLE
HTTPS only flipped to true for dashboard and query tool

### DIFF
--- a/iac/arm-templates/dashboard-app.json
+++ b/iac/arm-templates/dashboard-app.json
@@ -123,6 +123,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
+                "httpsOnly": true,
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('servicePlan'))]",
                 "siteConfig": "[variables('baseSiteConfig')]",
                 "resources": [

--- a/iac/arm-templates/query-tool-app.json
+++ b/iac/arm-templates/query-tool-app.json
@@ -151,6 +151,7 @@
                 "[resourceId('Microsoft.Web/serverfarms', parameters('servicePlan'))]"
             ],
             "properties": {
+                "httpsOnly": true,
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('servicePlan'))]",
                 "siteConfig": "[variables('baseSiteConfig')]",
                 "resources": [


### PR DESCRIPTION
## What’s changing?

Setting HttpsOnly to true to make it so HTTP always redirects to HTTPS for Dashboard and Query Tool app service.

## Why?

Closes NAC-32

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [x] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
