### PR TITLE
Write replacement for xxd

### DIFF
--- a/iac/configure-encryption-secrets.bash
+++ b/iac/configure-encryption-secrets.bash
@@ -53,14 +53,14 @@ main () {
 
     echo "Generate Column Encryption Key"
     columnKey=$(openssl enc -aes-256-cbc -k secret -P -md sha512 -pbkdf2 | sed -n 's/^key=\(.*\)/\1/p')
-    BASE64COLUMNKEY=$(../tools/hexToBase64Converter.py "${columnKey}")
+    BASE64COLUMNKEY=$(python ../tools/hexToBase64Converter.py "${columnKey}")
     create_kv_secret "${COLUMN_ENCRYPT_KEY_KV}" "${BASE64COLUMNKEY}"
 
     echo "Generate Payload Encryption Keys"
     payloadKey=$(openssl enc -aes-256-cbc -k secret -P -md sha512 -pbkdf2 | sed -n 's/^key=\(.*\)/\1/p')
-    BASE64UPLOADKEY=$(../tools/hexToBase64Converter.py "${payloadKey}")
-    shaOfPayloadKey=$(../tools/sha256Calculator.py "${payloadKey}")
-    BASE64UPLOADSHAKEY=$(../tools/hexToBase64Converter.py "${shaOfPayloadKey}")
+    BASE64UPLOADKEY=$(python ../tools/hexToBase64Converter.py "${payloadKey}")
+    shaOfPayloadKey=$(python ../tools/sha256Calculator.py "${payloadKey}")
+    BASE64UPLOADSHAKEY=$(python ../tools/hexToBase64Converter.py "${shaOfPayloadKey}")
     create_kv_secret "${UPLOAD_ENCRYPT_KEY_KV}" "${BASE64UPLOADKEY}"
     create_kv_secret "${UPLOAD_ENCRYPT_KEY_SHA_KV}" "${BASE64UPLOADSHAKEY}"
 }

--- a/iac/configure-encryption-secrets.bash
+++ b/iac/configure-encryption-secrets.bash
@@ -53,14 +53,14 @@ main () {
 
     echo "Generate Column Encryption Key"
     columnKey=$(openssl enc -aes-256-cbc -k secret -P -md sha512 -pbkdf2 | sed -n 's/^key=\(.*\)/\1/p')
-    BASE64COLUMNKEY=$(echo "${columnKey}" | xxd -r -p | base64)
+    BASE64COLUMNKEY=$(../tools/hexToBase64Converter.py "${columnKey}")
     create_kv_secret "${COLUMN_ENCRYPT_KEY_KV}" "${BASE64COLUMNKEY}"
 
     echo "Generate Payload Encryption Keys"
     payloadKey=$(openssl enc -aes-256-cbc -k secret -P -md sha512 -pbkdf2 | sed -n 's/^key=\(.*\)/\1/p')
-    BASE64UPLOADKEY=$(echo "${payloadKey}" | xxd -r -p | base64)
-    shaOfPayloadKey=$(echo -n "${payloadKey}" | xxd -r -p | sha256sum)
-    BASE64UPLOADSHAKEY=$(echo "${shaOfPayloadKey}" | xxd -r -p | base64)
+    BASE64UPLOADKEY=$(../tools/hexToBase64Converter.py "${payloadKey}")
+    shaOfPayloadKey=$(../tools/sha256Calculator.py "${payloadKey}")
+    BASE64UPLOADSHAKEY=$(../tools/hexToBase64Converter.py "${shaOfPayloadKey}")
     create_kv_secret "${UPLOAD_ENCRYPT_KEY_KV}" "${BASE64UPLOADKEY}"
     create_kv_secret "${UPLOAD_ENCRYPT_KEY_SHA_KV}" "${BASE64UPLOADSHAKEY}"
 }

--- a/tools/hexToBase64Converter.py
+++ b/tools/hexToBase64Converter.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# Python code convert hex string
+# to the Base64 string 
+  
+import codecs
+import sys
+
+hex = sys.argv[1]
+b64 = codecs.encode(codecs.decode(hex, 'hex'), 'base64').decode()
+
+# Print the resultant string
+print (str(b64))

--- a/tools/sha256Calculator.py
+++ b/tools/sha256Calculator.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+# Python code convert calculate sha256 sum 
+  
+import codecs
+import sys
+import hashlib
+
+hex = sys.argv[1]
+
+value=codecs.decode(hex, 'hex')
+shaResult=hashlib.sha256(value)
+
+# Print the resultant string
+print (shaResult.hexdigest())


### PR DESCRIPTION
## What’s changing?

Wrote replacement scripts for xxd and calculating sha256 checksum.

## Why?

Microsoft updated Cloud Shell recently and xxd is no longer available on their Linux distribute (CBL Delridge). This broke the configure-encryption-secrets.bash.

## This PR has:

- [ ] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [x] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
