### PR TITLE
Nac 995 match metrics

### DIFF
--- a/match/src/Piipan.Match/Piipan.Match.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ namespace Piipan.Match.Core.Extensions
             serviceCollection.AddTransient<IMatchRecordDao, MatchRecordDao>();
             serviceCollection.AddTransient<IMatchRecordApi, MatchRecordService>();
             serviceCollection.AddTransient<IParticipantPublishSearchMetric, ParticipantPublishSearchMetric>();
+            serviceCollection.AddTransient<IParticipantPublishMatchMetric, ParticipantPublishMatchMetric>();
             serviceCollection.AddTransient<IMatchEventService, MatchEventService>();
 
         }

--- a/match/src/Piipan.Match/Piipan.Match.Core/Services/IParticipantPublishMatchMetric.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Services/IParticipantPublishMatchMetric.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Piipan.Metrics.Api;
+
+namespace Piipan.Match.Core.Services
+{
+    public interface IParticipantPublishMatchMetric
+    {
+        Task PublishMatchMetric(ParticipantMatchMetrics metrics);
+    }
+}

--- a/match/src/Piipan.Match/Piipan.Match.Core/Services/ParticipantPublishMatchMetric.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Core/Services/ParticipantPublishMatchMetric.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Messaging.EventGrid;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Piipan.Metrics.Api;
+
+namespace Piipan.Match.Core.Services
+{
+    public class ParticipantPublishMatchMetric : IParticipantPublishMatchMetric
+    {
+        public EventGridPublisherClient _client;
+        public ILogger<ParticipantPublishMatchMetric> _logger;
+
+        public ParticipantPublishMatchMetric(ILogger<ParticipantPublishMatchMetric> logger)
+        {
+            _logger = logger;
+            InitializeEventGridPublisherClient();
+        }
+
+        private void InitializeEventGridPublisherClient()
+        {
+            try
+            {
+                if (_client == null)
+                {
+                    //Create event grid client to publish metric data
+                    string eventGridUriString = Environment.GetEnvironmentVariable("EventGridMetricMatchEndPoint");
+                    string eventGridKeyString = Environment.GetEnvironmentVariable("EventGridMetricMatchKeyString");
+
+                    if (eventGridUriString != null && eventGridKeyString != null)
+                    {
+                        _client = new EventGridPublisherClient(
+                            new Uri(eventGridUriString),
+                            new AzureKeyCredential(eventGridKeyString),
+                            default
+                        );
+                    }
+                    else
+                    {
+                        _logger.LogError("EventGridMetricMatchEndPoint and EventGridMetricMatchKeyString environment variables are not set.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unable to initialize EventGridPublisherClient.");
+            }
+
+        }
+
+        /// <summary>
+        /// Publishes an event to EventGrid containing ParticipantUpload metrics
+        /// </summary>
+        /// <param name="metrics">Bulk Upload Metadata And Metrics</param>
+        /// <returns></returns>
+        public Task PublishMatchMetric(ParticipantMatchMetrics metrics)
+        {
+            try
+            {
+                var result = JsonConvert.SerializeObject(metrics);
+                //We want to use pre-serialized verion of the ParticipantMatch.
+                //Otherwise, EventGridEvent serializes it according to class property names rather than JsonProperty attributes
+                var binaryData = BinaryData.FromString(result);
+                // Add EventGridEvents to a list to publish to the topic
+                EventGridEvent egEvent =
+                    new EventGridEvent(
+                        "Publish match metrics",
+                        "Publish to the database",
+                        "1.0",
+                        binaryData);
+
+                // Send the event
+                _client.SendEventAsync(egEvent);
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to publish Publish Participant Match metrics event to EventGrid.");
+                throw;
+            }
+            return Task.CompletedTask;
+        }
+
+    }
+}

--- a/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/Startup.cs
+++ b/match/src/Piipan.Match/Piipan.Match.Func.ResolutionApi/Startup.cs
@@ -10,6 +10,7 @@ using Piipan.Match.Api.Models;
 using Piipan.Match.Core.Builders;
 using Piipan.Match.Core.DataAccessObjects;
 using Piipan.Match.Core.Parsers;
+using Piipan.Match.Core.Services;
 using Piipan.Match.Core.Validators;
 using Piipan.Shared.Database;
 using Piipan.States.Core.DataAccessObjects;
@@ -28,6 +29,8 @@ namespace Piipan.Match.Func.ResolutionApi
 
             builder.Services.AddTransient<IMatchRecordDao, MatchRecordDao>();
             builder.Services.AddTransient<IMatchResEventDao, MatchResEventDao>();
+            builder.Services.AddTransient<IParticipantPublishMatchMetric, ParticipantPublishMatchMetric>();
+
             builder.Services.AddTransient<IStateInfoDao, StateInfoDao>();
             builder.Services.AddSingleton<IMemoryCache, MemoryCache>();
             builder.Services.AddTransient<IMatchResAggregator, MatchResAggregator>();

--- a/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Moq;
 using Piipan.Match.Api;
@@ -24,7 +22,7 @@ namespace Piipan.Match.Core.Tests.Services
         private const string QueryToolUrl = "https://tts.test";
         private string base64EncodedKey = "kW6QuilIQwasK7Maa0tUniCdO+ACHDSx8+NYhwCo7jQ=";
         private ICryptographyClient cryptographyClient;
-                
+
         public MatchEventServiceTests()
         {
             Environment.SetEnvironmentVariable("QueryToolUrl", QueryToolUrl);
@@ -69,7 +67,22 @@ namespace Piipan.Match.Core.Tests.Services
 
             return mock;
         }
+        private Mock<IParticipantPublishSearchMetric> ParticipantPublishSearchMetricMock()
+        {
+            var mock = new Mock<IParticipantPublishSearchMetric>();
+            mock.Setup(m => m.PublishSearchdMetric(It.IsAny<ParticipantSearchMetrics>()))
+                  .Returns(Task.CompletedTask);
 
+            return mock;
+        }
+        private Mock<IParticipantPublishMatchMetric> ParticipantPublishMatchMetricMock()
+        {
+            var mock = new Mock<IParticipantPublishMatchMetric>();
+            mock.Setup(m => m.PublishMatchMetric(It.IsAny<ParticipantMatchMetrics>()))
+                  .Returns(Task.CompletedTask);
+
+            return mock;
+        }
         private Mock<IMatchResAggregator> MatchResAggregatorMock(
             MatchResRecord result
         )
@@ -123,16 +136,18 @@ namespace Piipan.Match.Core.Tests.Services
 
             var mreDao = MatchResEventDaoMock(new List<IMatchResEvent>());
             var aggDao = MatchResAggregatorMock(new MatchResRecord());
-            var participantPublishSearchMetric = new Mock<IParticipantPublishSearchMetric>();
-            participantPublishSearchMetric.Setup(m => m.PublishSearchdMetric(It.IsAny<ParticipantSearchMetrics>()))
-                   .Returns(Task.CompletedTask);
+
+            var publishSearchMetrics = ParticipantPublishSearchMetricMock();
+            var publishMatchMetrics = ParticipantPublishMatchMetricMock();
+
             var service = new MatchEventService(
                 recordBuilder.Object,
                 recordApi.Object,
                 mreDao.Object,
-                aggDao.Object, 
+                aggDao.Object,
                 cryptographyClient,
-                participantPublishSearchMetric.Object
+                publishSearchMetrics.Object,
+                publishMatchMetrics.Object
             );
 
             // Act
@@ -147,11 +162,17 @@ namespace Piipan.Match.Core.Tests.Services
                     r.States.SequenceEqual(record.States))),
                 Times.Once);
 
