### PR TITLE
Add required participant_id field to match API test script

### DIFF
--- a/match/tools/test-apim-match-api.bash
+++ b/match/tools/test-apim-match-api.bash
@@ -19,6 +19,7 @@ MATCH_API_PATH="/match/v2/find_matches"
 JSON='{
     "data": [{
       "lds_hash": "a3cab51dd68da2ac3e5508c8b0ee514ada03b9f166f7035b4ac26d9c56aa7bf9d6271e44c0064337a01b558ff63fd282de14eead7e8d5a613898b700589bcdec",
+      "participant_id": "participant1",
       "search_reason": "application"
     }]
 }'


### PR DESCRIPTION
## What’s changing?

Adds required `participant_id` field to request body in `test-apim-match-api.bash`. Verify changes by running: `./match/tools/test-apim-match-api.bash <env>`.

## Why?

NAC-1047; Smoke test does not function as intended without the required field.

## This PR has:

- [ ] ~**Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)~
- [ ] ~**Developer documentation** (_for new build/test/API changes or complex portions of the system_)~
- [ ] ~**Automated unit tests** (_to maintain or increase level of code coverage_)~
- [ ] ~**Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)~
