### PR TITLE
Changed metrics filter form to a GET instead of POST

### DIFF
--- a/dashboard/src/Piipan.Dashboard.Client/Components/ParticipantUploads/ParticipantUploads.razor
+++ b/dashboard/src/Piipan.Dashboard.Client/Components/ParticipantUploads/ParticipantUploads.razor
@@ -4,7 +4,6 @@
 @using static Piipan.Components.Shared.CommonConstants
 @code {
     [Parameter] public ParticipantUploadModel Upload { get; set; } = new();
-    [Parameter] public string Token { get; set; }
 }
 
 <div class="grid-container margin-bottom-6">
@@ -21,7 +20,7 @@
     
     <section id="historical-upload-info">
         <h2>Historical Upload Information</h2>
-        <ParticipantUploadsFilter Token="@Token" UploadRequest="Upload.ParticipantUploadFilter" />
+        <ParticipantUploadsFilter UploadRequest="Upload.ParticipantUploadFilter" />
 
         <ParticipantUploadsResults Upload="Upload" />
     </section>

--- a/dashboard/src/Piipan.Dashboard.Client/Components/ParticipantUploads/ParticipantUploadsFilter.razor
+++ b/dashboard/src/Piipan.Dashboard.Client/Components/ParticipantUploads/ParticipantUploadsFilter.razor
@@ -4,7 +4,6 @@
 
 @code {
     [Parameter] public ParticipantUploadRequestFilter UploadRequest { get; set; } = new();
-    [Parameter] public string Token { get; set; }
 
     private (string, string)[] dropdownOptions = null;
     int hoursOffset = 0;
@@ -40,25 +39,24 @@
 }
 
 <section id="participant-uploads-filter">
-    <UsaForm @ref="FilterForm" Id="upload-filter-form" Model="UploadRequest" method="post">
-        <input type="hidden" name="__RequestVerificationToken" value="@Token" />
-        <input type="hidden" name="UploadRequest.HoursOffset" value="@hoursOffset" />
-        <input type="hidden" name="UploadRequest.Status" value="@UploadRequest.Status" />
+    <UsaForm @ref="FilterForm" Id="upload-filter-form" Model="UploadRequest" method="get">
+        <input type="hidden" name="HoursOffset" value="@hoursOffset" />
+        <input type="hidden" name="Status" value="@UploadRequest.Status" />
         <div class="top-filters">
             <h2>Filters</h2>
             <div class="top-filter-grid">
         <UsaFormGroup>
-            <UsaInputDate Width="140" @bind-Value="UploadRequest.StartDate"  />
+            <UsaInputDate Width="140" @bind-Value="UploadRequest.StartDate" name="StartDate" />
         </UsaFormGroup>
         <span class="date-separator">to</span>
         <div class="end-date">
             <UsaFormGroup>
-                <UsaInputDate Width="140" @bind-Value="UploadRequest.EndDate"  />
+                <UsaInputDate Width="140" @bind-Value="UploadRequest.EndDate" name="EndDate" />
             </UsaFormGroup>
         </div>
         <UsaFormGroup>
             <ChildContent>
-                <UsaSelect @bind-Value="UploadRequest.State" DropdownOptions="dropdownOptions"  />
+                <UsaSelect @bind-Value="UploadRequest.State" DropdownOptions="dropdownOptions" name="State" />
             </ChildContent>
         </UsaFormGroup>
         </div>

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml
@@ -1,7 +1,5 @@
 ﻿@page
 @model Piipan.Dashboard.Pages.ParticipantUploadsModel
-@inject IAntiforgery antiforgery
-@using Microsoft.AspNetCore.Antiforgery
 @using Piipan.Dashboard.Client.Models
 @using Piipan.Dashboard.Extensions
 
@@ -17,4 +15,4 @@
     };
 }
 <component type="typeof(Dashboard.Client.Components.ParticipantUploads.ParticipantUploads)" render-mode="WebAssembly"
-param-Upload="model" param-Token="antiforgery.GetAndStoreTokens(HttpContext).RequestToken" />
+param-Upload="model" />

--- a/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
+++ b/dashboard/src/Piipan.Dashboard/Pages/ParticipantUploads.cshtml.cs
@@ -80,32 +80,6 @@ namespace Piipan.Dashboard.Pages
         [BindProperty]
         public ParticipantUploadRequestFilter UploadRequest { get; set; } = new ParticipantUploadRequestFilter();
 