-            participantPublishSearchMetric.Verify(r => r.PublishSearchdMetric(
+            publishSearchMetrics.Verify(r => r.PublishSearchdMetric(
               It.Is<ParticipantSearchMetrics>(r => r.Data.First().MatchCount == search.MatchCount &&
                                                    r.Data.First().MatchCreation == search.MatchCreation &&
                                                    r.Data.First().SearchReason == search.SearchReason)),
                                                    Times.Once);
+
+            publishMatchMetrics.Verify(r => r.PublishMatchMetric(
+             It.Is<ParticipantMatchMetrics>(r => r.MatchId == "foo" &&
+                                                  r.InitState == record.Initiator
+                                                 )),
+                                                  Times.Once);
         }
 
         [Fact]
@@ -185,16 +206,17 @@ namespace Piipan.Match.Core.Tests.Services
 
             var mreDao = MatchResEventDaoMock(new List<IMatchResEvent>());
             var aggDao = MatchResAggregatorMock(new MatchResRecord());
-            var participantPublishSearchMetric = new Mock<IParticipantPublishSearchMetric>();
-            participantPublishSearchMetric.Setup(m => m.PublishSearchdMetric(It.IsAny<ParticipantSearchMetrics>()))
-                   .Returns(Task.CompletedTask);
+            var publishSearchMetrics = ParticipantPublishSearchMetricMock();
+            var publishMatchMetrics = ParticipantPublishMatchMetricMock();
+
             var service = new MatchEventService(
                 recordBuilder.Object,
                 recordApi.Object,
                 mreDao.Object,
-                aggDao.Object, 
+                aggDao.Object,
                 cryptographyClient,
-                participantPublishSearchMetric.Object
+                publishSearchMetrics.Object,
+                publishMatchMetrics.Object
             );
 
             // Act
@@ -241,16 +263,17 @@ namespace Piipan.Match.Core.Tests.Services
             var mreDao = MatchResEventDaoMock(new List<IMatchResEvent>());
             var aggDao = MatchResAggregatorMock(new MatchResRecord());
 
-            var participantPublishSearchMetric = new Mock<IParticipantPublishSearchMetric>();
-            participantPublishSearchMetric.Setup(m => m.PublishSearchdMetric(It.IsAny<ParticipantSearchMetrics>()))
-                               .Returns(Task.CompletedTask);
+            var publishSearchMetrics = ParticipantPublishSearchMetricMock();
+            var publishMatchMetrics = ParticipantPublishMatchMetricMock();
+
             var service = new MatchEventService(
                 recordBuilder.Object,
                 recordApi.Object,
                 mreDao.Object,
-                aggDao.Object, 
+                aggDao.Object,
                 cryptographyClient,
-                participantPublishSearchMetric.Object
+                publishSearchMetrics.Object,
+                publishMatchMetrics.Object
             );
 
             // Act
@@ -304,22 +327,23 @@ namespace Piipan.Match.Core.Tests.Services
 
             var mreDao = MatchResEventDaoMock(new List<IMatchResEvent>());
             var aggDao = MatchResAggregatorMock(new MatchResRecord());
-            var participantPublishSearchMetric = new Mock<IParticipantPublishSearchMetric>();
-            participantPublishSearchMetric.Setup(m => m.PublishSearchdMetric(It.IsAny<ParticipantSearchMetrics>()))
-                               .Returns(Task.CompletedTask);
+            var publishSearchMetrics = ParticipantPublishSearchMetricMock();
+            var publishMatchMetrics = ParticipantPublishMatchMetricMock();
+
             var service = new MatchEventService(
                 recordBuilder.Object,
                 recordApi.Object,
                 mreDao.Object,
-                aggDao.Object, 
+                aggDao.Object,
                 cryptographyClient,
-                participantPublishSearchMetric.Object
+                publishSearchMetrics.Object,
+                publishMatchMetrics.Object
             );
 
             // Act
             var resolvedResponse = await service.ResolveMatches(request, response, "ea");
             var firstMatch = resolvedResponse.Data.Results.First().Matches.First();
-            
+
             // Assert
             Assert.Equal($"{QueryToolUrl}/match/{openMatchId}", firstMatch.MatchUrl);
             Assert.Equal(openMatchId, firstMatch.MatchId);
@@ -362,17 +386,17 @@ namespace Piipan.Match.Core.Tests.Services
             var mreDao = MatchResEventDaoMock(new List<IMatchResEvent>());
             var aggDao = MatchResAggregatorMock(new MatchResRecord());
 
-            var participantPublishSearchMetric = new Mock<IParticipantPublishSearchMetric>();
-            participantPublishSearchMetric.Setup(m => m.PublishSearchdMetric(It.IsAny<ParticipantSearchMetrics>()))
-                               .Returns(Task.CompletedTask);
+            var publishSearchMetrics = ParticipantPublishSearchMetricMock();
+            var publishMatchMetrics = ParticipantPublishMatchMetricMock();
 
             var service = new MatchEventService(
                 recordBuilder.Object,
                 recordApi.Object,
                 mreDao.Object,
-                aggDao.Object, 
+                aggDao.Object,
                 cryptographyClient,
-                participantPublishSearchMetric.Object
+                publishSearchMetrics.Object,
+                publishMatchMetrics.Object
             );
 
             // Act
@@ -431,13 +455,13 @@ namespace Piipan.Match.Core.Tests.Services
             response.Data.Results.Add(result);
 
             var mreDao = MatchResEventDaoMock(new List<IMatchResEvent>());
-            var aggDao = MatchResAggregatorMock(new MatchResRecord(){
+            var aggDao = MatchResAggregatorMock(new MatchResRecord()
+            {
                 Status = MatchRecordStatus.Closed
             });
 
-            var participantPublishSearchMetric = new Mock<IParticipantPublishSearchMetric>();
-            participantPublishSearchMetric.Setup(m => m.PublishSearchdMetric(It.IsAny<ParticipantSearchMetrics>()))
-                               .Returns(Task.CompletedTask);
+            var publishSearchMetrics = ParticipantPublishSearchMetricMock();
+            var publishMatchMetrics = ParticipantPublishMatchMetricMock();
 
             var service = new MatchEventService(
                 recordBuilder.Object,
@@ -445,7 +469,8 @@ namespace Piipan.Match.Core.Tests.Services
                 mreDao.Object,
                 aggDao.Object,
                 cryptographyClient,
-                participantPublishSearchMetric.Object
+                publishSearchMetrics.Object,
+                publishMatchMetrics.Object
             );
 
             // Act
@@ -456,7 +481,7 @@ namespace Piipan.Match.Core.Tests.Services
             Assert.Equal($"{QueryToolUrl}/match/{newId}", firstMatch.MatchUrl);
             Assert.Equal(newId, firstMatch.MatchId);
 
-            participantPublishSearchMetric.Verify(r => r.PublishSearchdMetric(
+            publishSearchMetrics.Verify(r => r.PublishSearchdMetric(
              It.Is<ParticipantSearchMetrics>(r => r.Data.First().MatchCount == search.MatchCount &&
                                                   r.Data.First().MatchCreation == search.MatchCreation &&
                                                   r.Data.First().SearchReason == search.SearchReason)),

--- a/match/tests/Piipan.Match.Func.Api.IntegrationTests/ApiIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.Api.IntegrationTests/ApiIntegrationTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -21,7 +20,6 @@ using Piipan.Match.Core.Extensions;
 using Piipan.Match.Core.Parsers;
 using Piipan.Match.Core.Services;
 using Piipan.Match.Core.Validators;
-using Piipan.Metrics.Api;
 using Piipan.Participants.Core.DataAccessObjects;
 using Piipan.Participants.Core.Extensions;
 using Piipan.Participants.Core.Models;
@@ -111,11 +109,12 @@ namespace Piipan.Match.Func.Api.IntegrationTests
         static MatchApi Construct()
         {
             Environment.SetEnvironmentVariable("States", "ea");
-            Environment.SetEnvironmentVariable("EventGridEndPoint","http://someendpoint.gov");
-            Environment.SetEnvironmentVariable("EventGridKeyString","example");
+            Environment.SetEnvironmentVariable("EventGridEndPoint", "http://someendpoint.gov");
+            Environment.SetEnvironmentVariable("EventGridKeyString", "example");
             Environment.SetEnvironmentVariable("EventGridMetricSearchEndPoint", "http://someendpoint.gov");
             Environment.SetEnvironmentVariable("EventGridMetricSearchKeyString", "example");
-
+            Environment.SetEnvironmentVariable("EventGridMetricMatchEndPoint", "http://someendpoint.gov");
+            Environment.SetEnvironmentVariable("EventGridMetricMatchKeyString", "example");
 
             // Mixing cases to verify the enabled states can be used no matter their casing.
             Environment.SetEnvironmentVariable("EnabledStates", "ea,EB");
@@ -140,16 +139,6 @@ namespace Piipan.Match.Func.Api.IntegrationTests
                 return new BasicPgConnectionFactory<ParticipantsDb>(
                     NpgsqlFactory.Instance,
                     Environment.GetEnvironmentVariable(Startup.DatabaseConnectionString));
-            });
-            services.AddTransient<IParticipantPublishSearchMetric>(b =>
-            {
-                var factory = new Mock<IParticipantPublishSearchMetric>();
-
-                factory.Setup(m => m.PublishSearchdMetric(
-                                        It.IsAny<ParticipantSearchMetrics>()))
-                       .Returns(Task.CompletedTask);
-
-                return factory.Object;
             });
             services.RegisterParticipantsServices();
             services.RegisterMatchServices();
@@ -331,7 +320,7 @@ namespace Piipan.Match.Func.Api.IntegrationTests
             Assert.Equal(resultA.Matches.First().ParticipantId, recordA.ParticipantId);
             Assert.Equal(resultB.Matches.First().ParticipantId, recordB.ParticipantId);
         }
-        
+
         [Fact]
         public async void ApiCreatesMatchRecords()
         {
@@ -362,7 +351,7 @@ namespace Piipan.Match.Func.Api.IntegrationTests
             // Arrange
             var recordA = FullRecord();
             var recordEncryptedA = EncryptedFullRecord(recordA);
-            
+
             var recordB = FullRecord();
             // lynn,1940-08-01,000-12-3457
             recordB.LdsHash = "97719c32bb3c6a5e08c1241a7435d6d7047e75f40d8b3880744c07fef9d586954f77dc93279044c662d5d379e9c8a447ce03d9619ce384a7467d322e647e5d95";

--- a/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.IntegrationTests/AddEventIntegrationTests.cs
@@ -28,7 +28,8 @@ namespace Piipan.Match.Func.ResolutionApi.IntegrationTests
         static AddEventApi Construct()
         {
             Environment.SetEnvironmentVariable("States", "ea");
-
+            Environment.SetEnvironmentVariable("EventGridMetricMatchEndPoint", "http://someendpoint.gov");
+            Environment.SetEnvironmentVariable("EventGridMetricMatchKeyString", "example");
             var services = new ServiceCollection();
             services.AddLogging();
 

--- a/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
+++ b/match/tests/Piipan.Match.Func.ResolutionApi.Tests/AddEventApiTests.cs
@@ -306,8 +306,8 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
                 .Setup(r => r.GetRecordByMatchId(It.IsAny<string>()))
                 .ReturnsAsync(new MatchRecordDbo()
                 {
-                    States = new string[] { "ea", "eb"
-                }
+                    States = new string[] { "ea", "eb" },
+                    MatchId = "foo"
                 });
             var matchResEventDao = new Mock<IMatchResEventDao>();
             var events = new List<IMatchResEvent>() {
@@ -329,7 +329,8 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
                 .Returns(new MatchResRecord()
                 {
                     Status = "open",
-                    MatchId = It.IsAny<string>()
+                    MatchId = "foo",
+                    States = new string[] { "ea", "eb" }
                 });
             var requestParser = new AddEventRequestParser(
                 new AddEventRequestValidator(),
@@ -355,7 +356,7 @@ namespace Piipan.Match.Func.ResolutionApi.Tests
             // Assert
             matchResEventDao.Verify(mock => mock.AddEvent(It.IsAny<MatchResEventDbo>()), Times.Once());
             matchResEventDao.Verify(mock => mock.AddEvent(It.Is<MatchResEventDbo>(m => m.ActorState == "ea")), Times.Once());
-            publishMatchMetrics.Verify(mock => mock.PublishMatchMetric(It.Is<ParticipantMatchMetrics>(m => m.MatchId == It.IsAny<string>())), Times.Once());
+            publishMatchMetrics.Verify(mock => mock.PublishMatchMetric(It.Is<ParticipantMatchMetrics>(m => m.MatchId == "foo")), Times.Once());
             Assert.Equal(200, response.StatusCode);
         }
 

--- a/metrics/ddl/metrics.sql
+++ b/metrics/ddl/metrics.sql
@@ -24,4 +24,29 @@ CREATE TABLE IF NOT EXISTS participant_searches(
 );
 
 COMMENT ON TABLE participant_searches IS 'Participant search event record';
+
+CREATE TABLE IF NOT EXISTS participant_matches(
+    id serial PRIMARY KEY,
+    match_id text UNIQUE NOT NULL,
+    match_created_at timestamptz NOT NULL,
+    init_state VARCHAR(50) NOT NULL,
+    init_state_invalid BOOLEAN NULL,
+    init_state_invalid_match_reason VARCHAR(250) NULL,
+    init_state_initial_action_taken  VARCHAR(250) NULL,
+    init_state_initial_action_at  timestamptz NULL,
+    init_state_final_disposition VARCHAR(250) NULL,
+    init_state_final_disposition_date timestamptz NULL,
+    init_state_vulnerable_individual BOOLEAN NULL,
+    matching_state VARCHAR(50) NOT NULL,
+    matching_state_invalid BOOLEAN NULL,
+    matching_state_invalid_match_reason VARCHAR(250) NULL,
+    matching_state_initial_action_taken  VARCHAR(250) NULL,
+    matching_state_initial_action_at  timestamptz NULL,
+    matching_state_final_disposition VARCHAR(250) NULL,
+    matching_state_final_disposition_date timestamptz NULL,
+    matching_state_vulnerable_individual BOOLEAN NULL,
+    match_status VARCHAR(50) NOT NULL
+    );
+COMMENT ON TABLE participant_matches IS 'Participant match event record for reporting purpose';
+
 COMMIT;

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/IParticipantMatchWriterApi.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/IParticipantMatchWriterApi.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Piipan.Metrics.Api
+{
+    public interface IParticipantMatchWriterApi
+    {
+        Task<int> AddMatchMetrics(ParticipantMatchMetrics participantMatch);
+        Task<int> UpdateMatchMetrics(ParticipantMatchMetrics participantMatch);
+        Task<int> PublishMatchMetrics(ParticipantMatchMetrics participantMatch);
+    }
+}

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/ParticipantMatchMetrics.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Api/ParticipantMatchMetrics.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Piipan.Metrics.Api
+{
+    public class ParticipantMatchMetrics
+    {
+        [JsonProperty("match_id")]
+        public string MatchId { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("init_state")]
+        public string InitState { get; set; }
+
+        [JsonProperty("init_state_invalid_match", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? InitStateInvalidMatch { get; set; }
+
+        [JsonProperty("init_state_invalid_match_reason")]
+        public string? InitStateInvalidMatchReason { get; set; }
+
+        [JsonProperty("init_state_initial_action_at", NullValueHandling = NullValueHandling.Ignore)]
+        public DateTime? InitStateInitialActionAt { get; set; }
+
+        [JsonProperty("init_state_initial_action_taken")]
+        public string InitStateInitialActionTaken { get; set; }
+
+        [JsonProperty("init_state_final_disposition", NullValueHandling = NullValueHandling.Ignore)]
+        public string InitStateFinalDisposition { get; set; }
+
+        [JsonProperty("init_state_final_disposition_date")]
+        public DateTime? InitStateFinalDispositionDate { get; set; }
+
+        [JsonProperty("init_state_vulnerable_individual", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? InitStateVulnerableIndividual { get; set; }
+
+        [JsonProperty("matching_state")]
+        public string MatchingState { get; set; }
+
+        [JsonProperty("matching_state_invalid_match", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? MatchingStateInvalidMatch { get; set; }
+
+        [JsonProperty("matching_state_invalid_match_reason")]
+        public string? MatchingStateInvalidMatchReason { get; set; }
+
+        [JsonProperty("matching_state_initial_action_at", NullValueHandling = NullValueHandling.Ignore)]
+        public DateTime? MatchingStateInitialActionAt { get; set; }
+
+        [JsonProperty("matching_state_initial_action_taken")]
+        public string MatchingStateInitialActionTaken { get; set; }
+
+        [JsonProperty("matching_state_final_disposition", NullValueHandling = NullValueHandling.Ignore)]
+        public string MatchingStateFinalDisposition { get; set; }
+
+        [JsonProperty("matching_state_final_disposition_date")]
+        public DateTime? MatchingStateFinalDispositionDate { get; set; }
+
+        [JsonProperty("matching_state_vulnerable_individual", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? MatchingStateVulnerableIndividual { get; set; }
+        [JsonProperty("status")]
+        public string Status { get; set; }
+    }
+}

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/DataAccessObjects/IParticipantMatchDao.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/DataAccessObjects/IParticipantMatchDao.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Piipan.Metrics.Api;
+using Piipan.Metrics.Core.Models;
+
+#nullable enable
+
+namespace Piipan.Metrics.Core.DataAccessObjects
+{
+    public interface IParticipantMatchDao
+    {
+        Task<int> AddParticipantMatchRecord(ParticipantMatchDbo newSearchDbo);
+        Task<IEnumerable<ParticipantMatchMetrics>> GetMatchMetrics(string matchId);
+        Task<IEnumerable<ParticipantMatchDbo>> GetRecords(ParticipantMatchDbo newSearchDbo);
+        Task<int> UpdateParticipantMatchRecord(ParticipantMatchDbo matchDbo);
+    }
+}

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/DataAccessObjects/ParticipantMatchDao.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/DataAccessObjects/ParticipantMatchDao.cs
@@ -1,0 +1,218 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Extensions.Logging;
+using Piipan.Metrics.Api;
+using Piipan.Metrics.Core.Models;
+using Piipan.Shared.Database;
+
+namespace Piipan.Metrics.Core.DataAccessObjects
+{
+    /// <summary>
+    /// Data access object for Participant Search records in Metrics database
+    /// </summary>
+    public class ParticipantMatchDao : IParticipantMatchDao
+    {
+        private readonly IDbConnectionFactory<MetricsDb> _dbConnectionFactory;
+        private readonly ILogger<ParticipantMatchDao> _logger;
+
+        public ParticipantMatchDao(
+            IDbConnectionFactory<MetricsDb> dbConnectionFactory,
+            ILogger<ParticipantMatchDao> logger)
+        {
+            _dbConnectionFactory = dbConnectionFactory;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Adds a new Participant Match record to the Metrics database.
+        /// </summary>
+        /// <param name="newSearchDbo">The ParticipantMatchDbo object that will be added to the database.</param>
+        /// <returns>Number of rows affected</returns>
+        public async Task<int> AddParticipantMatchRecord(ParticipantMatchDbo newSearchDbo)
+        {
+            using (var connection = await _dbConnectionFactory.Build())
+            {
+                return await connection.ExecuteAsync(@"
+                    INSERT INTO participant_matches(
+	                    match_id,
+                        match_created_at,
+                        init_state,
+                        init_state_invalid,
+                        init_state_invalid_match_reason,
+                        init_state_initial_action_taken,
+                        init_state_initial_action_at,
+                        init_state_final_disposition,
+                        init_state_final_disposition_date,
+                        init_state_vulnerable_individual,
+                        matching_state,
+                        matching_state_invalid,
+                        matching_state_invalid_match_reason,
+                        matching_state_initial_action_taken,
+                        matching_state_initial_action_at,
+                        matching_state_final_disposition,
+                        matching_state_final_disposition_date,
+                        matching_state_vulnerable_individual,
+                        match_status
+                    )
+                    VALUES
+                    (
+                        @MatchId,
+                        now() at time zone 'utc',
+                        @InitState,
+                        @InitStateInvalidMatch,
+                        @InitStateInvalidMatchReason,
+                        @InitStateInitialActionTaken,
+                        @InitStateInitialActionAt,
+                        @InitStateFinalDisposition,
+                        @InitStateFinalDispositionDate,
+                        @InitStateVulnerableIndividual,
+                        @MatchingState,
+                        @MatchingStateInvalidMatch,
+                        @MatchingStateInvalidMatchReason,
+                        @MatchingStateInitialActionTaken,
+                        @MatchingStateInitialActionAt,
+                        @MatchingStateFinalDisposition,
+                        @MatchingStateFinalDispositionDate,
+                        @MatchingStateVulnerableIndividual,
+                        @Status
+                    );",
+                    new
+                    {
+                        MatchId = newSearchDbo.MatchId,
+                        CreatedAt = newSearchDbo.CreatedAt,
+                        InitState = newSearchDbo.InitState,
+                        InitStateInvalidMatch = newSearchDbo.InitStateInvalidMatch,
+                        InitStateInvalidMatchReason = newSearchDbo.InitStateInvalidMatchReason,
+                        InitStateInitialActionAt = newSearchDbo.InitStateInitialActionAt?.ToUniversalTime(),
+                        InitStateInitialActionTaken = newSearchDbo.InitStateInitialActionTaken,
+                        InitStateFinalDisposition = newSearchDbo.InitStateFinalDisposition,
+                        InitStateFinalDispositionDate = newSearchDbo.InitStateFinalDispositionDate,
+                        InitStateVulnerableIndividual = newSearchDbo.InitStateVulnerableIndividual,
+                        MatchingState = newSearchDbo.MatchingState,
+                        MatchingStateInvalidMatch = newSearchDbo.MatchingStateInvalidMatch,
+                        MatchingStateInvalidMatchReason = newSearchDbo.MatchingStateInvalidMatchReason,
+                        MatchingStateInitialActionAt = newSearchDbo.MatchingStateInitialActionAt?.ToUniversalTime(),
+                        MatchingStateInitialActionTaken = newSearchDbo.MatchingStateInitialActionTaken,
+                        MatchingStateFinalDisposition = newSearchDbo.MatchingStateFinalDisposition,
+                        MatchingStateFinalDispositionDate = newSearchDbo.MatchingStateFinalDispositionDate,
+                        MatchingStateVulnerableIndividual = newSearchDbo.MatchingStateVulnerableIndividual,
+                        Status = newSearchDbo.Status
+                    });
+            }
+        }
+
+        /// <summary>
+        /// Update  Participant Match record in Metrics.
+        /// </summary>
+        /// <param name="matchDbo">The ParticipantMatchDbo object that will be added to the database.</param>
+        /// <returns>Number of rows affected</returns>
+        public async Task<int> UpdateParticipantMatchRecord(ParticipantMatchDbo matchDbo)
+        {
+            using (var connection = await _dbConnectionFactory.Build())
+            {
+                return await connection.ExecuteAsync(@"
+                    UPDATE participant_matches
+                    SET  	
+                        match_created_at= @CreatedAt,
+                        init_state= @InitState,
+                        init_state_invalid= @InitStateInvalidMatch,
+                        init_state_invalid_match_reason=@InitStateInvalidMatchReason,
+                        init_state_initial_action_taken=@InitStateInitialActionTaken,
+                        init_state_initial_action_at= @InitStateInitialActionAt,
+                        init_state_final_disposition= @InitStateFinalDisposition,
+                        init_state_final_disposition_date=@InitStateFinalDispositionDate,
+                        init_state_vulnerable_individual= @InitStateVulnerableIndividual,
+                        matching_state= @MatchingState,
+                        matching_state_invalid= @MatchingStateInvalidMatch,
+                        matching_state_invalid_match_reason=@MatchingStateInvalidMatchReason,
+                        matching_state_initial_action_taken=@MatchingStateInitialActionTaken,
+                        matching_state_initial_action_at= @MatchingStateInitialActionAt,
+                        matching_state_final_disposition= @MatchingStateFinalDisposition,
+                        matching_state_final_disposition_date=@MatchingStateFinalDispositionDate,
+                        matching_state_vulnerable_individual= @MatchingStateVulnerableIndividual,
+                        match_status= @Status
+                    WHERE match_id= @MatchId;
+                    ",
+                    new
+                    {
+                        MatchId = matchDbo.MatchId,
+                        CreatedAt = matchDbo.CreatedAt,
+                        InitState = matchDbo.InitState,
+                        InitStateInvalidMatch = matchDbo.InitStateInvalidMatch,
+                        InitStateInvalidMatchReason = matchDbo.InitStateInvalidMatchReason,
+                        InitStateInitialActionAt = matchDbo.InitStateInitialActionAt?.ToUniversalTime(),
+                        InitStateInitialActionTaken = matchDbo.InitStateInitialActionTaken,
+                        InitStateFinalDisposition = matchDbo.InitStateFinalDisposition,
+                        InitStateFinalDispositionDate = matchDbo.InitStateFinalDispositionDate,
+                        InitStateVulnerableIndividual = matchDbo.InitStateVulnerableIndividual,
+                        MatchingState = matchDbo.MatchingState,
+                        MatchingStateInvalidMatch = matchDbo.MatchingStateInvalidMatch,
+                        MatchingStateInvalidMatchReason = matchDbo.MatchingStateInvalidMatchReason,
+                        MatchingStateInitialActionAt = matchDbo.MatchingStateInitialActionAt?.ToUniversalTime(),
+                        MatchingStateInitialActionTaken = matchDbo.MatchingStateInitialActionTaken,
+                        MatchingStateFinalDisposition = matchDbo.MatchingStateFinalDisposition,
+                        MatchingStateFinalDispositionDate = matchDbo.MatchingStateFinalDispositionDate,
+                        MatchingStateVulnerableIndividual = matchDbo.MatchingStateVulnerableIndividual,
+                        Status = matchDbo.Status
+                    });
+            }
+        }
+
+        /// <summary>
+        /// Search for any exisiting match records in the Metrics database.
+        /// </summary>
+        /// <param name="newSearchDbo">The ParticipantMatchDbo object that will be searched in the database.</param>
+        /// <returns>Number of rows affected</returns>
+        ///
+        public async Task<IEnumerable<ParticipantMatchDbo>> GetRecords(ParticipantMatchDbo newSearchDbo)
+        {
+            const string sql = @"
+                 SELECT
+	                    match_id
+                FROM
+                    participant_matches
+                WHERE
+                    match_id = @MatchId;";
+
+            using (var connection = await _dbConnectionFactory.Build())
+            {
+                return await connection.QueryAsync<ParticipantMatchDbo>(sql, newSearchDbo);
+            }
+        }
+        public async Task<IEnumerable<ParticipantMatchMetrics>> GetMatchMetrics(string matchId)
+        {
+            var sql = @"
+                    SELECT
+                        match_id,
+                        match_created_at,
+                        init_state,
+                        init_state_invalid,
+                        init_state_invalid_match_reason,
+                        init_state_initial_action_taken,
+                        init_state_initial_action_at,
+                        init_state_final_disposition,
+                        init_state_final_disposition_date,
+                        init_state_vulnerable_individual,
+                        matching_state,
+                        matching_state_invalid,
+                        matching_state_invalid_match_reason,
+                        matching_state_initial_action_taken,
+                        matching_state_initial_action_at,
+                        matching_state_final_disposition,
+                        matching_state_final_disposition_date,
+                        matching_state_vulnerable_individual,
+                        match_status
+                 FROM
+                    participant_matches
+                 WHERE
+                    match_id = @MatchId;";
+
+            using (var connection = await _dbConnectionFactory.Build())
+            {
+                return await connection
+                    .QueryAsync<ParticipantMatchMetrics>(sql, new { MatchId = matchId });
+            }
+        }
+    }
+}

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/Extensions/ServiceCollectionExtensions.cs
@@ -12,9 +12,11 @@ namespace Piipan.Metrics.Core.Extensions
         {
             serviceCollection.AddTransient<IParticipantUploadDao, ParticipantUploadDao>();
             serviceCollection.AddTransient<IParticipantSearchDao, ParticipantSearchDao>();
+            serviceCollection.AddTransient<IParticipantMatchDao, ParticipantMatchDao>();
             serviceCollection.AddTransient<IParticipantUploadReaderApi, ParticipantUploadService>();
             serviceCollection.AddTransient<IParticipantUploadWriterApi, ParticipantUploadService>();
             serviceCollection.AddTransient<IParticipantSearchWriterApi, ParticipantSearchService>();
+            serviceCollection.AddTransient<IParticipantMatchWriterApi, ParticipantMatchService>();
             serviceCollection.AddTransient<IMetaBuilder, MetaBuilder>();
         }
     }

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/Models/ParticipantMatchDbo.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/Models/ParticipantMatchDbo.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Piipan.Metrics.Api;
+
+namespace Piipan.Metrics.Core.Models
+{
+    /// <summary>
+    /// Implementation of ParticipantSearch record for Metrics database interactions
+    /// </summary>
+    public class ParticipantMatchDbo
+    {
+        public string MatchId { get; set; }
+
+        public DateTime? CreatedAt { get; set; }
+
+        public string InitState { get; set; }
+
+        public bool? InitStateInvalidMatch { get; set; }
+
+        public string? InitStateInvalidMatchReason { get; set; }
+
+        public DateTime? InitStateInitialActionAt { get; set; }
+
+        public string InitStateInitialActionTaken { get; set; }
+
+        public string InitStateFinalDisposition { get; set; }
+
+        public DateTime? InitStateFinalDispositionDate { get; set; }
+
+        public bool? InitStateVulnerableIndividual { get; set; }
+
+        public string MatchingState { get; set; }
+
+        public bool? MatchingStateInvalidMatch { get; set; }
+
+        public string? MatchingStateInvalidMatchReason { get; set; }
+
+        public DateTime? MatchingStateInitialActionAt { get; set; }
+
+        public string MatchingStateInitialActionTaken { get; set; }
+
+        public string MatchingStateFinalDisposition { get; set; }
+
+        public DateTime? MatchingStateFinalDispositionDate { get; set; }
+
+        public bool? MatchingStateVulnerableIndividual { get; set; }
+
+        public string Status { get; set; }//= MatchRecordStatus.Open;
+
+        public ParticipantMatchDbo()
+        {
+        }
+
+        public ParticipantMatchDbo(ParticipantMatchMetrics match)
+        {
+            MatchId = match.MatchId;
+            CreatedAt = match.CreatedAt;
+            InitState = match.InitState;
+            InitStateInvalidMatch = match.InitStateInvalidMatch;
+            InitStateInvalidMatchReason = match.InitStateInvalidMatchReason;
+            InitStateInitialActionAt = match.InitStateInitialActionAt;
+            InitStateInitialActionTaken = match.InitStateInitialActionTaken;
+            InitStateFinalDisposition = match.InitStateFinalDisposition;
+            InitStateFinalDispositionDate = match.InitStateFinalDispositionDate;
+            InitStateVulnerableIndividual = match.InitStateVulnerableIndividual;
+            MatchingState = match.MatchingState;
+            MatchingStateInvalidMatch = match.MatchingStateInvalidMatch;
+            MatchingStateInvalidMatchReason = match.MatchingStateInvalidMatchReason;
+            MatchingStateInitialActionAt = match.MatchingStateInitialActionAt;
+            MatchingStateInitialActionTaken = match.MatchingStateInitialActionTaken;
+            MatchingStateFinalDisposition = match.MatchingStateFinalDisposition;
+            MatchingStateFinalDispositionDate = match.MatchingStateFinalDispositionDate;
+            MatchingStateVulnerableIndividual = match.MatchingStateVulnerableIndividual;
+            Status = match.Status;
+        }
+    }
+}

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/Services/ParticipantMatchService.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Core/Services/ParticipantMatchService.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Piipan.Metrics.Api;
+using Piipan.Metrics.Core.Builders;
+using Piipan.Metrics.Core.DataAccessObjects;
+using Piipan.Metrics.Core.Models;
+
+#nullable enable
+
+namespace Piipan.Metrics.Core.Services
+{
+    /// <summary>
+    /// Service layer for creating, retrieving, updating Metrics MatchParticipant records
+    /// </summary>
+    public class ParticipantMatchService : IParticipantMatchWriterApi
+    {
+        private readonly IParticipantMatchDao _participantMatchDao;
+        private readonly IMetaBuilder _metaBuilder;
+
+        public ParticipantMatchService(IParticipantMatchDao participantMatchDao, IMetaBuilder metaBuilder)
+        {
+            _participantMatchDao = participantMatchDao;
+            _metaBuilder = metaBuilder;
+        }
+
+
+        public async Task<int> AddMatchMetrics(ParticipantMatchMetrics participantMatch)
+        {
+            return await _participantMatchDao.AddParticipantMatchRecord(new ParticipantMatchDbo(participantMatch));
+        }
+        public async Task<int> UpdateMatchMetrics(ParticipantMatchMetrics participantMatch)
+        {
+            return await _participantMatchDao.UpdateParticipantMatchRecord(new ParticipantMatchDbo(participantMatch));
+        }
+        public async Task<int> PublishMatchMetrics(ParticipantMatchMetrics participantMatch)
+        {
+            // Check if the Match is already existing, if not create a new Match in the metrics
+            var particpantMatchDbo = new ParticipantMatchDbo(participantMatch);
+            var existingRecords = await _participantMatchDao.GetMatchMetrics(particpantMatchDbo.MatchId);
+            if (existingRecords.Any())
+            {
+                return await _participantMatchDao.UpdateParticipantMatchRecord(new ParticipantMatchDbo(participantMatch));
+            }
+            else
+            {
+                return await _participantMatchDao.AddParticipantMatchRecord(particpantMatchDbo);
+            }
+        }
+    }
+}

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/PublishMatchMetrics.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/PublishMatchMetrics.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure.Messaging.EventGrid;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Piipan.Metrics.Api;
+
+namespace Piipan.Metrics.Func.Collect
+{
+    public class PublishMatchMetrics
+    {
+        private readonly IParticipantMatchWriterApi _participantMatchWriterApi;
+
+        public PublishMatchMetrics(IParticipantMatchWriterApi participantSearchWriterApi)
+        {
+            _participantMatchWriterApi = participantSearchWriterApi;
+        }
+
+        /// <summary>
+        /// Listens for Find_Matches events when users searche participants;
+        /// write meta info to Metrics database for any New Match
+        /// </summary>
+        /// <param name="eventGridEvent">storage container blob creation event</param>
+        /// <param name="log">handle to the function log</param>
+
+        [FunctionName("PublishMatchMetrics")]
+        public async Task Run(
+            [EventGridTrigger] EventGridEvent eventGridEvent,
+            ILogger log)
+        {
+            log.LogInformation(eventGridEvent.Data.ToString());
+            try
+            {
+                ParticipantMatchMetrics newParticipantSearch = JsonConvert.DeserializeObject<ParticipantMatchMetrics>(eventGridEvent.Data.ToString());
+                //  CheckParticipantSearch(newParticipantSearch);
+                log.LogInformation(newParticipantSearch.MatchId);
+                int nRows = await _participantMatchWriterApi.PublishMatchMetrics(newParticipantSearch);
+
+                log.LogInformation(String.Format("Number of rows inserted={0}", nRows));
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex.Message);
+                throw;
+            }
+        }
+
+        private void CheckParticipantSearch(ParticipantSearch metric)
+        {
+            if (metric.State == null)
+                throw new ArgumentException("Error with ParticipantSearch");
+        }
+    }
+}

--- a/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/UpdateMatchMetrics.cs
+++ b/metrics/src/Piipan.Metrics/Piipan.Metrics.Func.Collect/UpdateMatchMetrics.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure.Messaging.EventGrid;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Piipan.Metrics.Api;
+
+namespace Piipan.Metrics.Func.Collect
+{
+    public class UpdateMatchMetrics
+    {
+        private readonly IParticipantMatchWriterApi _participantMatchWriterApi;
+
+        public UpdateMatchMetrics(IParticipantMatchWriterApi participantSearchWriterApi)
+        {
+            _participantMatchWriterApi = participantSearchWriterApi;
+        }
+        /// <summary>
+        /// Listens for Find_Matches events when users searche participants;
+        /// updates meta info to Metrics database for the match.
+        /// </summary>
+        /// <param name="eventGridEvent">storage container blob creation event</param>
+        /// <param name="log">handle to the function log</param>
+
+        [FunctionName("UpdateMatchMetrics")]
+        public async Task Run(
+            [EventGridTrigger] EventGridEvent eventGridEvent,
+            ILogger log)
+        {
+            log.LogInformation(eventGridEvent.Data.ToString());
+            try
+            {
+                ParticipantMatchMetrics newParticipantSearch = JsonConvert.DeserializeObject<ParticipantMatchMetrics>(eventGridEvent.Data.ToString());
+                //  CheckParticipantSearch(newParticipantSearch);
+                int nRows = await _participantMatchWriterApi.UpdateMatchMetrics(newParticipantSearch);
+
+                log.LogInformation(String.Format("Number of rows updated={0}", nRows));
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex.Message);
+                throw;
+            }
+        }
+        private void CheckParticipantSearch(ParticipantSearch metric)
+        {
+            if (metric.State == null)
+                throw new ArgumentException("Error with ParticipantSearch");
+        }
+    }
+}

--- a/metrics/tests/Piipan.Metrics.Core.IntegrationTests/MetricsCommonDaoTests.cs
+++ b/metrics/tests/Piipan.Metrics.Core.IntegrationTests/MetricsCommonDaoTests.cs
@@ -1,17 +1,17 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Moq;
-using Piipan.Shared.Database;
-using Piipan.Metrics.Core.DataAccessObjects;
-using Xunit;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Piipan.Metrics.Core.DataAccessObjects;
 using Piipan.Metrics.Core.Models;
 using Piipan.Participants.Core.Enums;
+using Piipan.Shared.Database;
+using Xunit;
 
 namespace Piipan.Metrics.Core.IntegrationTests
 {
-    
+
 
     public class MetricsCommonDaoTests : DbFixture
     {
@@ -114,7 +114,7 @@ namespace Piipan.Metrics.Core.IntegrationTests
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
-        [InlineData(50)]        
+        [InlineData(50)]
         public async Task GetUploads_LimitingWorks(int limit)
         {
             // Arrange
@@ -131,11 +131,11 @@ namespace Piipan.Metrics.Core.IntegrationTests
             // Assert
             Assert.Equal(limit, eaUploads.Count());
         }
-        
+
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
-        [InlineData(50)]        
+        [InlineData(50)]
         public async Task GetUploads_OffsettingWorks(int offset)
         {
             // Arrange
@@ -194,13 +194,13 @@ namespace Piipan.Metrics.Core.IntegrationTests
             Assert.Equal(0, uploadCount);
 
             // Act
-            await dao.AddUpload(new ParticipantUploadDbo() { State = "ea", UploadedAt = uploadedAt, Status=UploadStatuses.UPLOADING.ToString()});
+            await dao.AddUpload(new ParticipantUploadDbo() { State = "ea", UploadedAt = uploadedAt, Status = UploadStatuses.UPLOADING.ToString() });
             var results = await dao.GetUploads("ea", 10);
 
             // Assert
             uploadCount = await dao.GetUploadCount("ea");
             Assert.Equal(1, uploadCount);
-            
+
             Assert.Equal(uploadedAt, results.ToList()[0].UploadedAt);
         }
 
@@ -221,7 +221,7 @@ namespace Piipan.Metrics.Core.IntegrationTests
             Assert.Null(results.ToList()[0].CompletedAt);
 
             // Act
-            await dao.UpdateUpload(new ParticipantUploadDbo() { State = "ea", UploadedAt = uploadedAt, CompletedAt=completedAt, Status = UploadStatuses.COMPLETE.ToString(), UploadIdentifier = upload_id });
+            await dao.UpdateUpload(new ParticipantUploadDbo() { State = "ea", UploadedAt = uploadedAt, CompletedAt = completedAt, Status = UploadStatuses.COMPLETE.ToString(), UploadIdentifier = upload_id });
 
             // Assert
             uploadCount = await dao.GetUploadCount("ea");
@@ -246,6 +246,44 @@ namespace Piipan.Metrics.Core.IntegrationTests
                 SearchedAt = DateTime.UtcNow
             });
             Assert.Equal(1, numberOfRows);
+        }
+        [Fact]
+        public async Task ParticipantMatch_InsertsRecord()
+        {
+            // Arrange
+            var dao = new ParticipantMatchDao(DbConnFactory(), new NullLogger<ParticipantMatchDao>());
+            // Act
+            var numberOfRows = await dao.AddParticipantMatchRecord(new ParticipantMatchDbo()
+            {
+                MatchId = "foo",
+                InitState = "ea",
+                MatchingState = "ec"
+            });
+            Assert.Equal(1, numberOfRows);
+        }
+        [Fact]
+        public async Task ParticipantMatch_UpdateRecord()
+        {
+            // Arrange
+            var dao = new ParticipantMatchDao(DbConnFactory(), new NullLogger<ParticipantMatchDao>());
+            ParticipantMatchDbo participantMatchDbo = new ParticipantMatchDbo()
+            {
+                MatchId = "foo",
+                InitState = "ea",
+                MatchingState = "ec"
+            };
+            var numberOfRows = await dao.AddParticipantMatchRecord(participantMatchDbo);
+
+            participantMatchDbo.MatchingStateFinalDisposition = "MSFinalDisposition";
+            participantMatchDbo.InitStateFinalDisposition = "ISFinalDisposition";
+            var numberOfRowsUPdated = await dao.UpdateParticipantMatchRecord(participantMatchDbo);
+
+            var results = await dao.GetMatchMetrics(participantMatchDbo.MatchId);
+
+            Assert.Equal(participantMatchDbo.MatchingStateFinalDisposition, results.ToList()[0].MatchingStateFinalDisposition);
+            Assert.Equal(participantMatchDbo.InitStateFinalDisposition, results.ToList()[0].InitStateFinalDisposition);
+
+            Assert.Equal(1, numberOfRowsUPdated);
         }
     }
 }

--- a/metrics/tests/Piipan.Metrics.Core.IntegrationTests/MetricsCommonDaoTests.cs
+++ b/metrics/tests/Piipan.Metrics.Core.IntegrationTests/MetricsCommonDaoTests.cs
@@ -257,7 +257,8 @@ namespace Piipan.Metrics.Core.IntegrationTests
             {
                 MatchId = "foo",
                 InitState = "ea",
-                MatchingState = "ec"
+                MatchingState = "ec",
+                Status = "open"
             });
             Assert.Equal(1, numberOfRows);
         }
@@ -270,7 +271,8 @@ namespace Piipan.Metrics.Core.IntegrationTests
             {
                 MatchId = "foo",
                 InitState = "ea",
-                MatchingState = "ec"
+                MatchingState = "ec",
+                Status = "open"
             };
             var numberOfRows = await dao.AddParticipantMatchRecord(participantMatchDbo);
 

--- a/metrics/tests/Piipan.Metrics.Core.IntegrationTests/PublishMatchMetricsTests.cs
+++ b/metrics/tests/Piipan.Metrics.Core.IntegrationTests/PublishMatchMetricsTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading.Tasks;
+using Azure.Messaging.EventGrid;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Piipan.Metrics.Api;
+using Piipan.Metrics.Func.Collect;
+using Xunit;
+
+
+namespace Piipan.Metrics.Core.IntegrationTests
+{
+    public class PublishMatchMetricsTests
+    {
+
+        private EventGridEvent MockEvent(DateTime eventTime, string State)
+        {
+
+            var gridEvent = new Mock<EventGridEvent>("", "", "", new BinaryData(new
+            {
+                State = "ea",
+                search_reason = It.IsAny<string>(),
+                search_from = It.IsAny<string>(),
+                match_creation = It.IsAny<string>(),
+                match_count = It.IsAny<int>(),
+                searched_at = eventTime
+            }));
+            gridEvent.Object.EventTime = eventTime;
+            return gridEvent.Object;
+
+        }
+
+        private EventGridEvent MockBadEvent(DateTime eventTime, string State)
+        {
+
+            var gridEvent = new Mock<EventGridEvent>("", "", "", new BinaryData(new
+            {
+                example = "123"
+            }));
+            gridEvent.Object.EventTime = eventTime;
+            return gridEvent.Object;
+
+        }
+
+
+        [Fact]
+        public async Task Run_DB_Success()
+        {
+            // Arrange
+            var now = DateTime.Now;
+            var logger = new Mock<ILogger>();
+
+            var searchMetricsApi = new Mock<IParticipantSearchWriterApi>();
+            searchMetricsApi
+                .Setup(m => m.AddSearchMetrics(
+                    It.IsAny<ParticipantSearch>()))
+                .ReturnsAsync(1);
+
+            var function = new CreateSearchMetrics(searchMetricsApi.Object);
+
+            // Act
+            await function.Run(MockEvent(now, "ea"), logger.Object);
+
+            // Assert
+            searchMetricsApi.Verify(m => m.AddSearchMetrics(It.IsAny<ParticipantSearch>()), Times.Once);
+            logger.Verify(x => x.Log(
+                It.Is<LogLevel>(l => l == LogLevel.Information),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString() == "Number of rows inserted=1"),
+                It.IsAny<Exception>(),
+                It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)
+            ));
+        }
+
+
+
+        [Fact]
+        public async Task Run_DB_BadParticipantUpload()
+        {
+            var now = DateTime.Now;
+            var logger = new Mock<ILogger>();
+
+            var searchMetricsApi = new Mock<IParticipantSearchWriterApi>();
+            searchMetricsApi
+                .Setup(m => m.AddSearchMetrics(
+                    It.IsAny<ParticipantSearch>()))
+                .ReturnsAsync(1);
+
+            var function = new CreateSearchMetrics(searchMetricsApi.Object);
+
+
+            // Act //Assert
+            await Assert.ThrowsAsync<System.ArgumentException>(() => function.Run(MockBadEvent(now, null), logger.Object));
+
+        }
+
+    }
+}


### PR DESCRIPTION
## What’s changing?

Capture information on all matches and related resolution events in Metrics database.

## Why?
@nac-995

To feed the Match data for future analyze.

## This PR has:

- [ x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [x ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
IAC changes are captured in another PR.
