### PR TITLE
Fixing a couple permission-based bugs

### DIFF
--- a/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/MatchDetailWrapper.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/MatchDetail/MatchDetailWrapper.razor
@@ -21,6 +21,6 @@
     </div>
 }
 else {
-    <MatchDetail Match="Match" StateInfo="StateInfo" LoggedInUsersState="LoggedInUsersState" Token="Token"
-        MatchDetailInfo="MatchDetailInfo" ServerErrors="ServerErrors" Role="Role" RequiredRolesToEdit="RequiredRolesToEdit" />
+    <MatchDetail Match="Match" StateInfo="StateInfo" LoggedInUsersState="@LoggedInUsersState" Token="@Token"
+        MatchDetailInfo="MatchDetailInfo" ServerErrors="ServerErrors" Role="@Role" RequiredRolesToEdit="RequiredRolesToEdit" />
 }

--- a/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
+++ b/query-tool/src/Piipan.QueryTool.Client/Components/QueryForm.razor
@@ -49,7 +49,7 @@
 {
     <GenericUnauthorizedBanner style="margin-bottom: 2rem;" />    
 }
-<div id="snap-participants-query-form-wrapper" class="@(AppData.IsAuthorized ? "" : "disabled-area")" inert>
+<div id="snap-participants-query-form-wrapper" class="@(AppData.IsAuthorized ? "" : "disabled-area")" inert="@(!AppData.IsAuthorized)">
     <p style="margin-bottom: 0;"><span class="usa-required">*</span> indicates a required field</p>
     @if (NoResults && showNoResultsAlert)
     {

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/MatchDetailWrapperTests.razor
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/MatchDetail/MatchDetailWrapperTests.razor
@@ -126,7 +126,8 @@
             },
             Role = "Worker",
             RequiredRolesToEdit = new string[] { "Worker" },
-            MatchDetailInfo = new MatchDetailData() { ReferralPage = MatchDetailReferralPage.Self }
+            MatchDetailInfo = new MatchDetailData() { ReferralPage = MatchDetailReferralPage.Self },
+            LoggedInUsersState = "Echo Bravo"
         };
     }
 
@@ -142,10 +143,10 @@
             JSInterop.SetupVoid("piipan.utilities.scrollToElement", _ => true).SetVoidResult();
         Component = Render<MatchDetailWrapper>(
             @<MatchDetailWrapper Match="InitialValues.Match" ServerErrors="InitialValues.ServerErrors" MatchDetailInfo="InitialValues.MatchDetailInfo"
-                StateInfo="InitialValues.StateInfo" LoggedInUsersState="Echo Bravo"
+                StateInfo="InitialValues.StateInfo" LoggedInUsersState="@InitialValues.LoggedInUsersState"
                 Role="@InitialValues.Role" RequiredRolesToEdit="@InitialValues.RequiredRolesToEdit">
-            </MatchDetailWrapper>
-        );
+        </MatchDetailWrapper>
+    );
         usaForm = Component.HasComponent<UsaForm>() ? Component.FindComponent<UsaForm>() : null;
     }
 
@@ -180,6 +181,27 @@
         // Assert
         Assert.True(Component.HasComponent<MatchDetail>());
         Assert.False(Component.HasComponent<MatchUnauthorizedBanner>());
+    }
+
+    /// <summary>
+    /// Verify values are passed correctly to MatchDetail component
+    /// </summary>
+    [Fact]
+    public void MatchDetail_Parameters_AreCorrect()
+    {
+        // Arrange
+        CreateTestComponent();
+
+        // Assert
+        var matchDetail = Component.FindComponent<MatchDetail>();
+        Assert.Equal(matchDetail.Instance.LoggedInUsersState, InitialValues.LoggedInUsersState);
+        Assert.Equal(matchDetail.Instance.Match, InitialValues.Match);
+        Assert.Equal(matchDetail.Instance.MatchDetailInfo, InitialValues.MatchDetailInfo);
+        Assert.Equal(matchDetail.Instance.RequiredRolesToEdit, InitialValues.RequiredRolesToEdit);
+        Assert.Equal(matchDetail.Instance.Role, InitialValues.Role);
+        Assert.Equal(matchDetail.Instance.ServerErrors, InitialValues.ServerErrors);
+        Assert.Equal(matchDetail.Instance.StateInfo, InitialValues.StateInfo);
+        Assert.Equal(matchDetail.Instance.Token, InitialValues.Token);        
     }
 
     #endregion

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
@@ -293,6 +293,24 @@ namespace Piipan.QueryTool.Tests.Components
         /// Verify that when you don't have a state location that the button is disabled
         /// </summary>
         [Fact]
+        public void Form_Should_Be_Enabled_When_Authorized()
+        {
+            // Arrange
+            AppData.IsAuthorized = true;
+            CreateTestComponent();
+
+            // Assert
+            Assert.True(Component.HasComponent<GenericUnauthorizedBanner>());
+
+            var wrapper = Component.Find("#snap-participants-query-form-wrapper");
+            Assert.False(wrapper.ClassList.Contains("disabled-area"));
+            Assert.False(wrapper.HasAttribute("inert")); // Inert makes it so the fields cannot be entered
+        }
+
+        /// <summary>
+        /// Verify that when you don't have a state location that the button is disabled
+        /// </summary>
+        [Fact]
         public void Form_Should_Be_Disabled_When_Not_Authorized()
         {
             // Arrange

--- a/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
+++ b/query-tool/tests/Piipan.QueryTool.Tests/Components/QueryFormTests.cs
@@ -290,7 +290,7 @@ namespace Piipan.QueryTool.Tests.Components
         }
 
         /// <summary>
-        /// Verify that when you don't have a state location that the button is disabled
+        /// Verify that when you have authorization the form should not be disabled
         /// </summary>
         [Fact]
         public void Form_Should_Be_Enabled_When_Authorized()
@@ -300,7 +300,7 @@ namespace Piipan.QueryTool.Tests.Components
             CreateTestComponent();
 
             // Assert
-            Assert.True(Component.HasComponent<GenericUnauthorizedBanner>());
+            Assert.False(Component.HasComponent<GenericUnauthorizedBanner>());
 
             var wrapper = Component.Find("#snap-participants-query-form-wrapper");
             Assert.False(wrapper.ClassList.Contains("disabled-area"));


### PR DESCRIPTION
## What’s changing?

Due to the Unauthorized Banner PR (https://github.com/18F/piipan/pull/3663), a couple of bugs were introduced for users that did have correct permissions. While the focus was hiding/disabling things for users without permissions, sufficient unit tests and manual testing was not done for users that had permissions. @kcherukupalli found these errors during his development, and these fixes should take care of them. Unit tests added as well for these scenarios.

## Why?

Fixes bugs introduced as part of https://github.com/18F/piipan/pull/3663

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