-        public async Task<IActionResult> OnPostAsync()
-        {
-            try
-            {
-                _logger.LogInformation("Querying uploads via search form");
-                RequestError = null;
-
-                StateQuery = Request.Form["state"];
-                var response = await _participantUploadApi.GetUploads(UploadRequest);
-                await GetUploadStatistics();
-                ParticipantUploadResults = response.Data.ToList();
-                SetPageLinks(response.Meta);
-            }
-            catch (HttpRequestException exception)
-            {
-                _logger.LogError(exception, exception.Message);
-                RequestError = "There was an error running your search. You may be able to try again. If the problem persists, please contact system maintainers.";
-            }
-            catch (Exception exception)
-            {
-                _logger.LogError(exception, exception.Message);
-                RequestError = "Internal Server Error. Please contact system maintainers.";
-            }
-            return Page();
-        }
-
         private void SetPageLinks(Meta meta)
         {
             PageParams = meta.PageQueryParams;

--- a/dashboard/tests/Piipan.Dashboard.Tests/Components/ParticipantUploads/ParticipantUploadsFilterTests.razor
+++ b/dashboard/tests/Piipan.Dashboard.Tests/Components/ParticipantUploads/ParticipantUploadsFilterTests.razor
@@ -18,7 +18,7 @@
     {
         InitialValues = new ParticipantUploadsFilter()
         {
-            Token = "token"
+            
         };
     }
     /// <summary>
@@ -28,7 +28,7 @@
     {
         base.CreateTestComponent();
         Component = Render<ParticipantUploadsFilter>(
-            @<ParticipantUploadsFilter UploadRequest="InitialValues.UploadRequest" Token="@InitialValues.Token">
+            @<ParticipantUploadsFilter UploadRequest="InitialValues.UploadRequest">
             </ParticipantUploadsFilter>
         );
     }
@@ -48,28 +48,27 @@
         Component!.MarkupMatches(
             @<section id="participant-uploads-filter" >
                 <div class="usa-form ">
-                    <form id="upload-filter-form" method="post" novalidate="" >
+                    <form id="upload-filter-form" method="get" novalidate="" >
                         <fieldset class="usa-fieldset">
-                        <input type="hidden" name="__RequestVerificationToken" value="token" >
-                        <input type="hidden" name="UploadRequest.HoursOffset" value:ignore >
-                        <input type="hidden" name="UploadRequest.Status" >
+                        <input type="hidden" name="HoursOffset" value:ignore >
+                        <input type="hidden" name="Status" >
                         <div class="top-filters" >
                             <h2 >Filters</h2>
                             <div class="top-filter-grid" >
                             <div class="usa-form-group " >
                                 <label class="usa-label" for="UploadRequest_StartDate">Start Date</label>
-                                <input  id="UploadRequest_StartDate" name="UploadRequest.StartDate" style="width: 140px;" type="date" class="usa-input  valid" value=""  >
+                                <input  id="UploadRequest_StartDate" name="StartDate" style="width: 140px;" type="date" class="usa-input  valid" value=""  >
                             </div>
                             <span class="date-separator" >to</span>
                             <div class="end-date" >
                                 <div class="usa-form-group " >
                                 <label class="usa-label" for="UploadRequest_EndDate">End Date</label>
-                                <input  id="UploadRequest_EndDate" name="UploadRequest.EndDate" style="width: 140px;" type="date" class="usa-input  valid" value=""  >
+                                <input  id="UploadRequest_EndDate" name="EndDate" style="width: 140px;" type="date" class="usa-input  valid" value=""  >
                                 </div>
                             </div>
                             <div class="usa-form-group " >
                                 <label class="usa-label" for="UploadRequest_State">State</label>
-                                <select class="usa-select usa-input "  id="UploadRequest_State" name="UploadRequest.State" style=""  >
+                                <select class="usa-select usa-input "  id="UploadRequest_State" name="State" style=""  >
                                 <option value="">- Select -</option>
                                 <option value="EA">Echo Alpha (EA)</option>
                                 </select>

--- a/dashboard/tests/Piipan.Dashboard.Tests/Components/ParticipantUploads/ParticipantUploadsTests.razor
+++ b/dashboard/tests/Piipan.Dashboard.Tests/Components/ParticipantUploads/ParticipantUploadsTests.razor
@@ -36,7 +36,7 @@
     {
         base.CreateTestComponent();
         Component = Render<ParticipantUploads>(
-            @<ParticipantUploads Token="token" Upload="InitialValues.Upload">
+            @<ParticipantUploads Upload="InitialValues.Upload">
             </ParticipantUploads>
         );
     }


### PR DESCRIPTION
## What’s changing?

Changing the metrics filter form to use GET instead of POST, so that the URL always accurately reflects the filter

## Why?

_Link to specific issue (ex: Closes #123)_

## This PR has:

- [x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [x] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
