### PR TITLE
Refactor NotificationRecordBuilder.

### DIFF
--- a/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
+++ b/match/tests/Piipan.Match.Core.Tests/Services/MatchEventServiceTests.cs
@@ -272,7 +272,7 @@ namespace Piipan.Match.Core.Tests.Services
                                                  )),
                                                   Times.Once);
             // Need to be called only when creating new Match Record
-            notificationService.Verify(r => r.PublishNotificationOnMatchCreation(It.Is<NotificationRecord>(p => p.MatchRecord.InitState == "Echo Alpha" && p.EmailToRecord.EmailTo == "Ea@Nac.gov" && p.EmailToRecordMS.EmailTo == "Eb@Nac.gov")), Times.Once);
+            notificationService.Verify(r => r.PublishNotificationOnMatchCreation(It.Is<NotificationRecord>(p => p.MatchRecord.InitState == "ea" && p.EmailToRecord.EmailTo == "Ea@Nac.gov" && p.EmailToRecordMS.EmailTo == "Eb@Nac.gov")), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
## What’s changing?

Added Lock to avoid multi-threading for NotificationRecordBuilder.

## Why?

_Link to specific issue (ex: Closes #123)_

## This PR has:

- [ x] **Commented source code** (_required on public classes and methods, and elsewhere as appropriate_)

- [ ] **Developer documentation** (_for new build/test/API changes or complex portions of the system_)

- [ ] **Automated unit tests** (_to maintain or increase level of code coverage_)

- [ ] **Changes to IAC** (_add any deployment steps that require manual intervention to the draft release notes_)

## Anything else?
